### PR TITLE
Update MiaPlaza.ExpressionUtils to 1.3.1 and adapt to its breaking change

### DIFF
--- a/solutions/Directory.Packages.props
+++ b/solutions/Directory.Packages.props
@@ -5,10 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup Label="Third party">
-    <!-- NOTE: pinned to 1.2.0 deliberately. 1.3.x removes the general
-         PartialEval(Expression, IExpressionEvaluator) overload, leaving only a
-         LambdaExpression-constrained generic, which ExpressionVisitor.cs relies on. -->
-    <PackageVersion Include="MiaPlaza.ExpressionUtils" Version="1.2.0" />
+    <PackageVersion Include="MiaPlaza.ExpressionUtils" Version="1.3.1" />
     <!-- NOTE: 4.12.2 is the newest Microsoft.Z3 published to nuget.org; later Z3
          releases ship via GitHub releases only. -->
     <PackageVersion Include="Microsoft.Z3" Version="4.12.2" />

--- a/solutions/Z3.Linq/ExpressionVisitor.cs
+++ b/solutions/Z3.Linq/ExpressionVisitor.cs
@@ -220,7 +220,17 @@ public static class ExpressionVisitor
                             foreach (var item in caller)
                             {
                                 var substitutedExpression = ParameterSubstituter.SubstituteParameter(arg, Expression.Constant(item));
-                                var newlyFlattened = PartialEvaluator.PartialEval(substitutedExpression, ExpressionInterpreter.Instance);
+
+                                // SubstituteParameter yields the selector's body, which is not a
+                                // lambda, but from 1.3.0 PartialEval only accepts a LambdaExpression.
+                                // Wrapping the body in a lambda and taking the partially evaluated
+                                // Body back off is the supported equivalent of the overload that
+                                // used to take a bare Expression. The body still references the
+                                // theorem's own parameter, which stays free in the wrapper - the
+                                // evaluator leaves parameter-dependent subtrees alone and folds
+                                // only the closed ones, exactly as before.
+                                var wrappedExpression = Expression.Lambda(substitutedExpression);
+                                var newlyFlattened = PartialEvaluator.PartialEval(wrappedExpression, ExpressionInterpreter.Instance).Body;
                                 subExps.Add(newlyFlattened);
                             }
 


### PR DESCRIPTION
1.3.x removes PartialEvaluator.PartialEval's Expression-taking overloads,
leaving only PartialEval<TExpression>(TExpression, IExpressionEvaluator)
constrained to LambdaExpression. ExpressionVisitor fed it the output of
ParameterSubstituter.SubstituteParameter, which is the selector's body and
so not a lambda, giving CS0311 on upgrade.

The body is now wrapped in a lambda for the call and unwrapped afterwards,
which is the supported equivalent of the removed overload. The theorem's own
parameter stays free in the wrapper; the evaluator folds only closed subtrees
and leaves parameter-dependent ones alone, so the result is unchanged.

This affects Z3Methods.Distinct(collection.Select(...).ToArray()). Nothing in
the repository exercises that branch - the Sudoku theorems build their
Distinct arguments as a NewArrayExpression, which takes the other path - so
it was verified with a purpose-built probe covering satisfiable, unsatisfiable,
constant-folded and two-symbol selectors. All four produce byte-identical
results before and after the upgrade:

  multipliers-sat:  X1=11, X2=12
  duplicate-unsat:  <unsat>
  folded-sat:       X1=7, X2=0
  two-symbols-sat:  X1=4, X2=9

The demo app's output is also unchanged, and the full ZeroFailed build passes
(35 tasks, 0 errors, 0 warnings under TreatWarningsAsErrors).

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>