### PR TITLE
Add optimisation tests for Optimize, OrderBy and OrderByDescending

### DIFF
--- a/solutions/Z3.Linq.Tests/OptimizationTests.cs
+++ b/solutions/Z3.Linq.Tests/OptimizationTests.cs
@@ -1,0 +1,344 @@
+namespace Z3.Linq.Tests;
+
+/// <summary>
+/// Optimisation: <see cref="Theorem{T}.Optimize"/> and the <c>orderby</c> query operators that
+/// delegate to it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>Optimize</c> takes the same constraints as <c>Solve</c> but asserts them against an
+/// <c>Optimize</c> solver with an objective attached, so the model returned is the best one
+/// rather than any satisfying one (Theorem.cs:99-129). <c>OrderBy</c> maps to
+/// <c>Minimize</c> and <c>OrderByDescending</c> to <c>Maximize</c>, each wrapped in a deferred
+/// solvable so nothing runs until <c>Solve</c> is called.
+/// </para>
+/// <para>
+/// An optimum is unique in its objective value even where several assignments achieve it, so
+/// these tests assert the objective rather than the particular vertex Z3 lands on - except
+/// where the constraints pin the variables outright.
+/// </para>
+/// </remarks>
+[TestClass]
+public class OptimizationTests
+{
+    [TestMethod]
+    public void Optimize_Minimize_ReturnsTheSmallestSatisfyingValue()
+    {
+        // Arrange: the range is closed on both sides, so the minimum is exactly 5.
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<Symbols<int, int>>()
+            .Where(t => t.X1 >= 5)
+            .Where(t => t.X1 <= 9)
+            .Where(t => t.X2 == 0)
+            .Optimize(Optimization.Minimize, t => t.X1);
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.X1.ShouldBe(5);
+    }
+
+    [TestMethod]
+    public void Optimize_Maximize_ReturnsTheLargestSatisfyingValue()
+    {
+        // Arrange
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<Symbols<int, int>>()
+            .Where(t => t.X1 >= 5)
+            .Where(t => t.X1 <= 9)
+            .Where(t => t.X2 == 0)
+            .Optimize(Optimization.Maximize, t => t.X1);
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.X1.ShouldBe(9);
+    }
+
+    [TestMethod]
+    public void Optimize_MinimizeAndMaximizeOverTheSameTheorem_ReturnOppositeBounds()
+    {
+        // Arrange: the two directions applied to one theorem. A mapping that sent both to the
+        // same Z3 objective would still pass each of the two tests above in isolation only if
+        // it happened to pick the right one; this fails whichever way it was collapsed.
+        using var context = new Z3Context();
+        var theorem = context.NewTheorem<Symbols<int, int>>()
+            .Where(t => t.X1 >= 5)
+            .Where(t => t.X1 <= 9)
+            .Where(t => t.X2 == 0);
+
+        // Act
+        var minimum = theorem.Optimize(Optimization.Minimize, t => t.X1);
+        var maximum = theorem.Optimize(Optimization.Maximize, t => t.X1);
+
+        // Assert
+        minimum.X1.ShouldBe(5);
+        maximum.X1.ShouldBe(9);
+        minimum.X1.ShouldBeLessThan(maximum.X1);
+    }
+
+    [TestMethod]
+    public void OrderBy_ProducesTheSameResultAsMinimize()
+    {
+        // Arrange: OrderBy is documented as sugar for Optimize(Minimize, ...), so the two must
+        // agree - and this test costs nothing beyond stating that.
+        using var context = new Z3Context();
+        var theorem = context.NewTheorem<Symbols<int, int>>()
+            .Where(t => t.X1 >= 3)
+            .Where(t => t.X1 <= 8)
+            .Where(t => t.X2 == 0);
+
+        // Act
+        var viaOptimize = theorem.Optimize(Optimization.Minimize, t => t.X1);
+        var viaOrderBy = theorem.OrderBy(t => t.X1).Solve();
+
+        // Assert
+        viaOrderBy.ShouldNotBeNull();
+        viaOrderBy.X1.ShouldBe(viaOptimize.X1);
+        viaOrderBy.X1.ShouldBe(3);
+    }
+
+    [TestMethod]
+    public void OrderByDescending_ProducesTheSameResultAsMaximize()
+    {
+        // Arrange
+        using var context = new Z3Context();
+        var theorem = context.NewTheorem<Symbols<int, int>>()
+            .Where(t => t.X1 >= 3)
+            .Where(t => t.X1 <= 8)
+            .Where(t => t.X2 == 0);
+
+        // Act
+        var viaOptimize = theorem.Optimize(Optimization.Maximize, t => t.X1);
+        var viaOrderBy = theorem.OrderByDescending(t => t.X1).Solve();
+
+        // Assert
+        viaOrderBy.ShouldNotBeNull();
+        viaOrderBy.X1.ShouldBe(viaOptimize.X1);
+        viaOrderBy.X1.ShouldBe(8);
+    }
+
+    [TestMethod]
+    public void OrderBy_BeforeSolveIsCalled_DoesNotSolveAnything()
+    {
+        // Arrange: OrderBy returns a deferred solvable (Theorem{T}.cs:70), so building the query
+        // must not touch Z3. The log is the observable proof - Theorem.cs:178 writes a line per
+        // asserted constraint, so an eager implementation would have written to it already.
+        using var log = new StringWriter();
+        using var context = new Z3Context { Log = log };
+        var theorem = context.NewTheorem<Symbols<int, int>>()
+            .Where(t => t.X1 >= 3)
+            .Where(t => t.X2 == 0);
+
+        // Act
+        var deferred = theorem.OrderBy(t => t.X1);
+
+        // Assert
+        log.ToString().ShouldBeEmpty();
+
+        // ...and solving is what actually runs it.
+        deferred.Solve();
+        log.ToString().ShouldNotBeEmpty();
+    }
+
+    [TestMethod]
+    public void OrderByDescending_BeforeSolveIsCalled_DoesNotSolveAnything()
+    {
+        // Arrange
+        using var log = new StringWriter();
+        using var context = new Z3Context { Log = log };
+        var theorem = context.NewTheorem<Symbols<int, int>>()
+            .Where(t => t.X1 >= 3)
+            .Where(t => t.X2 == 0);
+
+        // Act
+        var deferred = theorem.OrderByDescending(t => t.X1);
+
+        // Assert
+        log.ToString().ShouldBeEmpty();
+
+        deferred.Solve();
+        log.ToString().ShouldNotBeEmpty();
+    }
+
+    [TestMethod]
+    public void Optimize_ObjectiveOverSeveralSymbols_MinimisesTheirCombination()
+    {
+        // Arrange: the objective need not be a single symbol. Both are free within their ranges
+        // and only their sum is minimised, so the sum is what can be asserted.
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<Symbols<int, int>>()
+            .Where(t => t.X1 >= 2)
+            .Where(t => t.X2 >= 3)
+            .Where(t => t.X1 + t.X2 >= 10)
+            .Optimize(Optimization.Minimize, t => t.X1 + t.X2);
+
+        // Assert
+        result.ShouldNotBeNull();
+        (result.X1 + result.X2).ShouldBe(10);
+        result.X1.ShouldBeGreaterThanOrEqualTo(2);
+        result.X2.ShouldBeGreaterThanOrEqualTo(3);
+    }
+
+    [TestMethod]
+    public void Optimize_LinearProgramOverDoubles_FindsTheKnownOptimum()
+    {
+        // Arrange: the oil purchase problem from the README, whose optimum is a single vertex -
+        // buy 2200 barrels from Saudi Arabia and 3100 from Venezuela for $90,500. An LP optimum
+        // is unique in its objective value, so the cost is safe to assert exactly.
+        using var context = new Z3Context();
+
+        // Act
+        var result = (from t in context.NewTheorem<(double sa, double vz)>()
+                      where (0.3 * t.sa) + (0.4 * t.vz) >= 1900   // gasolene
+                      where (0.4 * t.sa) + (0.2 * t.vz) >= 1500   // jet fuel
+                      where (0.2 * t.sa) + (0.3 * t.vz) >= 500    // lubricant
+                      where 0 <= t.sa && t.sa <= 9000
+                      where 0 <= t.vz && t.vz <= 6000
+                      orderby (20.0 * t.sa) + (15.0 * t.vz)
+                      select t).Solve();
+
+        // Assert
+        double cost = (20.0 * result.sa) + (15.0 * result.vz);
+        cost.ShouldBe(90_500.0);
+
+        // The constraints must still hold at the optimum - a "minimum" that violated them would
+        // otherwise satisfy the cost assertion by being infeasible.
+        ((0.3 * result.sa) + (0.4 * result.vz)).ShouldBeGreaterThanOrEqualTo(1900);
+        ((0.4 * result.sa) + (0.2 * result.vz)).ShouldBeGreaterThanOrEqualTo(1500);
+        ((0.2 * result.sa) + (0.3 * result.vz)).ShouldBeGreaterThanOrEqualTo(500);
+    }
+
+    [TestMethod]
+    public void Optimize_MinimisingIsNotJustTheFirstSatisfyingModel()
+    {
+        // Arrange: this is the test that distinguishes optimising from solving. A plain Solve
+        // over the same constraints may return any value in [5, 100]; minimising must return 5.
+        // Without it, an Optimize that quietly ignored its objective would still look correct
+        // wherever Z3 happened to pick the boundary.
+        using var context = new Z3Context();
+        var theorem = context.NewTheorem<Symbols<int, int>>()
+            .Where(t => t.X1 >= 5)
+            .Where(t => t.X1 <= 100)
+            .Where(t => t.X2 == 0);
+
+        // Act
+        var minimised = theorem.Optimize(Optimization.Minimize, t => t.X1);
+        var maximised = theorem.Optimize(Optimization.Maximize, t => t.X1);
+
+        // Assert
+        minimised.X1.ShouldBe(5);
+        maximised.X1.ShouldBe(100);
+    }
+
+    [TestMethod]
+    public void Optimize_CalledTwiceOnTheSameTheorem_LeavesItReusable()
+    {
+        // Arrange: each call builds its own native context and optimiser, so an earlier
+        // optimisation must not leave an objective attached to the theorem.
+        using var context = new Z3Context();
+        var theorem = context.NewTheorem<Symbols<int, int>>()
+            .Where(t => t.X1 >= 1)
+            .Where(t => t.X1 <= 4)
+            .Where(t => t.X2 == 0);
+
+        // Act
+        var first = theorem.Optimize(Optimization.Minimize, t => t.X1);
+        var second = theorem.Optimize(Optimization.Minimize, t => t.X1);
+        var solved = theorem.Solve();
+
+        // Assert
+        first.X1.ShouldBe(1);
+        second.X1.ShouldBe(1);
+
+        // The plain solve is unconstrained by the objective and only has to satisfy the range.
+        solved.ShouldNotBeNull();
+        solved.X1.ShouldBeInRange(1, 4);
+    }
+
+    [TestMethod]
+    public void Optimize_WithUnrecognisedDirection_ThrowsArgumentOutOfRangeException()
+    {
+        // Arrange: Optimization has two members, and the switch rejects anything else rather
+        // than defaulting to one of them (Theorem.cs:118).
+        using var context = new Z3Context();
+        var theorem = context.NewTheorem<Symbols<int, int>>()
+            .Where(t => t.X1 == 1)
+            .Where(t => t.X2 == 0);
+
+        // Act & Assert
+        Should.Throw<ArgumentOutOfRangeException>(
+            () => theorem.Optimize((Optimization)42, t => t.X1));
+    }
+
+    /// <summary>
+    /// KNOWN DEFECT (#58): an unsatisfiable optimisation returns null through a signature that
+    /// promises it will not.
+    /// </summary>
+    /// <remarks>
+    /// <c>Solve</c> returns <c>T?</c> and callers are expected to check it, but <c>Optimize</c>
+    /// returns a non-nullable <c>T</c> while returning <c>default!</c> when the status is not
+    /// SATISFIABLE (Theorem.cs:126). For a reference environment type that is a null the
+    /// compiler has been told cannot happen, so the caller dereferences it and gets a
+    /// <see cref="NullReferenceException"/> far from the cause.
+    /// This test pins current behaviour and must be updated when the defect is fixed.
+    /// </remarks>
+    [TestMethod]
+    public void Optimize_WithUnsatisfiableTheorem_ReturnsNullDespiteNonNullableSignature()
+    {
+        // Arrange: a direct contradiction, so the optimiser has nothing to optimise over.
+        using var context = new Z3Context();
+        var theorem = context.NewTheorem<Symbols<int, int>>()
+            .Where(t => t.X1 > 10)
+            .Where(t => t.X1 < 5);
+
+        // Act
+        var result = theorem.Optimize(Optimization.Minimize, t => t.X1);
+
+        // Assert
+        result.ShouldBeNull();
+    }
+
+    [TestMethod]
+    public void OrderBy_OnAnUnsatisfiableTheorem_ReturnsNull()
+    {
+        // Arrange: the query-syntax route to the same place. Here the null is at least
+        // well-typed, since ISolveable<T>.Solve is declared to return T?.
+        using var context = new Z3Context();
+
+        // Act
+        var result = (from t in context.NewTheorem<Symbols<int, int>>()
+                      where t.X1 > 10
+                      where t.X1 < 5
+                      orderby t.X1
+                      select t).Solve();
+
+        // Assert
+        result.ShouldBeNull();
+    }
+
+    [TestMethod]
+    public void Optimize_AfterAdditionalWhere_RespectsTheNarrowedConstraints()
+    {
+        // Arrange: Where returns a new theorem, so optimising the child must see the extra
+        // constraint while the parent still does not.
+        using var context = new Z3Context();
+        var parent = context.NewTheorem<Symbols<int, int>>()
+            .Where(t => t.X1 >= 1)
+            .Where(t => t.X1 <= 10)
+            .Where(t => t.X2 == 0);
+        var child = parent.Where(t => t.X1 >= 6);
+
+        // Act
+        var parentMinimum = parent.Optimize(Optimization.Minimize, t => t.X1);
+        var childMinimum = child.Optimize(Optimization.Minimize, t => t.X1);
+
+        // Assert
+        parentMinimum.X1.ShouldBe(1);
+        childMinimum.X1.ShouldBe(6);
+    }
+}

