### PR TITLE
Add acceptance tests for the Sudoku and river crossing samples

### DIFF
--- a/solutions/Z3.Linq.Tests/MissionariesAndCannibalsTests.cs
+++ b/solutions/Z3.Linq.Tests/MissionariesAndCannibalsTests.cs
@@ -1,0 +1,208 @@
+namespace Z3.Linq.Tests;
+
+using Z3.Linq.Examples.RiverCrossing;
+
+/// <summary>
+/// Acceptance tests for the Missionaries and Cannibals sample: a planning problem expressed as a
+/// theorem over two integer arrays, one entry per step.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is the sample that exercises collection symbols at scale - the theorem is built by
+/// looping over <c>maxLength</c> and adding several constraints per step, so the constraint
+/// count grows with the bound rather than being fixed.
+/// </para>
+/// <para>
+/// <c>maxLength</c> is the search bound, not the answer. Measured: 11 and 12 are unsatisfiable,
+/// and 13 upwards all yield the same optimum of 12. The tests use 15 - comfortably past the
+/// boundary, and far cheaper than the 50 the demo uses, which costs 764ms for a plain solve
+/// against 112ms at 15.
+/// </para>
+/// </remarks>
+[TestClass]
+public class MissionariesAndCannibalsTests
+{
+    private const int Population = 3;
+    private const int BoatSize = 2;
+
+    /// <summary>The measured optimum: everyone crosses in 12 states.</summary>
+    private const int OptimalLength = 12;
+
+    [TestMethod]
+    public void Optimize_ClassicPuzzle_FindsTheShortestCrossing()
+    {
+        // Arrange: three missionaries, three cannibals, a boat holding two. The shortest
+        // solution is a known property of the puzzle rather than an artefact of the search
+        // bound, so it is safe to assert exactly.
+        using var context = new Z3Context();
+
+        // Act
+        var result = (from t in MissionariesAndCannibals.Create(context, 15)
+                      where t.MissionaryAndCannibalCount == Population
+                      where t.SizeBoat == BoatSize
+                      orderby t.Length
+                      select t).Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.Length.ShouldBe(OptimalLength);
+    }
+
+    [TestMethod]
+    [DataRow(13, DisplayName = "Smallest feasible bound")]
+    [DataRow(15, DisplayName = "Comfortably past the boundary")]
+    [DataRow(50, DisplayName = "The bound the demo uses")]
+    public void Optimize_WithDifferentSearchBounds_FindsTheSameOptimum(int maxLength)
+    {
+        // Arrange: the optimum must not depend on how much slack the search is given. This is
+        // what makes the reduced bound in the other tests legitimate rather than a shortcut.
+        using var context = new Z3Context();
+
+        // Act
+        var result = (from t in MissionariesAndCannibals.Create(context, maxLength)
+                      where t.MissionaryAndCannibalCount == Population
+                      where t.SizeBoat == BoatSize
+                      orderby t.Length
+                      select t).Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.Length.ShouldBe(OptimalLength);
+    }
+
+    [TestMethod]
+    [DataRow(11, DisplayName = "Bound below the optimum")]
+    [DataRow(12, DisplayName = "Bound equal to the optimum")]
+    public void Solve_WithSearchBoundBelowTheOptimum_ReturnsNull(int maxLength)
+    {
+        // Arrange: the goal requires Length < maxLength, so a bound equal to the optimum is one
+        // short. Pinning both sides of the boundary documents that off-by-one, which is easy to
+        // trip over when picking a bound.
+        using var context = new Z3Context();
+
+        // Act
+        var result = (from t in MissionariesAndCannibals.Create(context, maxLength)
+                      where t.MissionaryAndCannibalCount == Population
+                      where t.SizeBoat == BoatSize
+                      select t).Solve();
+
+        // Assert
+        result.ShouldBeNull();
+    }
+
+    [TestMethod]
+    public void Solve_ClassicPuzzle_ProducesAValidCrossing()
+    {
+        // Arrange: a plain solve returns some crossing rather than the shortest, so the answer
+        // is checked against the rules of the puzzle instead of a fixed length.
+        using var context = new Z3Context();
+
+        // Act
+        var result = (from t in MissionariesAndCannibals.Create(context, 15)
+                      where t.MissionaryAndCannibalCount == Population
+                      where t.SizeBoat == BoatSize
+                      select t).Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        AssertIsValidCrossing(result);
+    }
+
+    [TestMethod]
+    public void Optimize_ClassicPuzzle_ProducesAValidCrossingAtTheOptimum()
+    {
+        // Arrange: the optimal answer must also be a legal one. Without this, an optimiser that
+        // reached length 12 by violating the safety rule would satisfy the length assertion.
+        using var context = new Z3Context();
+
+        // Act
+        var result = (from t in MissionariesAndCannibals.Create(context, 15)
+                      where t.MissionaryAndCannibalCount == Population
+                      where t.SizeBoat == BoatSize
+                      orderby t.Length
+                      select t).Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.Length.ShouldBe(OptimalLength);
+        AssertIsValidCrossing(result);
+    }
+
+    [TestMethod]
+    public void Optimize_WithABoatHoldingThree_CrossesInFewerSteps()
+    {
+        // Arrange: a bigger boat must not make the puzzle harder. Varying an input the sample
+        // exposes checks the theorem is genuinely parameterised rather than solving one fixed
+        // instance.
+        using var context = new Z3Context();
+
+        // Act
+        var result = (from t in MissionariesAndCannibals.Create(context, 15)
+                      where t.MissionaryAndCannibalCount == Population
+                      where t.SizeBoat == 3
+                      orderby t.Length
+                      select t).Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.Length.ShouldBeLessThan(OptimalLength);
+        AssertIsValidCrossing(result, boatSize: 3);
+    }
+
+    /// <summary>
+    /// Asserts the rules of the puzzle: everyone starts on the near bank, everyone ends on the
+    /// far bank, the boat capacity is respected, and missionaries are never outnumbered on
+    /// either bank.
+    /// </summary>
+    private static void AssertIsValidCrossing(
+        MissionariesAndCannibals result,
+        int boatSize = BoatSize)
+    {
+        result.Missionaries.Length.ShouldBe(result.Length);
+        result.Cannibals.Length.ShouldBe(result.Length);
+
+        // Everyone starts on the near bank...
+        result.Missionaries[0].ShouldBe(Population);
+        result.Cannibals[0].ShouldBe(Population);
+
+        // ...and nobody is left on it at the end.
+        result.Missionaries[result.Length - 1].ShouldBe(0);
+        result.Cannibals[result.Length - 1].ShouldBe(0);
+
+        for (int step = 0; step < result.Length; step++)
+        {
+            int nearMissionaries = result.Missionaries[step];
+            int nearCannibals = result.Cannibals[step];
+
+            nearMissionaries.ShouldBeInRange(0, Population, $"missionaries at step {step}");
+            nearCannibals.ShouldBeInRange(0, Population, $"cannibals at step {step}");
+
+            // Missionaries are safe on a bank only if there are none of them, or they are not
+            // outnumbered. Both banks have to hold.
+            if (nearMissionaries > 0)
+            {
+                nearMissionaries.ShouldBeGreaterThanOrEqualTo(
+                    nearCannibals, $"near bank at step {step}");
+            }
+
+            int farMissionaries = Population - nearMissionaries;
+            int farCannibals = Population - nearCannibals;
+
+            if (farMissionaries > 0)
+            {
+                farMissionaries.ShouldBeGreaterThanOrEqualTo(
+                    farCannibals, $"far bank at step {step}");
+            }
+
+            // Each crossing moves at least one person and at most a boatful.
+            if (step > 0)
+            {
+                int moved = Math.Abs(
+                    (nearMissionaries + nearCannibals)
+                    - (result.Missionaries[step - 1] + result.Cannibals[step - 1]));
+
+                moved.ShouldBeInRange(1, boatSize, $"people moved into step {step}");
+            }
+        }
+    }
+}

