### PR TITLE
Update from .NET 6 to .NET 8

### DIFF
--- a/solutions/Z3.Linq.Demo/Z3.Linq.Demo.csproj
+++ b/solutions/Z3.Linq.Demo/Z3.Linq.Demo.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/solutions/Z3.Linq.Examples/Z3.Linq.Examples.csproj
+++ b/solutions/Z3.Linq.Examples/Z3.Linq.Examples.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<PlatformTarget>x64</PlatformTarget>

--- a/solutions/Z3.Linq/Environment.cs
+++ b/solutions/Z3.Linq/Environment.cs
@@ -1,8 +1,6 @@
 ﻿namespace Z3.Linq;
 
 using Microsoft.Z3;
-
-using System;
 using System.Collections.Generic;
 using System.Reflection;
 

--- a/solutions/Z3.Linq/Theorem.cs
+++ b/solutions/Z3.Linq/Theorem.cs
@@ -10,7 +10,6 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Runtime.CompilerServices;
-using System.Runtime.Serialization;
 
 /// <summary>
 /// Representation of a theorem with its constraints.
@@ -612,7 +611,7 @@ public class Theorem
             // However, we don't know the order and it's hard to correlate back the parameters
             // to the underlying properties. So, we want to bypass that constructor altogether
             // by using the FormatterServices to create an uninitialized (all-zero) instance.
-            object result = FormatterServices.GetUninitializedObject(t);
+            object result = RuntimeHelpers.GetUninitializedObject(t);
 
             // Here we take advantage of undesirable knowledge on how anonymous types are
             // implemented by the C# compiler. This is risky but we can live with it for

--- a/solutions/Z3.Linq/Z3.Linq.csproj
+++ b/solutions/Z3.Linq/Z3.Linq.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PlatformTarget>x64</PlatformTarget>

--- a/solutions/Z3.Linq/Z3.Linq.csproj
+++ b/solutions/Z3.Linq/Z3.Linq.csproj
@@ -20,7 +20,7 @@
 
   <ItemGroup>
     <PackageReference Include="MiaPlaza.ExpressionUtils" Version="1.2.0" />
-    <PackageReference Include="Microsoft.Z3" Version="4.8.12" />
+    <PackageReference Include="Microsoft.Z3" Version="4.12.2" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Also swapped from an obsolete formatting type, removed some unused using statements and updated the Microsoft.Z3 package to the latest.