--- a/solutions/Z3.Linq.Tests/OptimizationTests.cs
+++ b/solutions/Z3.Linq.Tests/OptimizationTests.cs
@@ -164,7 +164,7 @@ public class OptimizationTests
     }
 
     [TestMethod]
-    public void Optimize_ObjectiveOverSeveralSymbols_MinimisesTheirCombination()
+    public void Optimize_ObjectiveOverSeveralSymbols_MinimizesTheirCombination()
     {
         // Arrange: the objective need not be a single symbol. Both are free within their ranges
         // and only their sum is minimised, so the sum is what can be asserted.
@@ -214,7 +214,7 @@ public class OptimizationTests
     }
 
     [TestMethod]
-    public void Optimize_MinimisingIsNotJustTheFirstSatisfyingModel()
+    public void Optimize_MinimizingIsNotJustTheFirstSatisfyingModel()
     {
         // Arrange: this is the test that distinguishes optimising from solving. A plain Solve
         // over the same constraints may return any value in [5, 100]; minimising must return 5.


### PR DESCRIPTION
Phase C of the test plan: the optimisation surface, which was entirely untested despite being
the feature the README leads with.

**87 tests → 102. Line coverage 62.9% → 69.9%, branch 52.1% → 54.7%.**

## What it covers

- `Optimize(Minimize)` and `Optimize(Maximize)` return the correct bound
- `OrderBy` ⇒ `Minimize` and `OrderByDescending` ⇒ `Maximize`, each asserted equal to the
  `Optimize` call it delegates to
- **Deferred execution** — building an `orderby` query solves nothing
- objectives spanning several symbols
- a theorem stays reusable across repeated `Optimize` calls, and after one
- `Where` applied after the fact narrows what the optimiser sees
- an unrecognised `Optimization` value throws rather than silently defaulting to a direction
- the **oil purchase linear program** from the README

## The oil purchase LP

Reproduces the README's example end to end: 2200 barrels from Saudi Arabia, 3100 from
Venezuela, **$90,500**. An LP optimum is unique in its objective value, so the cost is safe to
assert exactly. The test also re-checks the three refining constraints at the optimum — a
"minimum" that reached that cost by being infeasible would otherwise pass.

## Pins #58

`Solve` returns `T?` and makes the caller check. `Optimize` returns a non-nullable `T` and then
hands back `default!` when the status is not SATISFIABLE (`Theorem.cs:126`). For a reference
environment type that is a null the compiler has been told cannot happen, so it surfaces as a
`NullReferenceException` somewhere else entirely. Pinned, not fixed, per the standing decision.

## Deferred execution, without timing or defects

Laziness is asserted through the `Z3Context.Log` seam: `Theorem.cs:178` writes a line per
asserted constraint, so an eager `OrderBy` would have written to the log before `Solve` was
called. That avoids both timing and the alternative of leaning on a theorem that happens to
throw — which would have quietly stopped testing laziness the day that defect was fixed.

## Mutation-checked

| Mutation | Tests failed |
|---|---|
| **objective never attached** — `Optimize` degenerates into `Solve` | **5** |
| `Minimize` and `Maximize` swapped inside `Optimize` | 9 |
| `OrderBy` mapped to `Maximize` | 2 |

The first is the one worth having: without it, tests over a theorem whose bound Z3 happens to
pick anyway would pass against an `Optimize` that ignored its objective entirely.

## Verification

- `dotnet build solutions/Z3.Linq.slnx -c Release` — 0 warnings, 0 errors
- 102/102 tests pass
- `./build.ps1 -Configuration Release` — 46 tasks, 0 errors, 0 warnings

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>