--- a/solutions/Z3.Linq.Tests/MissionariesAndCannibalsTests.cs
+++ b/solutions/Z3.Linq.Tests/MissionariesAndCannibalsTests.cs
@@ -194,14 +194,26 @@ public class MissionariesAndCannibalsTests
                     farCannibals, $"far bank at step {step}");
             }
 
-            // Each crossing moves at least one person and at most a boatful.
+            // Each crossing moves at least one person, at most a boatful, and in the direction
+            // the boat is actually travelling. The sample alternates by step parity - from an
+            // even step the boat leaves the near bank, from an odd step it returns - so checking
+            // only the magnitude would accept a plan that crossed twice the same way without
+            // the boat ever coming back.
             if (step > 0)
             {
-                int moved = Math.Abs(
-                    (nearMissionaries + nearCannibals)
-                    - (result.Missionaries[step - 1] + result.Cannibals[step - 1]));
+                int delta = (nearMissionaries + nearCannibals)
+                    - (result.Missionaries[step - 1] + result.Cannibals[step - 1]);
 
-                moved.ShouldBeInRange(1, boatSize, $"people moved into step {step}");
+                if ((step - 1) % 2 == 0)
+                {
+                    // Boat leaves the near bank, so its population falls.
+                    delta.ShouldBeInRange(-boatSize, -1, $"crossing into step {step}");
+                }
+                else
+                {
+                    // Boat returns, so its population rises.
+                    delta.ShouldBeInRange(1, boatSize, $"return into step {step}");
+                }
             }
         }
     }

