### PR TITLE
Add failure mode and rewriter tests

### DIFF
--- a/solutions/Z3.Linq.Tests/RewriterTests.cs
+++ b/solutions/Z3.Linq.Tests/RewriterTests.cs
@@ -1,0 +1,241 @@
+namespace Z3.Linq.Tests;
+
+using System.Linq.Expressions;
+
+/// <summary>
+/// The two rewriter extension points: a global rewriter attached to an environment type, which
+/// gets the whole constraint list before anything is translated, and a predicate rewriter
+/// attached to a method, which replaces a call the visitor would otherwise reject.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Both are public API and both were entirely unverified. They are also the only way to extend
+/// the translator without changing it, which makes them worth holding still.
+/// </para>
+/// <para>
+/// The tests assert what a rewrite <em>did</em>, not merely that one ran. A rewriter whose
+/// returned constraints were discarded, or whose replacement expression was built and then
+/// ignored, would satisfy a "was it called" check perfectly well while doing nothing.
+/// </para>
+/// </remarks>
+[TestClass]
+public class RewriterTests
+{
+    [TestMethod]
+    public void Solve_EnvironmentWithGlobalRewriter_AppliesTheRewrittenConstraints()
+    {
+        // Arrange: the rewriter appends a constraint pinning Second to 99, which no constraint
+        // in the query mentions. If the returned sequence were ignored, Second would be free
+        // and this would fail.
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<GloballyRewrittenEnvironment>()
+            .Where(t => t.First == 1)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.First.ShouldBe(1);
+        result.Second.ShouldBe(99);
+    }
+
+    [TestMethod]
+    public void Solve_GlobalRewriterThatDropsConstraints_ChangesSatisfiability()
+    {
+        // Arrange: the complementary direction. The query is a direct contradiction, and the
+        // rewriter discards everything, so a theorem that could not otherwise be satisfied is.
+        // A rewriter whose output was ignored would leave this unsatisfiable.
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<ConstraintDroppingEnvironment>()
+            .Where(t => t.First > 10)
+            .Where(t => t.First < 5)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.First.ShouldBe(7);
+    }
+
+    [TestMethod]
+    public void Solve_GlobalRewriterTypeNotImplementingTheInterface_ThrowsInvalidOperationException()
+    {
+        // Arrange: the attribute takes a bare Type, so nothing at compile time requires it to be
+        // a rewriter. The check happens on the way in (Theorem.cs:151).
+        using var context = new Z3Context();
+        var theorem = context.NewTheorem<BadlyRewrittenEnvironment>().Where(t => t.First == 1);
+
+        // Act & Assert
+        Should.Throw<InvalidOperationException>(() => theorem.Solve());
+    }
+
+    [TestMethod]
+    public void Solve_MethodWithPredicateRewriter_TranslatesTheRewrittenCall()
+    {
+        // Arrange: AllDifferent has no meaning to the visitor by itself - its own body throws.
+        // The rewriter turns the call into Z3Methods.Distinct over the same arguments, which
+        // the visitor does understand.
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<Symbols<int, int>>()
+            .Where(t => AllDifferent(t.X1, t.X2))
+            .Where(t => t.X1 == 1)
+            .Where(t => t.X2 == 2)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.X1.ShouldBe(1);
+        result.X2.ShouldBe(2);
+    }
+
+    [TestMethod]
+    public void Solve_MethodWithPredicateRewriter_AppliesTheRewrittenMeaning()
+    {
+        // Arrange: the test above shows the rewritten call is accepted; this one shows it means
+        // something. Both symbols are pinned to 3, so the Distinct the rewriter produced cannot
+        // hold and the theorem must be unsatisfiable. A rewrite that was accepted and then
+        // dropped would return a result here.
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<Symbols<int, int>>()
+            .Where(t => AllDifferent(t.X1, t.X2))
+            .Where(t => t.X1 == 3)
+            .Where(t => t.X2 == 3)
+            .Solve();
+
+        // Assert
+        result.ShouldBeNull();
+    }
+
+    [TestMethod]
+    public void Solve_PredicateRewriterThatReturnsItsInput_ThrowsTheProgressGuard()
+    {
+        // Arrange: the visitor re-visits whatever the rewriter returns, so a rewriter returning
+        // its own input would recurse forever. That is detected by reference equality and
+        // rejected (ExpressionVisitor.cs:191) - a guard worth keeping, since the alternative is
+        // a hung build rather than a failed one.
+        using var context = new Z3Context();
+        var theorem = context.NewTheorem<Symbols<int, int>>()
+            .Where(t => NeverRewritten(t.X1, t.X2));
+
+        // Act & Assert
+        Should.Throw<InvalidOperationException>(() => theorem.Solve());
+    }
+
+    [TestMethod]
+    public void Solve_PredicateRewriterTypeNotImplementingTheInterface_ThrowsInvalidOperationException()
+    {
+        // Arrange: as with the global rewriter, the attribute cannot enforce this at compile
+        // time (ExpressionVisitor.cs:179).
+        using var context = new Z3Context();
+        var theorem = context.NewTheorem<Symbols<int, int>>()
+            .Where(t => WrongRewriterType(t.X1, t.X2));
+
+        // Act & Assert
+        Should.Throw<InvalidOperationException>(() => theorem.Solve());
+    }
+
+    [TestMethod]
+    public void Solve_EnvironmentWithoutARewriter_IsUnaffected()
+    {
+        // Arrange: the control. Rewriting is opt-in by attribute, so an ordinary environment
+        // must behave as though the machinery were not there.
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<PlainEnvironment>()
+            .Where(t => t.First == 1)
+            .Where(t => t.Second == 2)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.First.ShouldBe(1);
+        result.Second.ShouldBe(2);
+    }
+
+    [TheoremPredicateRewriter(typeof(DistinctPredicateRewriter))]
+    private static bool AllDifferent(int first, int second)
+        => throw new NotSupportedException("This method should only be used in query expressions.");
+
+    [TheoremPredicateRewriter(typeof(IdentityPredicateRewriter))]
+    private static bool NeverRewritten(int first, int second)
+        => throw new NotSupportedException("This method should only be used in query expressions.");
+
+    [TheoremPredicateRewriter(typeof(NotARewriter))]
+    private static bool WrongRewriterType(int first, int second)
+        => throw new NotSupportedException("This method should only be used in query expressions.");
+
+    /// <summary>Implements neither rewriter interface, which is the point.</summary>
+    private sealed class NotARewriter
+    {
+    }
+
+    private sealed class DistinctPredicateRewriter : ITheoremPredicateRewriter
+    {
+        public MethodCallExpression Rewrite(MethodCallExpression call)
+        {
+            var distinct = typeof(Z3Methods).GetMethod(nameof(Z3Methods.Distinct))!
+                .MakeGenericMethod(typeof(int));
+
+            return Expression.Call(distinct, Expression.NewArrayInit(typeof(int), call.Arguments));
+        }
+    }
+
+    private sealed class IdentityPredicateRewriter : ITheoremPredicateRewriter
+    {
+        public MethodCallExpression Rewrite(MethodCallExpression call) => call;
+    }
+
+    private sealed class AppendConstraintRewriter : ITheoremGlobalRewriter
+    {
+        public IEnumerable<LambdaExpression> Rewrite(IEnumerable<LambdaExpression> constraints)
+        {
+            Expression<Func<GloballyRewrittenEnvironment, bool>> extra = t => t.Second == 99;
+
+            return constraints.Concat<LambdaExpression>([extra]);
+        }
+    }
+
+    private sealed class DropAllConstraintsRewriter : ITheoremGlobalRewriter
+    {
+        public IEnumerable<LambdaExpression> Rewrite(IEnumerable<LambdaExpression> constraints)
+        {
+            Expression<Func<ConstraintDroppingEnvironment, bool>> replacement = t => t.First == 7;
+
+            return [replacement];
+        }
+    }
+
+    [TheoremGlobalRewriter(typeof(AppendConstraintRewriter))]
+    private sealed class GloballyRewrittenEnvironment
+    {
+        public int First { get; set; }
+
+        public int Second { get; set; }
+    }
+
+    [TheoremGlobalRewriter(typeof(DropAllConstraintsRewriter))]
+    private sealed class ConstraintDroppingEnvironment
+    {
+        public int First { get; set; }
+    }
+
+    [TheoremGlobalRewriter(typeof(NotARewriter))]
+    private sealed class BadlyRewrittenEnvironment
+    {
+        public int First { get; set; }
+    }
+
+    private sealed class PlainEnvironment
+    {
+        public int First { get; set; }
+
+        public int Second { get; set; }
+    }
+}

