### PR TITLE
Add Z3.Linq.Tests covering the Distinct partial-evaluation path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -359,3 +359,8 @@ _packages/
 
 # Microsoft.Z3 packages downloaded by scripts/Install-Z3Package.ps1
 _z3-feed/*.nupkg
+
+# Test artefacts produced by the Microsoft.Testing.Platform run
+coverage.*.xml
+TestResults/
+*.trx

--- a/.zf/config.ps1
+++ b/.zf/config.ps1
@@ -23,9 +23,9 @@ $SkipInit = $false
 $SkipVersion = $false
 $SkipBuild = $false
 $CleanBuild = $Clean
-# NOTE: There is currently no test project in this solution.
-$SkipTest = $true
-$SkipTestReport = $true
+# Z3.Linq.Tests runs on Microsoft.Testing.Platform via the MSTest SDK.
+$SkipTest = $false
+$SkipTestReport = $false
 $SkipAnalysis = $false
 $SkipPackage = $false
 

--- a/global.json
+++ b/global.json
@@ -1,0 +1,8 @@
+{
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
+  },
+  "msbuild-sdks": {
+    "MSTest.Sdk": "4.3.3"
+  }
+}

--- a/solutions/Directory.Build.props
+++ b/solutions/Directory.Build.props
@@ -33,4 +33,19 @@
     <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
   </PropertyGroup>
 
+  <!--
+    MSTest.Sdk adds Microsoft.Testing.Extensions.CodeCoverage implicitly and pins its version
+    via this property, defaulting to an older build than the dotnet-coverage collector that the
+    ZeroFailed test task runs. The reference is injected from a .targets file imported AFTER the
+    project body, so a per-project <PackageReference Update VersionOverride> would be a no-op -
+    setting the property here, early in the SDK chain, is the supported override. Keep it in step
+    with the collector version.
+
+    Note there is deliberately NO PackageVersion for this package in Directory.Packages.props:
+    under CPM the SDK injects its own PackageVersion from this property, and a second one trips
+    NU1506 on restore.
+  -->
+  <PropertyGroup>
+    <MicrosoftTestingExtensionsCodeCoverageVersion>18.10.0</MicrosoftTestingExtensionsCodeCoverageVersion>
+  </PropertyGroup>
 </Project>

--- a/solutions/Directory.Packages.props
+++ b/solutions/Directory.Packages.props
@@ -15,4 +15,8 @@
     <PackageVersion Include="Microsoft.Z3" Version="5.1.0" />
   </ItemGroup>
 
+  <ItemGroup Label="Testing">
+    <PackageVersion Include="Shouldly" Version="4.3.0" />
+  </ItemGroup>
+
 </Project>

--- a/solutions/Z3.Linq.Tests/AssemblyInfo.cs
+++ b/solutions/Z3.Linq.Tests/AssemblyInfo.cs
@@ -1,0 +1,4 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+// Configure test parallelization. Required by MSTest 4.0 (MSTEST0001).
+[assembly: Parallelize(Workers = 0, Scope = ExecutionScope.MethodLevel)]

--- a/solutions/Z3.Linq.Tests/DistinctInlineArrayTheoremTests.cs
+++ b/solutions/Z3.Linq.Tests/DistinctInlineArrayTheoremTests.cs
@@ -1,0 +1,108 @@
+namespace Z3.Linq.Tests;
+
+using System.Linq;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Shouldly;
+
+using Z3.Linq;
+
+/// <summary>
+/// Covers <c>Z3Methods.Distinct</c> called with inline arguments, which the visitor reads
+/// straight off the <c>NewArrayExpression</c> without going near the partial evaluator.
+/// </summary>
+/// <remarks>
+/// This is the branch the Sudoku theorems take, and it is deliberately paired with
+/// <see cref="DistinctSelectorTheoremTests"/>: the two branches are different code paths to
+/// the same semantics, so holding them to the same expected results is what makes a change
+/// to the partial-evaluation branch safe to trust.
+/// </remarks>
+[TestClass]
+public class DistinctInlineArrayTheoremTests
+{
+    [TestMethod]
+    public void Distinct_InlineDistinctSymbols_Solves()
+    {
+        // Act
+        using var context = new Z3Context();
+        var result = (from t in context.NewTheorem<Symbols<int, int>>()
+                      where Z3Methods.Distinct(t.X1, t.X2)
+                      where t.X1 == 3
+                      where t.X2 > 3 && t.X2 < 5
+                      select t).Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.X1.ShouldBe(3);
+        result.X2.ShouldBe(4);
+    }
+
+    [TestMethod]
+    public void Distinct_InlineSymbolsConstrainedEqual_IsUnsatisfiable()
+    {
+        // Act
+        using var context = new Z3Context();
+        var result = (from t in context.NewTheorem<Symbols<int, int>>()
+                      where Z3Methods.Distinct(t.X1, t.X2)
+                      where t.X1 == t.X2
+                      select t).Solve();
+
+        // Assert
+        result.ShouldBeNull();
+    }
+
+    [TestMethod]
+    public void Distinct_InlineAndSelectorForms_AgreeOnSatisfiability()
+    {
+        // Arrange: 'Distinct(X1*1, X1*2)' expressed both ways. The inline form goes through
+        // the NewArrayExpression branch, the projected form through the partial-evaluation
+        // branch. Pinning X1 to zero makes both terms zero, so both must be unsatisfiable.
+        int[] multipliers = [1, 2];
+
+        // Act
+        using var inlineContext = new Z3Context();
+        var inlineResult = (from t in inlineContext.NewTheorem<Symbols<int, int>>()
+                            where Z3Methods.Distinct(t.X1 * 1, t.X1 * 2)
+                            where t.X1 == 0
+                            select t).Solve();
+
+        using var selectorContext = new Z3Context();
+        var selectorResult = (from t in selectorContext.NewTheorem<Symbols<int, int>>()
+                              where Z3Methods.Distinct(multipliers.Select(m => t.X1 * m).ToArray())
+                              where t.X1 == 0
+                              select t).Solve();
+
+        // Assert
+        inlineResult.ShouldBeNull();
+        selectorResult.ShouldBeNull();
+    }
+
+    [TestMethod]
+    public void Distinct_InlineAndSelectorForms_AgreeOnSolution()
+    {
+        // Arrange: the same theorem written both ways must yield the same assignment.
+        int[] multipliers = [1, 2];
+
+        // Act
+        using var inlineContext = new Z3Context();
+        var inlineResult = (from t in inlineContext.NewTheorem<Symbols<int, int>>()
+                            where Z3Methods.Distinct(t.X1 * 1, t.X1 * 2)
+                            where t.X1 == 5
+                            where t.X2 == 2
+                            select t).Solve();
+
+        using var selectorContext = new Z3Context();
+        var selectorResult = (from t in selectorContext.NewTheorem<Symbols<int, int>>()
+                              where Z3Methods.Distinct(multipliers.Select(m => t.X1 * m).ToArray())
+                              where t.X1 == 5
+                              where t.X2 == 2
+                              select t).Solve();
+
+        // Assert
+        inlineResult.ShouldNotBeNull();
+        selectorResult.ShouldNotBeNull();
+        selectorResult.X1.ShouldBe(inlineResult.X1);
+        selectorResult.X2.ShouldBe(inlineResult.X2);
+    }
+}

--- a/solutions/Z3.Linq.Tests/DistinctSelectorTheoremTests.cs
+++ b/solutions/Z3.Linq.Tests/DistinctSelectorTheoremTests.cs
@@ -1,0 +1,222 @@
+namespace Z3.Linq.Tests;
+
+using System.Linq;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Shouldly;
+
+using Z3.Linq;
+
+/// <summary>
+/// Covers <c>Z3Methods.Distinct(collection.Select(...).ToArray())</c>, which is the only
+/// shape that reaches <c>PartialEvaluator.PartialEval</c> in <c>ExpressionVisitor.VisitCall</c>.
+/// </summary>
+/// <remarks>
+/// The visitor takes one of two branches for a <c>Distinct</c> argument. An inline array
+/// (a <c>NewArrayExpression</c>, which is what the Sudoku theorems build) is read directly;
+/// a <c>Select(...).ToArray()</c> call is unrolled by interpreting the source collection,
+/// substituting each item into the selector, and partially evaluating the result. Only the
+/// second branch calls the partial evaluator, and these tests exist because
+/// MiaPlaza.ExpressionUtils 1.3.x changed that API - it dropped the overload taking a bare
+/// <see cref="System.Linq.Expressions.Expression"/> in favour of one constrained to
+/// <see cref="System.Linq.Expressions.LambdaExpression"/>, so the call site now wraps the
+/// substituted body in a lambda and unwraps the result.
+/// </remarks>
+[TestClass]
+public class DistinctSelectorTheoremTests
+{
+    [TestMethod]
+    public void Distinct_SelectorProducingDistinctTerms_Solves()
+    {
+        // Arrange: three multiples of X1 are pairwise distinct only when X1 is non-zero.
+        int[] multipliers = [1, 2, 3];
+
+        // Act
+        using var context = new Z3Context();
+        var result = (from t in context.NewTheorem<Symbols<int, int>>()
+                      where Z3Methods.Distinct(multipliers.Select(m => t.X1 * m).ToArray())
+                      where t.X1 > 10 && t.X1 < 14
+                      where t.X2 == t.X1 + 1
+                      select t).Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.X1.ShouldBeInRange(11, 13);
+        result.X2.ShouldBe(result.X1 + 1);
+    }
+
+    [TestMethod]
+    public void Distinct_SelectorProducingDuplicateTerms_IsUnsatisfiable()
+    {
+        // Arrange: the selector yields X1*5 twice, which can never be distinct from itself.
+        int[] duplicates = [5, 5];
+
+        // Act
+        using var context = new Z3Context();
+        var result = (from t in context.NewTheorem<Symbols<int, int>>()
+                      where Z3Methods.Distinct(duplicates.Select(d => t.X1 * d).ToArray())
+                      select t).Solve();
+
+        // Assert
+        result.ShouldBeNull();
+    }
+
+    [TestMethod]
+    public void Distinct_SelectorWithFoldableArithmetic_Solves()
+    {
+        // Arrange: '(o * 2) + (3 - 3)' is closed once 'o' is substituted, so the partial
+        // evaluator folds it to a constant; 't.X1' depends on the theorem parameter and
+        // must survive untouched.
+        int[] offsets = [0, 10, 20];
+
+        // Act
+        using var context = new Z3Context();
+        var result = (from t in context.NewTheorem<Symbols<int, int>>()
+                      where Z3Methods.Distinct(offsets.Select(o => t.X1 + (o * 2) + (3 - 3)).ToArray())
+                      where t.X1 == 7
+                      where t.X2 == 0
+                      select t).Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.X1.ShouldBe(7);
+        result.X2.ShouldBe(0);
+    }
+
+    [TestMethod]
+    public void Distinct_SelectorReferencingMultipleSymbols_Solves()
+    {
+        // Arrange: the selector closes over the loop variable and two theorem symbols, so
+        // the substituted body still has a free parameter when it is partially evaluated.
+        int[] picks = [1, 2];
+
+        // Act
+        using var context = new Z3Context();
+        var result = (from t in context.NewTheorem<Symbols<int, int>>()
+                      where Z3Methods.Distinct(picks.Select(p => (t.X1 * p) + t.X2).ToArray())
+                      where t.X1 == 4 && t.X2 == 9
+                      select t).Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.X1.ShouldBe(4);
+        result.X2.ShouldBe(9);
+    }
+
+    [TestMethod]
+    [DataRow(1, 2, 3, DisplayName = "Distinct multipliers are satisfiable")]
+    [DataRow(2, 4, 6, DisplayName = "Distinct even multipliers are satisfiable")]
+    [DataRow(-1, 1, 2, DisplayName = "Negative and positive multipliers are satisfiable")]
+    public void Distinct_SelectorOverDistinctMultipliers_Solves(int first, int second, int third)
+    {
+        // Arrange
+        int[] multipliers = [first, second, third];
+
+        // Act
+        using var context = new Z3Context();
+        var result = (from t in context.NewTheorem<Symbols<int, int>>()
+                      where Z3Methods.Distinct(multipliers.Select(m => t.X1 * m).ToArray())
+                      where t.X1 > 0
+                      where t.X2 == 0
+                      select t).Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.X1.ShouldBeGreaterThan(0);
+    }
+
+    [TestMethod]
+    [DataRow(3, 3, DisplayName = "Repeated multiplier is unsatisfiable")]
+    [DataRow(-2, -2, DisplayName = "Repeated negative multiplier is unsatisfiable")]
+    public void Distinct_SelectorOverRepeatedMultipliers_IsUnsatisfiable(int first, int second)
+    {
+        // Arrange
+        int[] multipliers = [first, second];
+
+        // Act
+        using var context = new Z3Context();
+        var result = (from t in context.NewTheorem<Symbols<int, int>>()
+                      where Z3Methods.Distinct(multipliers.Select(m => t.X1 * m).ToArray())
+                      select t).Solve();
+
+        // Assert
+        result.ShouldBeNull();
+    }
+
+    [TestMethod]
+    public void Distinct_SelectorCallingHostMethod_IsFoldedBeforeTranslation()
+    {
+        // Arrange: the selector calls an ordinary C# method on a captured object. Z3 has no
+        // notion of it, and the visitor throws NotSupportedException on any method call it
+        // does not recognise. The call is closed once the loop variable is substituted, so it
+        // only reaches Z3 as a constant because the substituted body is partially evaluated
+        // first. This is the assertion that actually pins the partial-evaluation step: the
+        // arithmetic-only cases above still pass without it, because Z3 folds constant
+        // arithmetic itself.
+        int[] steps = [1, 2, 3];
+        var offsets = new OffsetTable(100);
+
+        // Act
+        using var context = new Z3Context();
+        var result = (from t in context.NewTheorem<Symbols<int, int>>()
+                      where Z3Methods.Distinct(steps.Select(s => t.X1 + offsets.Get(s)).ToArray())
+                      where t.X1 == 5
+                      where t.X2 == 0
+                      select t).Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.X1.ShouldBe(5);
+        result.X2.ShouldBe(0);
+    }
+
+    [TestMethod]
+    public void Distinct_SelectorCallingHostMethodProducingDuplicates_IsUnsatisfiable()
+    {
+        // Arrange: as above, but the host method maps every index to the same offset, so the
+        // folded terms collide and the theorem cannot be satisfied. This guards against a
+        // partial evaluator that silently produced the wrong constant rather than throwing.
+        int[] steps = [1, 2];
+        var offsets = new OffsetTable(0);
+
+        // Act
+        using var context = new Z3Context();
+        var result = (from t in context.NewTheorem<Symbols<int, int>>()
+                      where Z3Methods.Distinct(steps.Select(s => t.X1 + offsets.Get(s)).ToArray())
+                      select t).Solve();
+
+        // Assert
+        result.ShouldBeNull();
+    }
+
+    [TestMethod]
+    public void Distinct_SelectorOverSingleItem_Solves()
+    {
+        // Arrange: a one-element source still exercises substitution and partial evaluation,
+        // and a single term is trivially distinct.
+        int[] single = [7];
+
+        // Act
+        using var context = new Z3Context();
+        var result = (from t in context.NewTheorem<Symbols<int, int>>()
+                      where Z3Methods.Distinct(single.Select(s => t.X1 * s).ToArray())
+                      where t.X1 == 6
+                      where t.X2 == 1
+                      select t).Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.X1.ShouldBe(6);
+        result.X2.ShouldBe(1);
+    }
+
+    /// <summary>
+    /// An ordinary object with no Z3 representation, used to prove that a closed call in the
+    /// selector is folded to a constant before the visitor sees it.
+    /// </summary>
+    private sealed class OffsetTable(int scale)
+    {
+        public int Get(int index) => index * scale;
+    }
+}

--- a/solutions/Z3.Linq.Tests/Z3.Linq.Tests.csproj
+++ b/solutions/Z3.Linq.Tests/Z3.Linq.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="MSTest.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <RootNamespace>Z3.Linq.Tests</RootNamespace>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <!-- Brings in the Microsoft Code Coverage and TRX report MTP extensions. -->
+    <TestingExtensionsProfile>Default</TestingExtensionsProfile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Shouldly" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Z3.Linq\Z3.Linq.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/solutions/Z3.Linq.slnx
+++ b/solutions/Z3.Linq.slnx
@@ -6,8 +6,10 @@
   <Folder Name="/Solution Items/">
     <File Path="Directory.Build.props" />
     <File Path="Directory.Packages.props" />
+    <File Path="../global.json" />
   </Folder>
   <Project Path="Z3.Linq/Z3.Linq.csproj" />
   <Project Path="Z3.Linq.Examples/Z3.Linq.Examples.csproj" />
   <Project Path="Z3.Linq.Demo/Z3.Linq.Demo.csproj" />
+  <Project Path="Z3.Linq.Tests/Z3.Linq.Tests.csproj" />
 </Solution>


### PR DESCRIPTION
Adds the repository's first test project, following the endjin .NET testing
framework guidelines: MSTest 4.0 on Microsoft.Testing.Platform via the MSTest
SDK, with Shouldly for assertions.

- global.json selects the MTP runner and pins MSTest.Sdk 4.3.3, which is how
  .NET 10 enables MTP mode (the older TestingPlatformDotnetTestSupport
  property is obsolete).
- AssemblyInfo.cs carries [assembly: Parallelize(Workers = 0, Scope =
  ExecutionScope.MethodLevel)], required by MSTest 4.0 to avoid MSTEST0001.
- TestingExtensionsProfile=Default brings in the code coverage and TRX
  report extensions.
- Shouldly is added to Directory.Packages.props. No PackageVersion is added
  for Microsoft.Testing.Extensions.CodeCoverage: the MSTest SDK injects its
  own under CPM and a second one trips NU1506.
- NSubstitute is deliberately omitted; there is nothing to substitute in
  these tests, and the guidelines say to mock only what is used.
- .zf/config.ps1 stops skipping the Test and TestReport stages, so the
  ZeroFailed build now runs tests and produces coverage. The coverage
  assembly filters added earlier (+Z3.Linq*;-Z3.Linq*.Tests*) apply as-is.
- .gitignore excludes the TRX and Cobertura output the run leaves behind.

The 16 tests cover Z3Methods.Distinct in both of its visitor branches: the
Select(...).ToArray() form that reaches PartialEvaluator.PartialEval, and the
inline NewArrayExpression form that does not, including cases asserting the
two forms agree.

Two of them exist specifically to pin the partial-evaluation step. The
arithmetic-only cases turned out to pass with partial evaluation removed,
because Z3 folds constant arithmetic itself, so they do not actually guard
the change. The host-method cases do: the selector calls an ordinary C#
method that the visitor cannot translate, so it only reaches Z3 as a constant
if the substituted body is partially evaluated first. Verified by mutation -
removing the PartialEval call fails exactly those two tests with
"NotSupportedException: Unknown method call: Int32 Get(Int32)", and passes
the other 14.

Full ZeroFailed build: 45 tasks, 0 errors, 0 warnings, 16/16 tests passing,
31.5% line coverage on Z3.Linq.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>