### PR TITLE
Update Microsoft.Z3 to 5.1.0 for Linux and arm64 native binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -356,3 +356,6 @@ _codeCoverage/
 _packages/
 *.sbom.*
 .zf/extensions/
+
+# Microsoft.Z3 packages downloaded by scripts/Install-Z3Package.ps1
+_z3-feed/*.nupkg

--- a/.zf/config.ps1
+++ b/.zf/config.ps1
@@ -49,7 +49,7 @@ task . FullBuild
 # task PostInit {}
 # task PreVersion {}
 # task PostVersion {}
-# task PreBuild {}
+task PreBuild EnsureZ3Package
 # task PostBuild {}
 # task PreTest {}
 # task PostTest {}
@@ -62,3 +62,12 @@ task . FullBuild
 # task PrePublish {}
 # task PostPublish {}
 # task RunLast {}
+
+#
+# Microsoft.Z3 is not available on nuget.org (see scripts/Install-Z3Package.ps1), so the
+# package has to be in the local folder feed before anything restores. PreBuild is the last
+# extensibility point that runs ahead of the RestorePackages task.
+#
+task EnsureZ3Package {
+    & (Join-Path $here "scripts/Install-Z3Package.ps1")
+}

--- a/.zf/config.ps1
+++ b/.zf/config.ps1
@@ -29,6 +29,12 @@ $SkipTestReport = $true
 $SkipAnalysis = $false
 $SkipPackage = $false
 
+# Releases are ON HOLD. The build uses Microsoft.Z3 5.1.0 for its Linux and arm64 native
+# binaries, but that version is not on nuget.org, so a published Z3.Linq would declare a
+# dependency no consumer can restore (NU1102). Lift this once Microsoft.Z3 5.x is published -
+# see https://github.com/endjin/Z3.Linq/issues/60 and https://github.com/Z3Prover/z3/issues/10711
+$SkipPublish = $true
+
 #
 # Build process configuration
 #

--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+
+  <!-- Microsoft.Z3 is not published to nuget.org beyond 4.12.2, which has no Linux or
+       arm64 native binaries. Later releases ship the package as a GitHub release asset
+       only, so it is downloaded into this folder feed before restore runs - see
+       scripts/Install-Z3Package.ps1. The feed is added alongside whatever sources are
+       already configured rather than replacing them. -->
+  <packageSources>
+    <add key="z3-github-release" value="_z3-feed" />
+  </packageSources>
+
+</configuration>

--- a/README.md
+++ b/README.md
@@ -161,8 +161,10 @@ Then you can copy any of the above samples.
 
 ### For Visual Studio
 
-Add the `Z3.Linq` package.
-Configure your application to [target x64 platform](https://docs.microsoft.com/en-us/visualstudio/ide/how-to-configure-projects-to-target-platforms?view=vs-2022). This is a requirement as `Z3.Linq` uses the [Microsoft.Z3](https://www.nuget.org/packages/Microsoft.Z3/) package.
+Add the `Z3.Linq` package. No platform target is needed: `Microsoft.Z3` supplies native binaries for x64 and arm64 on Windows, Linux and macOS, and the default `AnyCPU` resolves the right one.
+
+> [!NOTE]
+> This applies from the next release onwards. The versions published so far depend on `Microsoft.Z3` 4.12.2 - the newest build on nuget.org - which ships native binaries for `win-x64` and `osx-x64` only. On Linux or arm64 those versions restore successfully and then throw `DllNotFoundException` on the first solve, so they do need [an x64 platform target](https://docs.microsoft.com/en-us/visualstudio/ide/how-to-configure-projects-to-target-platforms?view=vs-2022) on Windows or macOS. Releases are paused until Z3 publishes a current build to nuget.org - see [#60](https://github.com/endjin/Z3.Linq/issues/60).
 
 ## Contributing
 

--- a/_z3-feed/.gitkeep
+++ b/_z3-feed/.gitkeep
@@ -1,0 +1,3 @@
+This folder is the local NuGet feed that scripts/Install-Z3Package.ps1 populates with the
+Microsoft.Z3 package, which is not available on nuget.org. The folder is committed (and the
+packages themselves ignored) because NuGet requires a configured local source to exist.

--- a/scripts/Install-Z3Package.ps1
+++ b/scripts/Install-Z3Package.ps1
@@ -1,0 +1,106 @@
+<#
+.SYNOPSIS
+    Downloads the Microsoft.Z3 NuGet package from its GitHub release into this
+    repository's local folder feed, so that `dotnet restore` can find it.
+
+.DESCRIPTION
+    The Z3 project stopped publishing Microsoft.Z3 to nuget.org after 4.12.2 (May 2023).
+    Every release since then - twenty and counting - ships the .NET package only as a
+    GitHub release asset. That matters here rather than being a mere inconvenience:
+    4.12.2 contains native binaries for win-x64 and osx-x64 *only*, so on Linux or on
+    any arm64 machine the managed assembly loads and then fails at the first solve with
+    DllNotFoundException (or, worse, silently binds to an unrelated system libz3 and
+    fails later with EntryPointNotFoundException). The version fetched here ships
+    linux-x64, linux-arm64, osx-x64, osx-arm64, win-x64 and win-arm64.
+
+    Because the package comes from a GitHub release rather than a signed nuget.org feed,
+    the download is checked against a pinned SHA-256 hash and only moved into the feed
+    once it matches. An interrupted or substituted download therefore never becomes a
+    package that restore will consume.
+
+    The script is idempotent - if the package is already in the feed with the expected
+    hash it does nothing - so it is cheap to run on every build.
+
+.PARAMETER Version
+    The Microsoft.Z3 version to install. Must match the PackageVersion in
+    solutions/Directory.Packages.props.
+
+.PARAMETER ExpectedHash
+    The SHA-256 hash of the expected .nupkg, as uppercase hex.
+
+.PARAMETER FeedPath
+    The local folder feed to populate. Must match the source registered in NuGet.config.
+
+.EXAMPLE
+    ./scripts/Install-Z3Package.ps1
+
+    Populates the feed ready for `dotnet build` or `dotnet restore`. The ZeroFailed
+    build runs this automatically; you only need it by hand when building the solution
+    directly (for example from an IDE) on a clean clone.
+
+.NOTES
+    To move to a new Z3 version, update Version and ExpectedHash here and the matching
+    PackageVersion in solutions/Directory.Packages.props together. The hash of a release
+    asset can be obtained with:
+        (Get-FileHash ./Microsoft.Z3.<version>.nupkg -Algorithm SHA256).Hash
+#>
+[CmdletBinding()]
+param (
+    [Parameter()]
+    [string] $Version = '5.1.0',
+
+    [Parameter()]
+    [string] $ExpectedHash = 'D808E6BD31D96895ECA446ECEB37E90DD24480B0D9B5F513113F3E2FD312ABF2',
+
+    [Parameter()]
+    [string] $FeedPath = (Join-Path $PSScriptRoot '..' '_z3-feed')
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version 4.0
+
+$packageFileName = "Microsoft.Z3.$Version.nupkg"
+$feed = New-Item -ItemType Directory -Path $FeedPath -Force
+$packagePath = Join-Path $feed.FullName $packageFileName
+
+function Test-ExpectedHash {
+    param ([string] $Path)
+
+    if (-not (Test-Path -Path $Path -PathType Leaf)) {
+        return $false
+    }
+
+    return (Get-FileHash -Path $Path -Algorithm SHA256).Hash -eq $ExpectedHash
+}
+
+if (Test-ExpectedHash -Path $packagePath) {
+    Write-Host "Microsoft.Z3 $Version already present in $($feed.FullName)"
+    return
+}
+
+$uri = "https://github.com/Z3Prover/z3/releases/download/z3-$Version/$packageFileName"
+$downloadPath = "$packagePath.download"
+
+Write-Host "Downloading $uri"
+
+# The package is ~64MB and Invoke-WebRequest's progress rendering dominates the transfer
+# time for a file this size, so suppress it for the duration of the download.
+$previousProgressPreference = $ProgressPreference
+try {
+    $ProgressPreference = 'SilentlyContinue'
+    Invoke-WebRequest -Uri $uri -OutFile $downloadPath
+}
+finally {
+    $ProgressPreference = $previousProgressPreference
+}
+
+if (-not (Test-ExpectedHash -Path $downloadPath)) {
+    $actualHash = (Get-FileHash -Path $downloadPath -Algorithm SHA256).Hash
+    Remove-Item -Path $downloadPath -Force
+    throw "Hash mismatch for $packageFileName - expected $ExpectedHash but got $actualHash. " +
+          "The release asset has changed or the download was corrupted; the package has not been installed."
+}
+
+Move-Item -Path $downloadPath -Destination $packagePath -Force
+
+Write-Host "Installed Microsoft.Z3 $Version into $($feed.FullName)"

--- a/solutions/Directory.Build.props
+++ b/solutions/Directory.Build.props
@@ -5,8 +5,9 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <!-- Microsoft.Z3 ships native x64 binaries, so every project has to be x64. -->
-    <PlatformTarget>x64</PlatformTarget>
+    <!-- Deliberately no PlatformTarget. Microsoft.Z3 5.1.0 ships native binaries for x64
+         and arm64 on all three platforms, so AnyCPU lets each machine resolve the one it
+         needs; pinning x64 here would shut arm64 out. -->
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 

--- a/solutions/Directory.Packages.props
+++ b/solutions/Directory.Packages.props
@@ -6,9 +6,13 @@
 
   <ItemGroup Label="Third party">
     <PackageVersion Include="MiaPlaza.ExpressionUtils" Version="1.3.1" />
-    <!-- NOTE: 4.12.2 is the newest Microsoft.Z3 published to nuget.org; later Z3
-         releases ship via GitHub releases only. -->
-    <PackageVersion Include="Microsoft.Z3" Version="4.12.2" />
+    <!-- Microsoft.Z3 is not on nuget.org beyond 4.12.2, which ships native binaries for
+         win-x64 and osx-x64 only and so cannot run on Linux or arm64 at all. This version
+         comes from the Z3 GitHub release and covers linux-x64, linux-arm64, osx-x64,
+         osx-arm64, win-x64 and win-arm64. It is downloaded into the local folder feed by
+         scripts/Install-Z3Package.ps1, which pins the version and its SHA-256 hash -
+         change both together with this one. -->
+    <PackageVersion Include="Microsoft.Z3" Version="5.1.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Why

`Microsoft.Z3` 4.12.2 ships native binaries for **`win-x64` and `osx-x64` only**:

```
runtimes/osx-x64/native/libz3.dylib
runtimes/win-x64/native/libz3.dll
```

On Linux the managed assembly loads and then fails at the first solve. In a clean container
that is `DllNotFoundException`; on a machine that happens to carry an unrelated system
`libz3` - as the GitHub Actions runner image does - .NET binds to *that* instead and fails
with `EntryPointNotFoundException: Unable to find an entry point named
'Z3_enable_concurrent_dec_ref'`.

The second is the more dangerous outcome: had the runner carried a closer version, every
entry point would have resolved and the tests would have silently run against a solver we
never pinned. It failed loudly by luck.

This is why CI goes red at #48 - the first PR in the stack whose build actually executes a
theorem. #44, #45 and #47 pass because nothing ever loads the native library.

## What

`Microsoft.Z3` 5.1.0 (16 Aug 2026) ships six RIDs:

| RID | 4.12.2 | 5.1.0 |
|---|---|---|
| `win-x64` | ✅ | ✅ |
| `osx-x64` | ✅ | ✅ |
| `linux-x64` | ❌ | ✅ |
| `linux-arm64` | ❌ | ✅ |
| `osx-arm64` | ❌ | ✅ |
| `win-arm64` | ❌ | ✅ |

`PlatformTarget=x64` is dropped as a result - its justifying comment is no longer true, and
pinning x64 would shut arm64 machines out.

### Getting the package

Z3 stopped publishing to nuget.org after 4.12.2 and has shipped the .NET package as a GitHub
release asset for twenty releases since. `scripts/Install-Z3Package.ps1` fetches it into a
local folder feed, wired to the `PreBuild` extensibility point so it runs ahead of restore.

Because this comes from a release asset rather than a signed nuget.org package, the download
is **pinned by SHA-256** and only moved into the feed once it matches - an interrupted or
substituted download never becomes a package restore will consume. The script is idempotent,
so it costs one hash check per build after the first.

## ⚠️ Releases are on hold

`$SkipPublish = $true`. The packed `Z3.Linq` declares `<dependency id="Microsoft.Z3"
version="5.1.0" />`, and a consumer restoring from nuget.org with a clean cache gets:

```
error NU1102: Unable to find package Microsoft.Z3 with version (>= 5.1.0)
  - Found 14 version(s) in nuget.org [ Nearest version: 4.12.2 ]
```

NuGet gives a package no way to tell consumers where its dependencies live, so no feed we
control can fix this - only an upstream publish can. See #60 for what lifts the hold, and
Z3Prover/z3#10711 upstream, where the blocker is package signing bandwidth rather than
willingness.

Note the published package is *already* broken on Linux and arm64 for the reason above, so
this is not a new limitation - it is the fix for one, waiting on distribution.

## Verification

- **Ubuntu 24.04 container** (glibc 2.39, matching `ubuntu-latest`), .NET 10.0.400: builds
  clean and the full suite passes. The same container on 4.12.2 fails 36 of 39.
- **Windows x64**: builds clean, 39/39 pass.
- **Full demo output diffed between 4.12.2 and 5.1.0** - both Sudoku puzzles, the oil
  purchase LP ($90,500) and the warehouse LP ($200,000) are identical, and Missionaries &
  Cannibals reaches the same optimum under both `Optimize()` and `orderby`. Only unoptimised
  `Solve()` returns a different valid model, which is expected where the constraints admit
  many.
- **API surface**: all 40 `Microsoft.Z3` members `Z3.Linq` calls are present in 5.1.0, and
  `Model.Eval` still takes its `completion` parameter.
- `./build.ps1 FullBuildAndPublish` - 35 tasks, 0 errors, 0 warnings, and reports
  `Task /FullBuildAndPublish/Publish skipped.`

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>