--- a/solutions/Z3.Linq.Tests/UnsupportedExpressionTests.cs
+++ b/solutions/Z3.Linq.Tests/UnsupportedExpressionTests.cs
@@ -1,0 +1,213 @@
+namespace Z3.Linq.Tests;
+
+/// <summary>
+/// The library's "we do not support that" contract: the expressions and environment shapes that
+/// are rejected, and what they are rejected with.
+/// </summary>
+/// <remarks>
+/// <para>
+/// These throw sites are the boundary of the translator. They matter as much as the supported
+/// cases, because a change that quietly stops rejecting something does not fail loudly - it
+/// produces a theorem that means something other than what was written. Pinning them also makes
+/// the boundary discoverable, since none of it is documented anywhere else.
+/// </para>
+/// <para>
+/// Assertions are on exception type rather than message. The messages are informative but
+/// several are misspelled or malformed, and pinning them would turn a typo fix into a test
+/// failure.
+/// </para>
+/// </remarks>
+[TestClass]
+public class UnsupportedExpressionTests
+{
+    [TestMethod]
+    public void Distinct_CalledOutsideAQueryExpression_ThrowsNotSupportedException()
+    {
+        // Arrange: Z3Methods.Distinct exists to be recognised by the visitor, never executed.
+        // Its body throws so that calling it directly cannot silently return a meaningless
+        // bool (Z3Methods.cs:19).
+
+        // Act & Assert
+        Should.Throw<NotSupportedException>(() => Z3Methods.Distinct(1, 2, 3));
+    }
+
+    [TestMethod]
+    public void Solve_ConditionalExpression_ThrowsNotSupportedException()
+    {
+        // Arrange: a ternary is a Conditional node, which the visitor has no case for. Z3 can
+        // express if-then-else, so this is a gap rather than a fundamental limit.
+        using var context = new Z3Context();
+        var theorem = context.NewTheorem<Symbols<int, int>>()
+            .Where(t => (t.X1 > 0 ? t.X1 : 0) == 1)
+            .Where(t => t.X2 == 0);
+
+        // Act & Assert
+        Should.Throw<NotSupportedException>(() => theorem.Solve());
+    }
+
+    [TestMethod]
+    public void Solve_CallToAnUnrecognisedMethod_ThrowsNotSupportedException()
+    {
+        // Arrange: only Z3Methods.Distinct, indexed property getters and methods carrying a
+        // predicate rewriter attribute are understood. An ordinary method that depends on a
+        // theorem symbol cannot be evaluated away, so it reaches the visitor and is rejected
+        // (ExpressionVisitor.cs:277).
+        using var context = new Z3Context();
+        var theorem = context.NewTheorem<Symbols<int, int>>()
+            .Where(t => Increment(t.X1) == 2)
+            .Where(t => t.X2 == 0);
+
+        // Act & Assert
+        Should.Throw<NotSupportedException>(() => theorem.Solve());
+    }
+
+    [TestMethod]
+    public void Solve_UnsupportedCast_ThrowsNotImplementedException()
+    {
+        // Arrange: the Convert case handles conversions to double, int and char only. Widening
+        // an int symbol to long is unremarkable C# but has no case, so it falls through to the
+        // catch-all (ExpressionVisitor.cs:140). Note this one is NotImplementedException rather
+        // than NotSupportedException - the throw sites are not consistent about which they use.
+        using var context = new Z3Context();
+        var theorem = context.NewTheorem<Symbols<int, int>>()
+            .Where(t => (long)t.X1 == 1L)
+            .Where(t => t.X2 == 0);
+
+        // Act & Assert
+        Should.Throw<NotImplementedException>(() => theorem.Solve());
+    }
+
+    [TestMethod]
+    public void Solve_CharProperty_ThrowsNotSupportedException()
+    {
+        // Arrange: char has no branch in the symbol declaration switch (Theorem.cs:342). The
+        // message names the mangled symbol - "CharEnvironment_Value" - rather than the type,
+        // which is worth knowing when diagnosing one of these.
+        using var context = new Z3Context();
+        var theorem = context.NewTheorem<CharEnvironment>().Where(t => t.Other == 1);
+
+        // Act & Assert
+        Should.Throw<NotSupportedException>(() => theorem.Solve());
+    }
+
+    [TestMethod]
+    public void Solve_UnsignedIntProperty_ThrowsNotSupportedException()
+    {
+        // Arrange: uint is likewise absent. Z3 integers are unbounded, so the omission is about
+        // the type switch rather than anything Z3 cannot represent.
+        using var context = new Z3Context();
+        var theorem = context.NewTheorem<UnsignedEnvironment>().Where(t => t.Other == 1);
+
+        // Act & Assert
+        Should.Throw<NotSupportedException>(() => theorem.Solve());
+    }
+
+    [TestMethod]
+    public void Solve_NullableProperty_ThrowsArgumentException()
+    {
+        // Arrange: a Nullable<int> property is TypeCode.Object, so it is treated as a nested
+        // environment and recursed into. Nullable<T> has no settable properties, so the failure
+        // surfaces from reflection as "Property set method not found" rather than as anything
+        // naming nullability.
+        using var context = new Z3Context();
+        var theorem = context.NewTheorem<NullableEnvironment>().Where(t => t.Other == 1);
+
+        // Act & Assert
+        Should.Throw<ArgumentException>(() => theorem.Solve());
+    }
+
+    /// <summary>
+    /// KNOWN DEFECT (#63): an enum symbol fails the same way a short does.
+    /// </summary>
+    /// <remarks>
+    /// An enum's TypeCode is that of its underlying type, so the symbol is created as an
+    /// integer - and then C# emits a Convert to int for the comparison, which
+    /// ExpressionVisitor.cs:131 reads as a real-to-int conversion and casts to RealExpr. Same
+    /// root cause as short, so the same fix covers both.
+    /// This test pins current behaviour and must be updated when the defect is fixed.
+    /// </remarks>
+    [TestMethod]
+    public void Solve_EnumProperty_ThrowsInvalidCastException()
+    {
+        // Arrange
+        using var context = new Z3Context();
+        var theorem = context.NewTheorem<EnumEnvironment>()
+            .Where(t => t.Day == DayOfWeek.Monday)
+            .Where(t => t.Other == 1);
+
+        // Act & Assert
+        Should.Throw<InvalidCastException>(() => theorem.Solve());
+    }
+
+    [TestMethod]
+    public void Solve_TwoLevelsOfObjectCollections_ThrowsNotSupportedException()
+    {
+        // Arrange: a collection of objects that themselves hold collections. The environment
+        // builder rejects this explicitly rather than producing something wrong
+        // (Theorem.cs:385), and its message names the offending prefix - one of the better
+        // diagnostics in the library.
+        using var context = new Z3Context();
+        var theorem = context.NewTheorem<TwoLevelCollectionEnvironment>().Where(t => t.Other == 2);
+
+        // Act & Assert
+        Should.Throw<NotSupportedException>(() => theorem.Solve());
+    }
+
+    [TestMethod]
+    public void Solve_SupportedExpressionsAlongsideRejectedOnes_StillRejects()
+    {
+        // Arrange: an unsupported constraint is not skipped in favour of the ones that do
+        // translate. Worth pinning, because silently dropping a constraint would produce a
+        // satisfying-looking answer to a different question.
+        using var context = new Z3Context();
+        var theorem = context.NewTheorem<Symbols<int, int>>()
+            .Where(t => t.X1 > 0)
+            .Where(t => t.X2 == 0)
+            .Where(t => (t.X1 > 5 ? t.X1 : 0) == 6);
+
+        // Act & Assert
+        Should.Throw<NotSupportedException>(() => theorem.Solve());
+    }
+
+    private static int Increment(int value) => value + 1;
+
+    private sealed class CharEnvironment
+    {
+        public char Value { get; set; }
+
+        public int Other { get; set; }
+    }
+
+    private sealed class UnsignedEnvironment
+    {
+        public uint Value { get; set; }
+
+        public int Other { get; set; }
+    }
+
+    private sealed class NullableEnvironment
+    {
+        public int? Value { get; set; }
+
+        public int Other { get; set; }
+    }
+
+    private sealed class EnumEnvironment
+    {
+        public DayOfWeek Day { get; set; }
+
+        public int Other { get; set; }
+    }
+
+    private sealed class InnerCollectionHolder
+    {
+        public int[] Values { get; set; } = new int[2];
+    }
+
+    private sealed class TwoLevelCollectionEnvironment
+    {
+        public InnerCollectionHolder[] Items { get; set; } = [new(), new()];
+
+        public int Other { get; set; }
+    }
+}


