### PR TITLE
Add type marshalling tests for symbols, collections and environment shapes

### DIFF
--- a/solutions/Z3.Linq.Tests/CollectionSymbolTests.cs
+++ b/solutions/Z3.Linq.Tests/CollectionSymbolTests.cs
@@ -1,0 +1,269 @@
+namespace Z3.Linq.Tests;
+
+/// <summary>
+/// Collection-typed symbols: arrays and generic collections whose elements are constrained
+/// individually and read back with an indexed <c>MkSelect</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A collection symbol is declared as a Z3 array with a domain (index) sort and a range
+/// (element) sort chosen per element type (Theorem.cs:205-235). Elements are always read with
+/// an integer index (Theorem.cs:446), and the number read is the <c>Count</c> of the collection
+/// already on the instance - so an environment must pre-size its collections, and a solution
+/// never changes their length.
+/// </para>
+/// <para>
+/// Only <c>int</c> elements work. Every other element type declares a domain or range that
+/// contradicts how the elements are constrained or read, and throws during translation; those
+/// cases are pinned below against #64. The Sudoku examples are all <c>int</c>, which is why the
+/// limitation has gone unnoticed.
+/// </para>
+/// </remarks>
+[TestClass]
+public class CollectionSymbolTests
+{
+    [TestMethod]
+    public void Solve_IntArraySymbol_RoundTripsEveryElement()
+    {
+        // Arrange
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<IntArrayEnvironment>()
+            .Where(t => t.Values[0] == 10)
+            .Where(t => t.Values[1] == 20)
+            .Where(t => t.Values[2] == 30)
+            .Where(t => t.Length == 3)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.Values.ShouldBe([10, 20, 30]);
+    }
+
+    [TestMethod]
+    public void Solve_IntArraySymbol_PreservesTheInitialisedLength()
+    {
+        // Arrange: the element count comes from the collection already on the instance, so the
+        // result has exactly the length the environment was constructed with - a solution can
+        // never grow or shrink it.
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<IntArrayEnvironment>()
+            .Where(t => t.Values[0] == 1)
+            .Where(t => t.Values[1] == 2)
+            .Where(t => t.Values[2] == 3)
+            .Where(t => t.Length == 3)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.Values.Length.ShouldBe(3);
+    }
+
+    [TestMethod]
+    public void Solve_IntArrayWithRelationalConstraints_SatisfiesThemAll()
+    {
+        // Arrange: constraints relating elements to each other rather than pinning them, which
+        // is how the Sudoku theorems actually use collection symbols.
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<IntArrayEnvironment>()
+            .Where(t => t.Values[0] > 0)
+            .Where(t => t.Values[1] == t.Values[0] * 2)
+            .Where(t => t.Values[2] == t.Values[1] + t.Values[0])
+            .Where(t => t.Values[0] < 5)
+            .Where(t => t.Length == 3)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.Values[0].ShouldBeGreaterThan(0);
+        result.Values[0].ShouldBeLessThan(5);
+        result.Values[1].ShouldBe(result.Values[0] * 2);
+        result.Values[2].ShouldBe(result.Values[1] + result.Values[0]);
+    }
+
+    [TestMethod]
+    public void Solve_IntArrayWithContradictoryElementConstraints_ReturnsNull()
+    {
+        // Arrange: one element cannot hold two values at once.
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<IntArrayEnvironment>()
+            .Where(t => t.Values[0] == 1)
+            .Where(t => t.Values[0] == 2)
+            .Solve();
+
+        // Assert
+        result.ShouldBeNull();
+    }
+
+    [TestMethod]
+    public void Solve_GenericIntCollectionSymbol_RoundTripsEveryElement()
+    {
+        // Arrange: the non-array branch, reached for a generic type implementing IEnumerable.
+        // It is reconstructed by passing the element array to the collection's constructor
+        // (Theorem.cs:490), which List<int> supports.
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<IntListEnvironment>()
+            .Where(t => t.Values[0] == 7)
+            .Where(t => t.Values[1] == 8)
+            .Where(t => t.Length == 2)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.Values.ShouldBe([7, 8]);
+    }
+
+    /// <summary>
+    /// KNOWN DEFECT (#64): no collection element type other than <c>int</c> can be translated.
+    /// </summary>
+    /// <remarks>
+    /// Each case declares a domain or range sort that contradicts either the constrained values
+    /// or the integer index used to read elements back, so Z3 rejects the term outright. The
+    /// message differs per type, so the assertion is on the exception rather than its text.
+    /// These pin current behaviour and must be updated when the defect is fixed.
+    /// </remarks>
+    [TestMethod]
+    public void Solve_LongArraySymbol_ThrowsZ3Exception()
+    {
+        // Arrange: range is BitVec 64 while the constrained value is an integer term.
+        using var context = new Z3Context();
+        var theorem = context.NewTheorem<LongArrayEnvironment>()
+            .Where(t => t.Values[0] == 1L)
+            .Where(t => t.Length == 2);
+
+        // Act & Assert
+        Should.Throw<Microsoft.Z3.Z3Exception>(() => theorem.Solve());
+    }
+
+    /// <summary>KNOWN DEFECT (#64). See <see cref="Solve_LongArraySymbol_ThrowsZ3Exception"/>.</summary>
+    [TestMethod]
+    public void Solve_BoolArraySymbol_ThrowsZ3Exception()
+    {
+        // Arrange: the domain - the index sort - is declared Bool, but elements are read with an
+        // integer index.
+        using var context = new Z3Context();
+        var theorem = context.NewTheorem<BoolArrayEnvironment>()
+            .Where(t => t.Values[0])
+            .Where(t => t.Length == 2);
+
+        // Act & Assert
+        Should.Throw<Microsoft.Z3.Z3Exception>(() => theorem.Solve());
+    }
+
+    /// <summary>KNOWN DEFECT (#64). See <see cref="Solve_LongArraySymbol_ThrowsZ3Exception"/>.</summary>
+    [TestMethod]
+    public void Solve_DoubleArraySymbol_ThrowsZ3Exception()
+    {
+        // Arrange: range is a floating-point sort while the constrained value is a real.
+        using var context = new Z3Context();
+        var theorem = context.NewTheorem<DoubleArrayEnvironment>()
+            .Where(t => t.Values[0] == 1.5)
+            .Where(t => t.Length == 2);
+
+        // Act & Assert
+        Should.Throw<Microsoft.Z3.Z3Exception>(() => theorem.Solve());
+    }
+
+    /// <summary>
+    /// KNOWN DEFECT (#64), and the reason #55 cannot currently be observed.
+    /// </summary>
+    /// <remarks>
+    /// #55 describes the decimal element branch evaluating the whole array expression instead of
+    /// the selected element (Theorem.cs:471-474), which would give every element the same value.
+    /// That code is still wrong, but unreachable: a decimal array never survives translation.
+    /// </remarks>
+    [TestMethod]
+    public void Solve_DecimalArraySymbol_ThrowsZ3Exception()
+    {
+        // Arrange
+        using var context = new Z3Context();
+        var theorem = context.NewTheorem<DecimalArrayEnvironment>()
+            .Where(t => t.Values[0] == 1.5m)
+            .Where(t => t.Length == 2);
+
+        // Act & Assert
+        Should.Throw<Microsoft.Z3.Z3Exception>(() => theorem.Solve());
+    }
+
+    /// <summary>
+    /// KNOWN DEFECT (#53): a collection held in a public field cannot be marshalled.
+    /// </summary>
+    /// <remarks>
+    /// Determining how many elements to read casts the reflection object itself rather than the
+    /// value it holds - <c>((ICollection)info1).Count</c> where <c>info1</c> is the
+    /// <see cref="System.Reflection.FieldInfo"/> (Theorem.cs:439). The property branch beside it
+    /// correctly calls <c>GetValue</c> first, which is why an array property works and an array
+    /// field does not.
+    /// This test pins current behaviour and must be updated when the defect is fixed.
+    /// </remarks>
+    [TestMethod]
+    public void Solve_CollectionInAPublicField_ThrowsInvalidCastException()
+    {
+        // Arrange
+        using var context = new Z3Context();
+        var theorem = context.NewTheorem<FieldCollectionEnvironment>()
+            .Where(t => t.Values[0] == 1)
+            .Where(t => t.Length == 2);
+
+        // Act & Assert
+        Should.Throw<InvalidCastException>(() => theorem.Solve());
+    }
+
+    private sealed class IntArrayEnvironment
+    {
+        public int[] Values { get; set; } = new int[3];
+
+        public int Length { get; set; }
+    }
+
+    private sealed class IntListEnvironment
+    {
+        public List<int> Values { get; set; } = [0, 0];
+
+        public int Length { get; set; }
+    }
+
+    private sealed class LongArrayEnvironment
+    {
+        public long[] Values { get; set; } = new long[2];
+
+        public int Length { get; set; }
+    }
+
+    private sealed class BoolArrayEnvironment
+    {
+        public bool[] Values { get; set; } = new bool[2];
+
+        public int Length { get; set; }
+    }
+
+    private sealed class DoubleArrayEnvironment
+    {
+        public double[] Values { get; set; } = new double[2];
+
+        public int Length { get; set; }
+    }
+
+    private sealed class DecimalArrayEnvironment
+    {
+        public decimal[] Values { get; set; } = new decimal[2];
+
+        public int Length { get; set; }
+    }
+
+    private sealed class FieldCollectionEnvironment
+    {
+        public int[] Values = new int[2];
+
+        public int Length { get; set; }
+    }
+}