--- a/solutions/Z3.Linq.Tests/SudokuTheoremTests.cs
+++ b/solutions/Z3.Linq.Tests/SudokuTheoremTests.cs
@@ -1,0 +1,209 @@
+namespace Z3.Linq.Tests;
+
+using System.Reflection;
+
+using Z3.Linq.Examples.Sudoku;
+
+/// <summary>
+/// Acceptance tests that solve the published Sudoku sample theorems end to end.
+/// </summary>
+/// <remarks>
+/// <para>
+/// These are the only tests that exercise the library at realistic problem size: 81 symbols, 27
+/// <c>Distinct</c> constraints and a global rewriter, all in one theorem. Everything else in the
+/// suite works with a handful of symbols, so this is where a translation regression that only
+/// shows up at scale would surface.
+/// </para>
+/// <para>
+/// Puzzle B is a published, uniquely-solvable puzzle, so its grid is asserted cell by cell.
+/// Puzzle A has only 21 givens and is almost certainly not unique, so it is asserted by
+/// invariant: the givens survive, and every row, column and box is a permutation of 1-9. That
+/// distinction is the determinism rule of this suite applied to its largest case - a fixed grid
+/// for a puzzle with several solutions would pin whichever one this version of Z3 happened to
+/// find.
+/// </para>
+/// </remarks>
+[TestClass]
+public class SudokuTheoremTests
+{
+    [TestMethod]
+    public void Solve_PublishedUniquePuzzle_ReturnsTheKnownSolution()
+    {
+        // Arrange: the puzzle from https://sandiway.arizona.edu/sudoku/examples.html, which has
+        // 36 givens and a single solution - so the whole grid is safe to assert.
+        using var context = new Z3Context();
+
+        // Act
+        var result = SolvePuzzleB(context);
+
+        // Assert
+        result.ShouldNotBeNull();
+        int[,] grid = ToGrid(result);
+
+        int[,] expected =
+        {
+            { 4, 3, 5, 2, 6, 9, 7, 8, 1 },
+            { 6, 8, 2, 5, 7, 1, 4, 9, 3 },
+            { 1, 9, 7, 8, 3, 4, 5, 6, 2 },
+            { 8, 2, 6, 1, 9, 5, 3, 4, 7 },
+            { 3, 7, 4, 6, 8, 2, 9, 1, 5 },
+            { 9, 5, 1, 7, 4, 3, 6, 2, 8 },
+            { 5, 1, 9, 3, 2, 6, 8, 7, 4 },
+            { 2, 4, 8, 9, 5, 7, 1, 3, 6 },
+            { 7, 6, 3, 4, 1, 8, 2, 5, 9 },
+        };
+
+        for (int row = 0; row < 9; row++)
+        {
+            for (int column = 0; column < 9; column++)
+            {
+                grid[row, column].ShouldBe(
+                    expected[row, column],
+                    $"cell R{row + 1}C{column + 1}");
+            }
+        }
+    }
+
+    [TestMethod]
+    public void Solve_PublishedUniquePuzzle_ProducesAValidGrid()
+    {
+        // Arrange: the same solve checked structurally rather than against a fixed answer. If
+        // the expected grid above ever needs revisiting, this still holds the line on what a
+        // Sudoku solution has to be.
+        using var context = new Z3Context();
+
+        // Act
+        var result = SolvePuzzleB(context);
+
+        // Assert
+        result.ShouldNotBeNull();
+        AssertIsValidSudokuGrid(ToGrid(result));
+    }
+
+    [TestMethod]
+    public void Solve_PuzzleWithTwentyOneGivens_ProducesAValidGridPreservingTheGivens()
+    {
+        // Arrange: the demo's first puzzle. Too few givens to assume a unique solution, so this
+        // asserts the two things true of every solution - the givens are untouched, and the grid
+        // is well formed.
+        using var context = new Z3Context();
+
+        // Act
+        var result = (from t in SudokuTheorem.Create(context)
+                      where t.Cell13 == 2 && t.Cell16 == 1 && t.Cell18 == 6
+                      where t.Cell23 == 7 && t.Cell26 == 4
+                      where t.Cell31 == 5 && t.Cell37 == 9
+                      where t.Cell42 == 1 && t.Cell44 == 3
+                      where t.Cell51 == 8 && t.Cell55 == 5 && t.Cell59 == 4
+                      where t.Cell66 == 6 && t.Cell68 == 2
+                      where t.Cell73 == 6 && t.Cell79 == 7
+                      where t.Cell84 == 8 && t.Cell87 == 3
+                      where t.Cell92 == 4 && t.Cell94 == 9 && t.Cell97 == 2
+                      select t).Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+
+        // The givens must survive the solve.
+        result.Cell13.ShouldBe(2);
+        result.Cell16.ShouldBe(1);
+        result.Cell18.ShouldBe(6);
+        result.Cell31.ShouldBe(5);
+        result.Cell37.ShouldBe(9);
+        result.Cell55.ShouldBe(5);
+        result.Cell92.ShouldBe(4);
+        result.Cell97.ShouldBe(2);
+
+        AssertIsValidSudokuGrid(ToGrid(result));
+    }
+
+    [TestMethod]
+    public void Solve_PuzzleWithContradictoryGivens_ReturnsNull()
+    {
+        // Arrange: two givens that collide in the same row. The theorem is well formed, so this
+        // checks that an 81-symbol problem reports unsatisfiable rather than failing some other
+        // way at that size.
+        using var context = new Z3Context();
+
+        // Act
+        var result = (from t in SudokuTheorem.Create(context)
+                      where t.Cell11 == 5
+                      where t.Cell12 == 5
+                      select t).Solve();
+
+        // Assert
+        result.ShouldBeNull();
+    }
+
+    // A puzzle with no givens at all was tried here and deliberately dropped. It solved
+    // correctly but took 25 seconds - fifty times the next slowest test in the suite - because
+    // an unconstrained grid gives Z3 nothing to propagate from. It proved only that the
+    // constraints are satisfiable on their own, which the two puzzles above already establish
+    // while also checking an answer. Tagging it as slow rather than removing it would have left
+    // a test that never actually runs.
+
+    private static SudokuTable? SolvePuzzleB(Z3Context context)
+        => (from t in SudokuTheorem.Create(context)
+            where t.Cell14 == 2 && t.Cell15 == 6 && t.Cell17 == 7 && t.Cell19 == 1
+            where t.Cell21 == 6 && t.Cell22 == 8 && t.Cell25 == 7 && t.Cell28 == 9
+            where t.Cell31 == 1 && t.Cell32 == 9 && t.Cell36 == 4 && t.Cell37 == 5
+            where t.Cell41 == 8 && t.Cell42 == 2 && t.Cell44 == 1 && t.Cell48 == 4
+            where t.Cell53 == 4 && t.Cell54 == 6 && t.Cell56 == 2 && t.Cell57 == 9
+            where t.Cell62 == 5 && t.Cell66 == 3 && t.Cell68 == 2 && t.Cell69 == 8
+            where t.Cell73 == 9 && t.Cell74 == 3 && t.Cell78 == 7 && t.Cell79 == 4
+            where t.Cell82 == 4 && t.Cell85 == 5 && t.Cell88 == 3 && t.Cell89 == 6
+            where t.Cell91 == 7 && t.Cell93 == 3 && t.Cell95 == 1 && t.Cell96 == 8
+            select t).Solve();
+
+    /// <summary>
+    /// Reads the 81 <c>CellRC</c> properties into a grid indexed from zero.
+    /// </summary>
+    private static int[,] ToGrid(SudokuTable table)
+    {
+        var grid = new int[9, 9];
+
+        for (int row = 1; row <= 9; row++)
+        {
+            for (int column = 1; column <= 9; column++)
+            {
+                PropertyInfo cell = typeof(SudokuTable).GetProperty($"Cell{row}{column}")
+                    ?? throw new InvalidOperationException($"SudokuTable has no Cell{row}{column}.");
+
+                grid[row - 1, column - 1] = (int)cell.GetValue(table)!;
+            }
+        }
+
+        return grid;
+    }
+
+    /// <summary>
+    /// Asserts the three Sudoku invariants: every row, column and 3x3 box holds 1-9 exactly once.
+    /// </summary>
+    private static void AssertIsValidSudokuGrid(int[,] grid)
+    {
+        int[] oneToNine = [1, 2, 3, 4, 5, 6, 7, 8, 9];
+
+        for (int row = 0; row < 9; row++)
+        {
+            Enumerable.Range(0, 9).Select(column => grid[row, column]).OrderBy(value => value).ToArray()
+                .ShouldBe(oneToNine, $"row {row + 1}");
+        }
+
+        for (int column = 0; column < 9; column++)
+        {
+            Enumerable.Range(0, 9).Select(row => grid[row, column]).OrderBy(value => value).ToArray()
+                .ShouldBe(oneToNine, $"column {column + 1}");
+        }
+
+        for (int box = 0; box < 9; box++)
+        {
+            int rowOffset = (box / 3) * 3;
+            int columnOffset = (box % 3) * 3;
+
+            Enumerable.Range(0, 9)
+                .Select(offset => grid[rowOffset + (offset / 3), columnOffset + (offset % 3)])
+                .OrderBy(value => value).ToArray()
+                .ShouldBe(oneToNine, $"box {box + 1}");
+        }
+    }
+}

