### PR TITLE
Migrate build from Endjin.RecommendedPractices.Build to ZeroFailed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
       id: prepareEnvVarsAndSecrets
       with:
         environmentVariablesYaml: |
-          BUILDVAR_NuGetPublishSource: "${{ startsWith(github.ref, 'refs/tags/') && 'https://api.nuget.org/v3/index.json' || 'https://nuget.pkg.github.com/endjin/index.json' }}"
+          ZF_NUGET_PUBLISH_SOURCE: "${{ startsWith(github.ref, 'refs/tags/') && 'https://api.nuget.org/v3/index.json' || 'https://nuget.pkg.github.com/endjin/index.json' }}"
         secretsYaml: |
           NUGET_API_KEY: "${{ startsWith(github.ref, 'refs/tags/') && secrets.ENDJIN_NUGET_APIKEY || secrets.ENDJIN_GITHUB_PUBLISHER_PAT }}"
 

--- a/.gitignore
+++ b/.gitignore
@@ -355,3 +355,4 @@ MigrationBackup/
 _codeCoverage/
 _packages/
 *.sbom.*
+.zf/extensions/

--- a/.zf/config.ps1
+++ b/.zf/config.ps1
@@ -5,7 +5,8 @@ needed when building .NET solutions.
 
 $zerofailedExtensions = @(
     @{
-        # References the extension from its GitHub repository. If not already installed, use latest version from 'main' will be downloaded.
+        # References the extension from its GitHub repository. If it is not already installed, the
+        # latest version from 'main' is downloaded.
         Name = "ZeroFailed.Build.DotNet"
         GitRepository = "https://github.com/zerofailed/ZeroFailed.Build.DotNet"
         GitRef = "main"

--- a/.zf/config.ps1
+++ b/.zf/config.ps1
@@ -1,0 +1,63 @@
+<#
+This build process uses the 'ZeroFailed.Build.DotNet' extension to provide the features
+needed when building .NET solutions.
+#>
+
+$zerofailedExtensions = @(
+    @{
+        # References the extension from its GitHub repository. If not already installed, use latest version from 'main' will be downloaded.
+        Name = "ZeroFailed.Build.DotNet"
+        GitRepository = "https://github.com/zerofailed/ZeroFailed.Build.DotNet"
+        GitRef = "main"
+    }
+)
+
+# Load the tasks and process
+. ZeroFailed.tasks -ZfPath $here/.zf
+
+#
+# Build process control options
+#
+$SkipInit = $false
+$SkipVersion = $false
+$SkipBuild = $false
+$CleanBuild = $Clean
+# NOTE: There is currently no test project in this solution.
+$SkipTest = $true
+$SkipTestReport = $true
+$SkipAnalysis = $false
+$SkipPackage = $false
+
+#
+# Build process configuration
+#
+$SolutionToBuild = (Resolve-Path (Join-Path $here "./solutions/Z3.Linq.sln")).Path
+$ProjectsToPublish = @()
+$NugetPublishSource = property ZF_NUGET_PUBLISH_SOURCE "$here/_local-nuget-feed"
+$IncludeAssembliesInCodeCoverage = "Z3.Linq*"
+$ExcludeAssembliesInCodeCoverage = "Z3.Linq*.Tests*"
+
+task . FullBuild
+
+#
+# Build Process Extensibility Points - uncomment and implement as required
+#
+
+# task RunFirst {}
+# task PreInit {}
+# task PostInit {}
+# task PreVersion {}
+# task PostVersion {}
+# task PreBuild {}
+# task PostBuild {}
+# task PreTest {}
+# task PostTest {}
+# task PreTestReport {}
+# task PostTestReport {}
+# task PreAnalysis {}
+# task PostAnalysis {}
+# task PrePackage {}
+# task PostPackage {}
+# task PrePublish {}
+# task PostPublish {}
+# task RunLast {}

--- a/build.ps1
+++ b/build.ps1
@@ -70,10 +70,10 @@ param (
     [string] $ZfModulePath,
 
     [Parameter()]
-    [string] $ZfModuleVersion = "1.0.6",
+    [string] $ZfModuleVersion = "1.0.7",
 
     [Parameter()]
-    [version] $InvokeBuildModuleVersion = "5.14.22"
+    [version] $InvokeBuildModuleVersion = "5.14.23"
 )
 $ErrorActionPreference = 'Stop'
 $here = Split-Path -Parent $PSCommandPath

--- a/build.ps1
+++ b/build.ps1
@@ -1,12 +1,13 @@
+#Requires -Version 7
 <#
 .SYNOPSIS
     Runs a .NET flavoured build process.
 .DESCRIPTION
-    This script was scaffolded using a template from the Endjin.RecommendedPractices.Build PowerShell module.
-    It uses the InvokeBuild module to orchestrate an opinonated software build process for .NET solutions.
+    This script was scaffolded using a template from the ZeroFailed project.
+    It uses the InvokeBuild module to orchestrate an opinionated software build process for .NET solutions.
 .EXAMPLE
     PS C:\> ./build.ps1
-    Downloads any missing module dependencies (Endjin.RecommendedPractices.Build & InvokeBuild) and executes
+    Downloads any missing module dependencies (ZeroFailed & InvokeBuild) and executes
     the build process.
 .PARAMETER Tasks
     Optionally override the default task executed as the entry-point of the build.
@@ -26,14 +27,12 @@
     The logging verbosity.
 .PARAMETER Clean
     When true, the .NET solution will be cleaned and all output/intermediate folders deleted.
-.PARAMETER BuildModulePath
-    The path to import the Endjin.RecommendedPractices.Build module from. This is useful when
-    testing pre-release versions of the Endjin.RecommendedPractices.Build that are not yet
-    available in the PowerShell Gallery.
-.PARAMETER BuildModuleVersion
-    The version of the Endjin.RecommendedPractices.Build module to import. This is useful when
-    testing pre-release versions of the Endjin.RecommendedPractices.Build that are not yet
-    available in the PowerShell Gallery.
+.PARAMETER ZfModulePath
+    The path to import the ZeroFailed module from. This is useful when testing pre-release
+    versions of ZeroFailed that are not yet available in the PowerShell Gallery.
+.PARAMETER ZfModuleVersion
+    The version of the ZeroFailed module to import. This is useful when testing pre-release
+    versions of ZeroFailed that are not yet available in the PowerShell Gallery.
 .PARAMETER InvokeBuildModuleVersion
     The version of the InvokeBuild module to be used.
 #>
@@ -68,110 +67,55 @@ param (
     [switch] $Clean,
 
     [Parameter()]
-    [string] $BuildModulePath,
+    [string] $ZfModulePath,
 
     [Parameter()]
-    [version] $BuildModuleVersion = "1.5.5",
+    [string] $ZfModuleVersion = "1.0.6",
 
     [Parameter()]
-    [version] $InvokeBuildModuleVersion = "5.10.3"
+    [version] $InvokeBuildModuleVersion = "5.14.22"
 )
-
-$ErrorActionPreference = $ErrorActionPreference ? $ErrorActionPreference : 'Stop'
-$InformationPreference = 'Continue'
-
+$ErrorActionPreference = 'Stop'
 $here = Split-Path -Parent $PSCommandPath
 
 #region InvokeBuild setup
-if (!(Get-Module -ListAvailable InvokeBuild)) {
-    Install-Module InvokeBuild -RequiredVersion $InvokeBuildModuleVersion -Scope CurrentUser -Force -Repository PSGallery
-}
-Import-Module InvokeBuild
 # This handles calling the build engine when this file is run like a normal PowerShell script
 # (i.e. avoids the need to have another script to setup the InvokeBuild environment and issue the 'Invoke-Build' command )
 if ($MyInvocation.ScriptName -notlike '*Invoke-Build.ps1') {
+    Install-PSResource InvokeBuild -Version $InvokeBuildModuleVersion -Scope CurrentUser -TrustRepository -Verbose:$false | Out-Null
     try {
         Invoke-Build $Tasks $MyInvocation.MyCommand.Path @PSBoundParameters
     }
     catch {
-        $_.ScriptStackTrace
-        throw
+        Write-Host -f Yellow "`n`n***`n*** Build Failure Summary - check previous logs for more details`n***"
+        Write-Host -f Yellow $_.Exception.Message
+        Write-Host -f Yellow $_.ScriptStackTrace
+        exit 1
     }
     return
 }
 #endregion
 
-#region Import shared tasks and initialise build framework
-if (!($BuildModulePath)) {
-    if (!(Get-Module -ListAvailable Endjin.RecommendedPractices.Build | ? { $_.Version -eq $BuildModuleVersion })) {
-        Write-Information "Installing 'Endjin.RecommendedPractices.Build' module..."
-        Install-Module Endjin.RecommendedPractices.Build -RequiredVersion $BuildModuleVersion -Scope CurrentUser -Force -Repository PSGallery -AllowPrerelease
-    }
-    $BuildModulePath = "Endjin.RecommendedPractices.Build"
+#region Initialise build framework
+$splat = @{ Force = $true; Verbose = $false}
+Import-Module Microsoft.PowerShell.PSResourceGet
+if (!($ZfModulePath)) {
+    Install-PSResource ZeroFailed -Version $ZfModuleVersion -Scope CurrentUser -TrustRepository | Out-Null
+    $ZfModulePath = "ZeroFailed"
+    $splat.Add("RequiredVersion", ($ZfModuleVersion -split '-')[0])
 }
 else {
-    Write-Information "BuildModulePath: $BuildModulePath"
+    Write-Host "ZfModulePath: $ZfModulePath"
 }
-Import-Module $BuildModulePath -RequiredVersion $BuildModuleVersion -Force
-
-# Load the build process & tasks
-. Endjin.RecommendedPractices.Build.tasks
+$splat.Add("Name", $ZfModulePath)
+# Ensure only 1 version of the module is loaded
+Get-Module ZeroFailed | Remove-Module
+Import-Module @splat
+$ver = "{0} {1}" -f (Get-Module ZeroFailed).Version, (Get-Module ZeroFailed).PrivateData.PsData.PreRelease
+Write-Host "Using ZeroFailed module version: $ver"
 #endregion
 
+$PSModuleAutoloadingPreference = 'none'
 
-#
-# Build process control options
-#
-$SkipInit = $false
-$SkipVersion = $false
-$SkipBuild = $false
-$CleanBuild = $Clean
-$SkipTest = $true
-$SkipTestReport = $false
-$SkipAnalysis = $false
-$SkipPackage = $false
-$SkipPublish = $false
-
-
-#
-# Build process configuration
-#
-$SolutionToBuild = (Resolve-Path (Join-Path $here ".\solutions\Z3.Linq.sln")).Path
-$ProjectsToPublish = @(
-    # "Solutions/MySolution/MyWebSite/MyWebSite.csproj"
-)
-$NuSpecFilesToPackage = @(
-    # "Solutions/MySolution/MyProject/MyProject.nuspec"
-)
-
-#
-# Specify files to exclude from code coverage
-# This option is for excluding generated code
-# - Use file path or directory path with globbing (e.g dir1/*.cs)
-# - Use single or multiple paths (separated by comma) (e.g. **/dir1/class1.cs,**/dir2/*.cs,**/dir3/**/*.cs)
-#
-$ExcludeFilesFromCodeCoverage = ""
-
-# Synopsis: Build, Test and Package
-task . FullBuild
-
-
-# build extensibility tasks
-task RunFirst {}
-task PreInit {}
-task PostInit {}
-task PreVersion {}
-task PostVersion {}
-task PreBuild {}
-task PostBuild {}
-task PreTest {}
-task PostTest {}
-task PreTestReport {}
-task PostTestReport {}
-task PreAnalysis {}
-task PostAnalysis {}
-task PrePackage {}
-task PostPackage {}
-task PrePublish {}
-task PostPublish {}
-task RunLast {}
+# Load the build configuration
+. $here/.zf/config.ps1


### PR DESCRIPTION
Replaces the Endjin.RecommendedPractices.Build bootstrap in build.ps1 with
the ZeroFailed equivalent, moving all build configuration out into
.zf/config.ps1 as per the ZeroFailed convention.

- build.ps1 is now a thin bootstrap (ZeroFailed 1.0.7, InvokeBuild 5.14.23)
  that dots into .zf/config.ps1.
- The build-facing parameters (Tasks, Configuration, BuildRepositoryUri,
  SourcesDir, CoverageDir, TestReportTypes, PackagesDir, LogLevel, Clean,
  InvokeBuildModuleVersion) are unchanged. The two that named the build
  framework are renamed to match it: `BuildModulePath` -> `ZfModulePath` and
  `BuildModuleVersion` -> `ZfModuleVersion`. These select which ZeroFailed
  module to bootstrap from and are only used when testing an unreleased
  ZeroFailed build, so nothing in this repository or its CI passes them.
- .zf/config.ps1 declares the ZeroFailed.Build.DotNet extension and carries
  the build configuration previously inline in build.ps1. SkipTest remains
  true as the solution still has no test project.
- The old $ExcludeFilesFromCodeCoverage placeholder becomes ZeroFailed's
  Include/ExcludeAssembliesInCodeCoverage properties.
- .gitignore excludes the .zf/extensions/ download cache.
- The CI publish source env var is renamed BUILDVAR_NuGetPublishSource ->
  ZF_NUGET_PUBLISH_SOURCE. BUILDVAR_ is an Endjin.RecommendedPractices.Build
  convention that ZeroFailed does not read, so without this the publish
  stage would silently fall back to the local feed default.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>