### PR DESCRIPTION
Phase D of the test plan: the library's "we do not support that" contract, and the two rewriter
extension points.

**102 tests → 120. Line coverage 69.9% → 76.2%, branch 54.7% → 68.7%.**

Branch coverage moves most here — throw sites are branches, and not one of them had ever been
executed.

## `UnsupportedExpressionTests`

Pins the boundary of the translator: `Z3Methods.Distinct` called outside a query, ternaries,
unrecognised method calls, unsupported casts, `char`/`uint`/nullable properties, and two levels
of object collections.

These matter as much as the supported cases. A change that quietly stops rejecting something
doesn't fail loudly — it produces a theorem that means something other than what was written.
One test covers exactly that: an unsupported constraint alongside valid ones must still reject,
rather than being silently dropped in favour of the constraints that do translate.

Assertions are on exception **type**, not message. Several messages are misspelled
(`"unsuported method call:"`) or malformed; pinning them would turn a typo fix into a test
failure. The throw sites are also inconsistent about `NotSupportedException` vs
`NotImplementedException`, which the tests record rather than paper over.

## `RewriterTests`

Both extension points are public API and were entirely unverified. They're also the only way to
extend the translator without modifying it.

**The tests assert what a rewrite did, not that one ran.** A rewriter whose returned constraints
were discarded would sail through a "was it called" check:

- a global rewriter **appends** a constraint no query mentions — the solution must satisfy it
- another **discards** a direct contradiction — an otherwise unsatisfiable theorem must now solve
- a predicate rewriter turns a call the visitor would reject into `Z3Methods.Distinct`, checked
  both for being **accepted** and for **meaning something** — the unsatisfiable case would still
  pass if the rewrite were built and then dropped
- the progress guard fires when a rewriter returns its own input, which would otherwise recurse
  forever — a hung build rather than a failed one
- both interface checks reject a type that implements neither interface, since the attributes
  take a bare `Type` and cannot enforce it at compile time

## Also found

**Enums fail exactly as `short` does** — same `Convert` defect at `ExpressionVisitor.cs:131`,
same fix covers both. Recorded on #63 with the marshalling side noted too.

## Mutation-checked

| Mutation | Tests failed |
|---|---|
| global rewriter invoked but its result **discarded** | **2** — precisely the effect-based tests |
| global rewriter interface check removed | 1 |

## Verification

- `dotnet build solutions/Z3.Linq.slnx -c Release` — 0 warnings, 0 errors
- 120/120 tests pass
- `./build.ps1 -Configuration Release` — 46 tasks, 0 errors, 0 warnings

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>