--- a/solutions/Z3.Linq.Tests/SudokuTheoremTests.cs
+++ b/solutions/Z3.Linq.Tests/SudokuTheoremTests.cs
@@ -104,14 +104,29 @@ public class SudokuTheoremTests
         // Assert
         result.ShouldNotBeNull();
 
-        // The givens must survive the solve.
+        // Every given must survive the solve - all 21, not a sample of them. Checking a subset
+        // would let a regression that dropped or mistranslated some of the constraints through,
+        // which is precisely the failure mode worth catching at this size.
         result.Cell13.ShouldBe(2);
         result.Cell16.ShouldBe(1);
         result.Cell18.ShouldBe(6);
+        result.Cell23.ShouldBe(7);
+        result.Cell26.ShouldBe(4);
         result.Cell31.ShouldBe(5);
         result.Cell37.ShouldBe(9);
+        result.Cell42.ShouldBe(1);
+        result.Cell44.ShouldBe(3);
+        result.Cell51.ShouldBe(8);
         result.Cell55.ShouldBe(5);
+        result.Cell59.ShouldBe(4);
+        result.Cell66.ShouldBe(6);
+        result.Cell68.ShouldBe(2);
+        result.Cell73.ShouldBe(6);
+        result.Cell79.ShouldBe(7);
+        result.Cell84.ShouldBe(8);
+        result.Cell87.ShouldBe(3);
         result.Cell92.ShouldBe(4);