--- a/solutions/Z3.Linq.Tests/EnvironmentTypeTests.cs
+++ b/solutions/Z3.Linq.Tests/EnvironmentTypeTests.cs
@@ -1,0 +1,295 @@
+namespace Z3.Linq.Tests;
+
+/// <summary>
+/// The shapes a theorem environment can take: the built-in <c>Symbols</c> family, anonymous
+/// types, value tuples, records, ordinary classes and nested objects.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Two code paths sit behind these. A compiler-generated type - an anonymous type - is created
+/// uninitialised and populated by writing to the compiler's backing fields, matched by name
+/// (Theorem.cs:607-648). Everything else is created with <c>Activator.CreateInstance</c> and
+/// populated through its properties and fields (Theorem.cs:651-696).
+/// </para>
+/// <para>
+/// The split matters because the two support different types. The anonymous path handles only
+/// <c>bool</c> and <c>int</c> and throws on anything else, while the ordinary path handles the
+/// full set. A value tuple looks like an anonymous type in source but is an ordinary framework
+/// type, so it takes the second path and is not restricted.
+/// </para>
+/// <para>
+/// Note that <c>Symbols&lt;T1, T2, T3, T4&gt;</c> does not exist - the family provides arities
+/// 2, 3 and 5 only.
+/// </para>
+/// </remarks>
+[TestClass]
+public class EnvironmentTypeTests
+{
+    [TestMethod]
+    public void Solve_SymbolsWithThreeSymbols_PopulatesEveryProperty()
+    {
+        // Arrange
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<Symbols<int, int, int>>()
+            .Where(t => t.X1 == 1)
+            .Where(t => t.X2 == 2)
+            .Where(t => t.X3 == 3)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        (result.X1, result.X2, result.X3).ShouldBe((1, 2, 3));
+    }
+
+    [TestMethod]
+    public void Solve_SymbolsWithFiveSymbols_PopulatesEveryProperty()
+    {
+        // Arrange: the largest arity the family provides.
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<Symbols<int, int, int, int, int>>()
+            .Where(t => t.X1 == 1)
+            .Where(t => t.X2 == 2)
+            .Where(t => t.X3 == 3)
+            .Where(t => t.X4 == 4)
+            .Where(t => t.X5 == 5)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        (result.X1, result.X2, result.X3, result.X4, result.X5).ShouldBe((1, 2, 3, 4, 5));
+    }
+
+    [TestMethod]
+    public void Solve_SymbolsWithMixedTypes_PopulatesEveryProperty()
+    {
+        // Arrange: the Symbols family is generic, so the arity and the element types vary
+        // independently.
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<Symbols<int, bool, string>>()
+            .Where(t => t.X1 == 1)
+            .Where(t => t.X2)
+            .Where(t => t.X3 == "three")
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.X1.ShouldBe(1);
+        result.X2.ShouldBeTrue();
+        result.X3.ShouldBe("three");
+    }
+
+    [TestMethod]
+    public void Solve_AnonymousTypeEnvironment_PopulatesEveryProperty()
+    {
+        // Arrange: anonymous types have get-only properties, so the solution is written to the
+        // compiler-generated backing fields instead.
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem(new { flag = default(bool), n = default(int) })
+            .Where(t => t.flag)
+            .Where(t => t.n == 9)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.flag.ShouldBeTrue();
+        result.n.ShouldBe(9);
+    }
+
+    /// <summary>
+    /// The anonymous-type path supports only <c>bool</c> and <c>int</c>.
+    /// </summary>
+    /// <remarks>
+    /// Theorem.cs:645 throws for any other property type, so a double that is perfectly usable
+    /// in a named environment cannot be used in an anonymous one. This is a real restriction
+    /// rather than a defect - the branch never grew the other cases - but it is undocumented,
+    /// and the failure names the property rather than explaining the restriction.
+    /// </remarks>
+    [TestMethod]
+    public void Solve_AnonymousTypeWithDoubleProperty_ThrowsNotSupportedException()
+    {
+        // Arrange
+        using var context = new Z3Context();
+        var theorem = context.NewTheorem(new { d = default(double) })
+            .Where(t => t.d == 1.5);
+
+        // Act & Assert
+        Should.Throw<NotSupportedException>(() => theorem.Solve());
+    }
+
+    [TestMethod]
+    public void Solve_ValueTupleWithDouble_PopulatesEveryField()
+    {
+        // Arrange: the counterpart to the test above. A value tuple is written the same way in
+        // source but is an ordinary framework type exposing public fields, so it takes the
+        // non-anonymous path and the bool/int restriction does not apply.
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<(int a, double b)>()
+            .Where(t => t.a == 3)
+            .Where(t => t.b == 2.5)
+            .Solve();
+
+        // Assert
+        result.a.ShouldBe(3);
+        result.b.ShouldBe(2.5);
+    }
+
+    [TestMethod]
+    public void Solve_ValueTupleWithString_PopulatesEveryField()
+    {
+        // Arrange
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<(int a, string s)>()
+            .Where(t => t.a == 1)
+            .Where(t => t.s == "hi")
+            .Solve();
+
+        // Assert
+        result.a.ShouldBe(1);
+        result.s.ShouldBe("hi");
+    }
+
+    [TestMethod]
+    public void Solve_RecordEnvironment_PopulatesEveryProperty()
+    {
+        // Arrange: a record declared with a body rather than a positional parameter list has an
+        // implicit parameterless constructor and settable properties, so it behaves as an
+        // ordinary class here. RecordTheorem in the examples carries a comment saying this does
+        // not work; it does, and the demo runs one unguarded.
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem(new BodyRecord())
+            .Where(t => t.X)
+            .Where(t => !t.Y)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.X.ShouldBeTrue();
+        result.Y.ShouldBeFalse();
+    }
+
+    /// <summary>
+    /// A positional record cannot be used as an environment.
+    /// </summary>
+    /// <remarks>
+    /// Environments are constructed with <c>Activator.CreateInstance(t)</c> (Theorem.cs:653),
+    /// and a positional record's only constructor takes its members, so there is nothing to
+    /// call. This is the distinction the stale comment on RecordTheorem was probably reaching
+    /// for: records work, positional records do not.
+    /// </remarks>
+    [TestMethod]
+    public void Solve_PositionalRecordEnvironment_ThrowsMissingMethodException()
+    {
+        // Arrange
+        using var context = new Z3Context();
+        var theorem = context.NewTheorem<PositionalRecord>().Where(t => t.X);
+
+        // Act & Assert
+        Should.Throw<MissingMethodException>(() => theorem.Solve());
+    }
+
+    [TestMethod]
+    public void Solve_NestedObjectEnvironment_PopulatesTheNestedProperties()
+    {
+        // Arrange: a property whose type is itself an environment recurses through GetSolution,
+        // building a sub-environment per level.
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<OuterEnvironment>()
+            .Where(t => t.Inner.A == 4)
+            .Where(t => t.Inner.B == 5)
+            .Where(t => t.Top == 6)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.Inner.ShouldNotBeNull();
+        result.Inner.A.ShouldBe(4);
+        result.Inner.B.ShouldBe(5);
+        result.Top.ShouldBe(6);
+    }
+
+    [TestMethod]
+    public void Solve_NestedObjectEnvironment_ConstrainsAcrossNestingLevels()
+    {
+        // Arrange: a constraint relating an inner symbol to an outer one, to show the levels
+        // share a single set of Z3 constants rather than being solved independently.
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<OuterEnvironment>()
+            .Where(t => t.Inner.A == t.Top * 2)
+            .Where(t => t.Top == 5)
+            .Where(t => t.Inner.B == 0)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.Top.ShouldBe(5);
+        result.Inner.A.ShouldBe(10);
+    }
+
+    [TestMethod]
+    public void Solve_EnvironmentWithPrivateSetters_PopulatesThemAnyway()
+    {
+        // Arrange: the Symbols family declares private setters, so reflection has to be writing
+        // through them. This pins that behaviour for a plain class, since a public-setter-only
+        // implementation would break every built-in environment.
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<PrivateSetterEnvironment>()
+            .Where(t => t.A == 3)
+            .Where(t => t.B == 4)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.A.ShouldBe(3);
+        result.B.ShouldBe(4);
+    }
+
+    private sealed record BodyRecord
+    {
+        public bool X { get; set; }
+
+        public bool Y { get; set; }
+    }
+
+    private sealed record PositionalRecord(bool X, bool Y);
+
+    private sealed class InnerEnvironment
+    {
+        public int A { get; set; }
+
+        public int B { get; set; }
+    }
+
+    private sealed class OuterEnvironment
+    {
+        public InnerEnvironment Inner { get; set; } = new();
+
+        public int Top { get; set; }
+    }
+
+    private sealed class PrivateSetterEnvironment
+    {
+        public int A { get; private set; }
+
+        public int B { get; private set; }
+    }
+}