+        result.Cell94.ShouldBe(9);
         result.Cell97.ShouldBe(2);
 
         AssertIsValidSudokuGrid(ToGrid(result));

--- a/solutions/Z3.Linq.Tests/Z3.Linq.Tests.csproj
+++ b/solutions/Z3.Linq.Tests/Z3.Linq.Tests.csproj
@@ -16,6 +16,9 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Z3.Linq\Z3.Linq.csproj" />
+    <!-- The acceptance tests solve the sample theorems as published. Examples adds no packages
+         of its own; it references only Z3.Linq. -->
+    <ProjectReference Include="..\Z3.Linq.Examples\Z3.Linq.Examples.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Phase E of the test plan, and the last of it. **120 → 133 tests.**

These are the only tests that exercise the library at realistic size — 81 symbols, 27 `Distinct`
constraints and a global rewriter in a single theorem — so they are where a translation
regression that only appears at scale would surface.

## What it asserts, and why differently per puzzle

**Sudoku B** is published and uniquely solvable, so its grid is asserted cell by cell.
**Sudoku A** has 21 givens and almost certainly several solutions, so it is asserted by
invariant: the givens survive, and every row, column and box is a permutation of 1–9. That is
this suite's determinism rule applied to its largest case — a fixed grid for a puzzle with
several solutions would pin whichever one this build of Z3 happened to find.

**Missionaries and Cannibals** is checked against the rules of the puzzle at every step, not
just its length: everyone starts on the near bank, nobody is left at the end, each crossing
moves between one and a boatful, and missionaries are never outnumbered on *either* bank. An
optimiser that reached the optimum by violating the safety rule would still fail.

## Two of the plan's numbers were wrong

Measured rather than assumed, per your direction:

| | plan said | measured |
|---|---|---|
| optimal crossing | `Length == 11` | **12** |
| smallest feasible `maxLength` | 12 | **13** |

The goal requires `Length < maxLength`, so a bound equal to the optimum is one short. Both
sides of that boundary are now pinned — 11 and 12 unsatisfiable, 13/15/50 all yielding 12 — so
the off-by-one is documented rather than rediscovered.

## Timings: nothing is tagged `Slow`

Measured from the TRX report before classifying, against the stated rule of >500ms:

| Test | ms |
|---|---:|
| `Solve_PuzzleWithTwentyOneGivens_…` | 443 |
| `Optimize_…SearchBounds` (bound 50) | 256 |
| `Solve_ClassicPuzzle_ProducesAValidCrossing` | 230 |
| `Solve_PublishedUniquePuzzle_ProducesAValidGrid` | 218 |

**Zero tests exceed 500ms**, and the whole 133-test suite runs in **946ms**. So the
`[TestCategory("Slow")]` tag and the `$AdditionalTestArgs` filter are both skipped, exactly as
the plan directed if nothing crossed the threshold.

### One test was dropped rather than tagged

A Sudoku with **no givens** solved correctly but took **25.2 seconds** — fifty times the next
slowest test — because an unconstrained grid gives Z3 nothing to propagate from. It proved only
that the constraints are satisfiable on their own, which the two real puzzles already establish
while also checking an answer. Tagging it slow would have left a test that never actually runs,
so it is removed with a comment recording why.

## Coverage

**75.8% line, 69.3% branch.** The line figure sits a shade below Phase D's 76.2% only because
`Z3.Linq.Examples` now falls inside the coverage filter — covered lines went from 555 to 627
against a denominator that grew by 99.

## Mutation-checked

| Mutation | Tests failed |
|---|---|
| `Distinct` degenerates to `true` | 11 |
| every collection element read from index 0 | 6 |

## Verification

- `dotnet build solutions/Z3.Linq.slnx -c Release` — 0 warnings, 0 errors
- 133/133 tests pass in 946ms
- `./build.ps1 -Configuration Release` — 46 tasks, 0 errors, 0 warnings

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>