--- a/solutions/Z3.Linq.Tests/SymbolTypeMarshallingTests.cs
+++ b/solutions/Z3.Linq.Tests/SymbolTypeMarshallingTests.cs
@@ -23,6 +23,12 @@ using System.Threading;
 [TestClass]
 public class SymbolTypeMarshallingTests
 {
+    /// <summary>
+    /// How long to wait for a solve running on a dedicated thread. Generous by design - it
+    /// exists to turn a hang into a failure, not to police how long a solve should take.
+    /// </summary>
+    private static readonly TimeSpan SolveTimeout = TimeSpan.FromSeconds(30);
+
     [TestMethod]
     [DataRow(0, DisplayName = "Zero")]
     [DataRow(42, DisplayName = "Positive")]
@@ -314,7 +320,11 @@ public class SymbolTypeMarshallingTests
 
         // Act
         thread.Start();
-        thread.Join();
+
+        // Bounded, so that a solver that never returns fails this test rather than hanging the
+        // whole run with no indication of which test stopped. The work itself takes single-digit
+        // milliseconds, so the limit is enormous slack rather than a tuned value.
+        thread.Join(SolveTimeout).ShouldBeTrue("the solve on the de-DE thread did not finish");
 
         // Assert
         captured.ShouldBeOfType<Microsoft.Z3.Z3Exception>();
@@ -343,7 +353,7 @@ public class SymbolTypeMarshallingTests
 
         // Act
         thread.Start();
-        thread.Join();
+        thread.Join(SolveTimeout).ShouldBeTrue("the solve on the invariant-culture thread did not finish");
 
         // Assert
         value.ShouldBe(1.5);

--- a/solutions/Z3.Linq.Tests/SymbolTypeMarshallingTests.cs
+++ b/solutions/Z3.Linq.Tests/SymbolTypeMarshallingTests.cs
@@ -1,0 +1,351 @@
+namespace Z3.Linq.Tests;
+
+using System.Globalization;
+using System.Threading;
+
+/// <summary>
+/// Round-trips a value of each scalar symbol type through <see cref="Theorem{T}.Solve"/>:
+/// C# constant -> Z3 term -> model -> CLR property.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Every test here pins its symbols to exactly one value, so the assertions hold for any model
+/// Z3 returns. That matters more in this file than elsewhere: the point is what came back, not
+/// which solution was chosen.
+/// </para>
+/// <para>
+/// Three of the types listed as supported do not work, and are pinned as characterisation tests
+/// rather than skipped - short (#63), float (#54) and DateTime (#56). All three fail in the
+/// marshalling layer, which no example in the repository exercises, which is why they went
+/// unnoticed.
+/// </para>
+/// </remarks>
+[TestClass]
+public class SymbolTypeMarshallingTests
+{
+    [TestMethod]
+    [DataRow(0, DisplayName = "Zero")]
+    [DataRow(42, DisplayName = "Positive")]
+    [DataRow(-42, DisplayName = "Negative")]
+    [DataRow(int.MaxValue, DisplayName = "Int32.MaxValue")]
+    [DataRow(int.MinValue, DisplayName = "Int32.MinValue")]
+    public void Solve_IntSymbol_RoundTripsTheValue(int value)
+    {
+        // Arrange
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<Symbols<int, int>>()
+            .Where(t => t.X1 == value)
+            .Where(t => t.X2 == 0)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.X1.ShouldBe(value);
+    }
+
+    [TestMethod]
+    [DataRow(0L, DisplayName = "Zero")]
+    [DataRow(9_000_000_000L, DisplayName = "Beyond Int32 range")]
+    [DataRow(-9_000_000_000L, DisplayName = "Negative beyond Int32 range")]
+    [DataRow(long.MaxValue, DisplayName = "Int64.MaxValue")]
+    public void Solve_LongSymbol_RoundTripsTheValue(long value)
+    {
+        // Arrange: the values beyond Int32 range are the point - they would survive a
+        // round-trip that silently narrowed to int only by accident.
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<Symbols<long, int>>()
+            .Where(t => t.X1 == value)
+            .Where(t => t.X2 == 0)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.X1.ShouldBe(value);
+    }
+
+    [TestMethod]
+    [DataRow(true, DisplayName = "True")]
+    [DataRow(false, DisplayName = "False")]
+    public void Solve_BoolSymbol_RoundTripsTheValue(bool value)
+    {
+        // Arrange
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<Symbols<bool, int>>()
+            .Where(t => t.X1 == value)
+            .Where(t => t.X2 == 0)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.X1.ShouldBe(value);
+    }
+
+    [TestMethod]
+    [DataRow(1.5, DisplayName = "Exactly representable")]
+    [DataRow(0.0, DisplayName = "Zero")]
+    [DataRow(-2.25, DisplayName = "Negative")]
+    [DataRow(1234.5678, DisplayName = "Several decimal places")]
+    public void Solve_DoubleSymbol_RoundTripsTheValue(double value)
+    {
+        // Arrange: doubles are carried as Z3 reals and read back through ToDecimalString(64),
+        // so these are values that survive that text round-trip exactly.
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<Symbols<double, int>>()
+            .Where(t => t.X1 == value)
+            .Where(t => t.X2 == 0)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.X1.ShouldBe(value);
+    }
+
+    [TestMethod]
+    public void Solve_DecimalSymbol_RoundTripsTheValue()
+    {
+        // Arrange: decimal goes through ToDecimalString(128) and is parsed with
+        // InvariantCulture. DataRow cannot carry a decimal constant, hence the single case.
+        using var context = new Z3Context();
+        const decimal Value = 2.25m;
+
+        // Act
+        var result = context.NewTheorem<Symbols<decimal, int>>()
+            .Where(t => t.X1 == Value)
+            .Where(t => t.X2 == 0)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.X1.ShouldBe(Value);
+    }
+
+    [TestMethod]
+    [DataRow("abc", DisplayName = "Simple string")]
+    [DataRow("", DisplayName = "Empty string")]
+    [DataRow("with space", DisplayName = "String containing a space")]
+    public void Solve_StringSymbol_RoundTripsTheValue(string value)
+    {
+        // Arrange
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<Symbols<string, int>>()
+            .Where(t => t.X1 == value)
+            .Where(t => t.X2 == 0)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.X1.ShouldBe(value);
+    }
+
+    [TestMethod]
+    public void Solve_DoubleSymbolWithInequality_SatisfiesTheConstraint()
+    {
+        // Arrange: pinning by equality is the easy case for a real-valued symbol. This checks an
+        // inequality, where Z3 picks the value and marshalling still has to survive whatever it
+        // chose - which need not be a tidy decimal.
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<Symbols<double, int>>()
+            .Where(t => t.X1 > 10.5)
+            .Where(t => t.X1 < 11.0)
+            .Where(t => t.X2 == 0)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.X1.ShouldBeGreaterThan(10.5);
+        result.X1.ShouldBeLessThan(11.0);
+    }
+
+    /// <summary>
+    /// KNOWN DEFECT (#63): no theorem over a short symbol can be solved.
+    /// </summary>
+    /// <remarks>
+    /// A short symbol is created with MkIntConst, but C# widens short to int for the comparison
+    /// and ExpressionVisitor.VisitUnary reads that Convert node as a real-to-int conversion,
+    /// casting the IntExpr to RealExpr (ExpressionVisitor.cs:131). A second defect waits behind
+    /// it: TypeCode.Int16 marshals to an int, which a short property rejects.
+    /// This test pins current behaviour and must be updated when the defect is fixed.
+    /// </remarks>
+    [TestMethod]
+    public void Solve_ShortSymbol_ThrowsInvalidCastException()
+    {
+        // Arrange
+        using var context = new Z3Context();
+        var theorem = context.NewTheorem<Symbols<short, short>>()
+            .Where(t => t.X1 == 7)
+            .Where(t => t.X2 == 1);
+
+        // Act & Assert
+        Should.Throw<InvalidCastException>(() => theorem.Solve());
+    }
+
+    /// <summary>
+    /// KNOWN DEFECT (#54): a float symbol solves but cannot be marshalled back.
+    /// </summary>
+    /// <remarks>
+    /// TypeCode.Single parses the model value into a double (Theorem.cs:527) and then writes it
+    /// to a float property, which reflection rejects. Note this fails later than short does -
+    /// translation and solving both succeed, so only the result is lost.
+    /// This test pins current behaviour and must be updated when the defect is fixed.
+    /// </remarks>
+    [TestMethod]
+    public void Solve_FloatSymbol_ThrowsArgumentException()
+    {
+        // Arrange
+        using var context = new Z3Context();
+        var theorem = context.NewTheorem<Symbols<float, int>>()
+            .Where(t => t.X1 == 1.5f)
+            .Where(t => t.X2 == 0);
+
+        // Act & Assert
+        Should.Throw<ArgumentException>(() => theorem.Solve());
+    }
+
+    /// <summary>
+    /// KNOWN DEFECT (#56): a DateTime does not compare equal to the value put in.
+    /// </summary>
+    /// <remarks>
+    /// The instant itself survives - the value is written with ToFileTimeUtc and read with
+    /// DateTime.FromFileTime, which is its correct inverse for the instant - but the result
+    /// comes back as <see cref="DateTimeKind.Local"/>. Since <see cref="DateTime"/> equality
+    /// compares ticks and ignores Kind, a caller comparing the result against the UTC value it
+    /// supplied gets false anywhere with a non-zero UTC offset. Asserted in a form that holds in
+    /// any time zone, including UTC where the offset is zero and the shift vanishes.
+    /// </remarks>
+    [TestMethod]
+    public void Solve_DateTimeSymbol_ReturnsTheSameInstantAsLocalTime()
+    {
+        // Arrange
+        using var context = new Z3Context();
+        var utc = new DateTime(2026, 6, 1, 12, 0, 0, DateTimeKind.Utc);
+
+        // Act
+        var result = context.NewTheorem<Symbols<DateTime, int>>()
+            .Where(t => t.X1 == utc)
+            .Where(t => t.X2 == 0)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+
+        // The instant is preserved...
+        result.X1.Kind.ShouldBe(DateTimeKind.Local);
+        result.X1.ToUniversalTime().ShouldBe(utc);
+
+        // ...but the value is shifted by the local UTC offset, so a direct comparison against
+        // what went in only succeeds where that offset happens to be zero.
+        TimeSpan offset = TimeZoneInfo.Local.GetUtcOffset(utc);
+        result.X1.Ticks.ShouldBe(utc.Ticks + offset.Ticks);
+    }
+
+    [TestMethod]
+    public void Solve_MixedTypeSymbols_MarshalsEveryPropertyIndependently()
+    {
+        // Arrange: the two properties take different marshalling branches, so this catches a
+        // change that fixed one type by breaking the dispatch for another.
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<Symbols<int, string>>()
+            .Where(t => t.X1 == 5)
+            .Where(t => t.X2 == "five")
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.X1.ShouldBe(5);
+        result.X2.ShouldBe("five");
+    }
+
+    /// <summary>
+    /// KNOWN DEFECT (#52): a real-valued constant is written to Z3 using the current culture.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// ExpressionVisitor.cs:304 calls MkReal(val.ToString()) with no format provider, so under a
+    /// comma-decimal culture the literal 1.5 is handed to Z3 as "1,5" and its parser rejects it.
+    /// Every other numeric conversion in the visitor passes InvariantCulture, and so does every
+    /// read back on the marshalling side, which is what makes this one look like an oversight
+    /// rather than a decision.
+    /// </para>
+    /// <para>
+    /// The work runs on a dedicated thread rather than by setting the culture on the test's own
+    /// thread. CurrentCulture is per-thread, these tests run in parallel at method level, and
+    /// the runner hands out pooled threads - so mutating it here could leak into whatever runs
+    /// next on the same thread. A thread created for the purpose cannot leak anywhere.
+    /// </para>
+    /// <para>This test pins current behaviour and must be updated when the defect is fixed.</para>
+    /// </remarks>
+    [TestMethod]
+    public void Solve_DoubleSymbolUnderCommaDecimalCulture_ThrowsZ3ParserError()
+    {
+        // Arrange
+        Exception? captured = null;
+
+        var thread = new Thread(() =>
+        {
+            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("de-DE");
+
+            try
+            {
+                using var context = new Z3Context();
+                _ = context.NewTheorem<Symbols<double, int>>()
+                    .Where(t => t.X1 == 1.5)
+                    .Where(t => t.X2 == 0)
+                    .Solve();
+            }
+            catch (Exception ex)
+            {
+                captured = ex;
+            }
+        });
+
+        // Act
+        thread.Start();
+        thread.Join();
+
+        // Assert
+        captured.ShouldBeOfType<Microsoft.Z3.Z3Exception>();
+    }
+
+    [TestMethod]
+    public void Solve_DoubleSymbolUnderInvariantCulture_RoundTripsTheValue()
+    {
+        // Arrange: the counterpart to the pin above, on the same dedicated-thread mechanism, so
+        // that the two differ only by culture. This is what the defect above should look like
+        // once it is fixed.
+        double? value = null;
+
+        var thread = new Thread(() =>
+        {
+            CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
+
+            using var context = new Z3Context();
+            var result = context.NewTheorem<Symbols<double, int>>()
+                .Where(t => t.X1 == 1.5)
+                .Where(t => t.X2 == 0)
+                .Solve();
+
+            value = result?.X1;
+        });
+
+        // Act
+        thread.Start();
+        thread.Join();
+
+        // Assert
+        value.ShouldBe(1.5);
+    }
+}


### PR DESCRIPTION
Phase B of the test plan: the layer that turns a Z3 model back into a CLR object.

**39 tests → 87. Line coverage 38.8% → 62.9%, branch → 52.1%.**

## What it covers

| File | Covers |
|---|---|
| `SymbolTypeMarshallingTests` | round-trips per scalar type - int, long, bool, double, decimal, string - plus inequality-chosen values and mixed-type environments |
| `CollectionSymbolTests` | `int[]` and `List<int>` element round-trips, relational constraints across elements, length preservation, unsatisfiable element constraints |
| `EnvironmentTypeTests` | `Symbols` arities 2/3/5, anonymous types, value tuples, records, nested objects, private setters |

## What it found

Four of the types the library presents as supported do not work. None is exercised by any
example, which is why they went unnoticed — every example uses `int`, `bool` or `double` in a
named environment.

- **`short` is unusable (#63, new).** Throws `InvalidCastException` before reaching the solver:
  a short symbol is an `IntExpr`, C# widens short→int for the comparison, and
  `ExpressionVisitor.cs:131` reads that `Convert` node as real→int and casts to `RealExpr`.
  A second defect waits behind it — `TypeCode.Int16` marshals to an `int`, which a `short`
  property rejects, verified directly against `SetValue`.
- **Only `int` collections work (#64, new).** `long[]`, `bool[]`, `double[]`, `decimal[]` and
  `string[]` all fail translation with a Z3 sort error. The array sort mapping pairs a domain
  and range per element type, and only `Int32` gets a self-consistent `Int → Int`; the others
  declare the element type as the *index* sort, or a range that contradicts the values
  constrained into it.
- **`float` solves then fails to marshal (#54).** `TypeCode.Single` parses into a `double` and
  writes it to a `float` property.
- **Real constants are written using the current culture (#52).** Under `de-DE`, `1.5` reaches
  Z3 as `"1,5"` and its parser rejects it. Every other numeric conversion in the visitor passes
  `InvariantCulture`.

Each is pinned by a characterisation test naming its issue, per the standing decision to
document rather than fix defects in this work.

**#55 turned out to be unreachable** and has been annotated rather than left misleading: the
element-evaluation bug it describes is real code, but `decimal[]` dies at translation long
before any marshalling happens.

## Two deliberate choices

**The culture test runs on a dedicated thread.** These tests run in parallel at method level on
pooled threads, so setting `CurrentCulture` in place could leak into whatever ran next on the
same thread. A thread created for the purpose cannot leak. This was the one case where the
plan's "no culture-mutating tests" rule needed a way around rather than an exemption.

**`DateTime` is asserted in a form that holds in any time zone.** The instant round-trips
correctly, but the value comes back as `Kind=Local`, so comparing it against the UTC value
supplied fails by exactly the local UTC offset — zero on a UTC machine, an hour here (#56).
Asserting the offset relationship rather than a fixed value keeps it honest on both.

## Mutation-checked

- reading `Int64` model values through `.Int` → **3 tests fail**
- reading every array element from index `0` → **3 tests fail**

## Verification

- `dotnet build solutions/Z3.Linq.slnx -c Release` — 0 warnings, 0 errors
- 87/87 tests pass
- `./build.ps1 -Configuration Release` — 46 tasks, 0 errors, 0 warnings

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>