### PR TITLE
Populate symbols the solver leaves uninterpreted

### DIFF
--- a/solutions/Z3.Linq.Tests/CollectionSymbolTests.cs
+++ b/solutions/Z3.Linq.Tests/CollectionSymbolTests.cs
@@ -218,6 +218,63 @@ public class CollectionSymbolTests
         Should.Throw<InvalidCastException>(() => theorem.Solve());
     }
 
+    /// <summary>
+    /// An array symbol that no constraint touches is still materialised, at its initialised
+    /// length.
+    /// </summary>
+    /// <remarks>
+    /// The collection form of #51, and the only test covering the element-select evaluation.
+    /// With no element constrained, the array constant itself has no interpretation, so every
+    /// <c>MkSelect</c> against it evaluated to the select term rather than to a numeral. The
+    /// element values come from model completion and are not asserted; the length is, because
+    /// it comes from the instance rather than from the model.
+    /// </remarks>
+    [TestMethod]
+    public void Solve_IntArraySymbolWithNoElementConstraints_ReturnsTheInitialisedLength()
+    {
+        // Arrange
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<IntArrayEnvironment>()
+            .Where(t => t.Length == 3)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.Values.Length.ShouldBe(3);
+        result.Length.ShouldBe(3);
+    }
+
+    /// <summary>
+    /// Constraining one element of an array leaves the rest resolvable.
+    /// </summary>
+    /// <remarks>
+    /// This one passed before #51 as well, and is here for the semantics it records rather than
+    /// as proof of the fix. Once any element is constrained the array constant has an
+    /// interpretation, and a free element resolves through that array's else-value rather than
+    /// being assigned independently - measured as <c>[10, 10, 10]</c> here. So free elements are
+    /// not independently arbitrary, which is why the blast radius of #51 on arrays was smaller
+    /// than it looks. Only the constrained element is asserted; the else-value is Z3's choice.
+    /// </remarks>
+    [TestMethod]
+    public void Solve_IntArrayWithSomeElementsConstrained_KeepsTheConstrainedElements()
+    {
+        // Arrange
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<IntArrayEnvironment>()
+            .Where(t => t.Values[0] == 10)
+            .Where(t => t.Length == 3)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.Values.Length.ShouldBe(3);
+        result.Values[0].ShouldBe(10);
+    }
+
     private sealed class IntArrayEnvironment
     {
         public int[] Values { get; set; } = new int[3];

--- a/solutions/Z3.Linq.Tests/EnvironmentTypeTests.cs
+++ b/solutions/Z3.Linq.Tests/EnvironmentTypeTests.cs
@@ -263,6 +263,58 @@ public class EnvironmentTypeTests
         result.B.ShouldBe(4);
     }
 
+    /// <summary>
+    /// An anonymous environment with an unconstrained property is still populated.
+    /// </summary>
+    /// <remarks>
+    /// The anonymous path writes to compiler-generated backing fields and evaluates the model
+    /// through its own call, separate from the one every other environment shape uses. So it
+    /// failed independently under #51 and it can regress independently: this is the only test
+    /// covering that call. Only <c>flag</c> is asserted - <c>n</c> is free and takes whatever
+    /// completion supplies.
+    /// </remarks>
+    [TestMethod]
+    public void Solve_AnonymousTypeWithAnUnconstrainedProperty_PopulatesTheConstrainedOne()
+    {
+        // Arrange
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem(new { flag = default(bool), n = default(int) })
+            .Where(t => t.flag)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.flag.ShouldBeTrue();
+    }
+
+    /// <summary>
+    /// A nested environment whose inner properties are unconstrained is still constructed.
+    /// </summary>
+    /// <remarks>
+    /// The nested environment is built from the type, not from the constraints, so every inner
+    /// symbol exists whether or not anything mentions it - and each is marshalled by the same
+    /// recursion that handles a top-level one. Before #51 a single free leaf anywhere in the
+    /// tree failed the whole solve.
+    /// </remarks>
+    [TestMethod]
+    public void Solve_NestedObjectEnvironmentWithUnconstrainedInnerProperties_PopulatesTheOuterOne()
+    {
+        // Arrange
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<OuterEnvironment>()
+            .Where(t => t.Top == 6)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.Inner.ShouldNotBeNull();
+        result.Top.ShouldBe(6);
+    }
+
     private sealed record BodyRecord
     {
         public bool X { get; set; }

--- a/solutions/Z3.Linq.Tests/OptimizationTests.cs
+++ b/solutions/Z3.Linq.Tests/OptimizationTests.cs
@@ -123,7 +123,7 @@ public class OptimizationTests
     [TestMethod]
     public void OrderBy_BeforeSolveIsCalled_DoesNotSolveAnything()
     {
-        // Arrange: OrderBy returns a deferred solvable (Theorem{T}.cs:70), so building the query
+        // Arrange: OrderBy returns a deferred solvable (Theorem{T}.cs:78), so building the query
         // must not touch Z3. The log is the observable proof - Theorem.cs:178 writes a line per
         // asserted constraint, so an eager implementation would have written to it already.
         using var log = new StringWriter();
@@ -340,5 +340,50 @@ public class OptimizationTests
         // Assert
         parentMinimum.X1.ShouldBe(1);
         childMinimum.X1.ShouldBe(6);
+    }
+
+    /// <summary>
+    /// An unconstrained symbol does not stop an optimisation returning its optimum.
+    /// </summary>
+    /// <remarks>
+    /// <c>Optimize</c> reads its answer from the optimiser's model rather than a solver's, so it
+    /// needs its own coverage of #51 - every test in this file constrained X2 purely to avoid
+    /// the defect. The minimum over a closed range is unique, so asserting it exactly is safe;
+    /// X2 is free and is not asserted.
+    /// </remarks>
+    [TestMethod]
+    public void Optimize_WithAnUnconstrainedSymbol_ReturnsTheOptimum()
+    {
+        // Arrange
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<Symbols<int, int>>()
+            .Where(t => t.X1 >= 5)
+            .Where(t => t.X1 <= 9)
+            .Optimize(Optimization.Minimize, t => t.X1);
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.X1.ShouldBe(5);
+    }
+
+    [TestMethod]
+    public void OrderBy_WithAnUnconstrainedSymbol_ReturnsTheOptimum()
+    {
+        // Arrange: the query-syntax route to the same code path, kept for the symmetry this
+        // file maintains between Optimize and OrderBy.
+        using var context = new Z3Context();
+
+        // Act
+        var result = (from t in context.NewTheorem<Symbols<int, int>>()
+                      where t.X1 >= 5
+                      where t.X1 <= 9
+                      orderby t.X1
+                      select t).Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.X1.ShouldBe(5);
     }
 }

--- a/solutions/Z3.Linq.Tests/SymbolTypeMarshallingTests.cs
+++ b/solutions/Z3.Linq.Tests/SymbolTypeMarshallingTests.cs
@@ -358,4 +358,122 @@ public class SymbolTypeMarshallingTests
         // Assert
         value.ShouldBe(1.5);
     }
+
+    /// <summary>
+    /// An unconstrained <c>long</c> symbol is populated rather than throwing.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The tests above pin what each type does with a value; these five pin what each does with
+    /// no value at all. Every type takes a different arm of the marshalling switch, so each can
+    /// regress on its own, and all but <c>bool</c> threw before #51. The value a free symbol
+    /// comes back with is supplied by model completion and is deliberately not asserted.
+    /// </para>
+    /// <para>
+    /// <c>short</c> and <c>float</c> are absent on purpose: an unconstrained one now evaluates
+    /// cleanly and then fails at the reflection write, which is #63 and #54 respectively rather
+    /// than anything to do with completion. Their pins above are unchanged.
+    /// </para>
+    /// </remarks>
+    [TestMethod]
+    public void Solve_UnconstrainedLongSymbol_ReturnsAResult()
+    {
+        // Arrange
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<Symbols<long, int>>()
+            .Where(t => t.X2 == 0)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.X2.ShouldBe(0);
+    }
+
+    [TestMethod]
+    public void Solve_UnconstrainedDoubleSymbol_ReturnsAResult()
+    {
+        // Arrange: the real-sorted counterpart. An uninterpreted real came back as a RealExpr
+        // rather than a RatNum, so this arm failed on a different cast to the integer ones.
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<Symbols<double, int>>()
+            .Where(t => t.X2 == 0)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.X2.ShouldBe(0);
+    }
+
+    [TestMethod]
+    public void Solve_UnconstrainedDecimalSymbol_ReturnsAResult()
+    {
+        // Arrange: decimal shares the real sort with double but has its own read-back, with
+        // trailing-'?' trimming and a decimal.Parse, so it is worth its own case.
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<Symbols<decimal, int>>()
+            .Where(t => t.X2 == 0)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.X2.ShouldBe(0);
+    }
+
+    /// <summary>
+    /// An unconstrained <c>string</c> symbol is populated rather than throwing.
+    /// </summary>
+    /// <remarks>
+    /// The one member of this group that did not fail with an <see cref="InvalidCastException"/>.
+    /// Strings are read with <c>Expr.String</c> rather than a cast, so an uninterpreted symbol
+    /// produced <c>Z3Exception: expression is not a string literal</c> instead. Same cause, and
+    /// fixed by the same change.
+    /// </remarks>
+    [TestMethod]
+    public void Solve_UnconstrainedStringSymbol_ReturnsAResult()
+    {
+        // Arrange
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<Symbols<string, int>>()
+            .Where(t => t.X2 == 0)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.X1.ShouldNotBeNull();
+        result.X2.ShouldBe(0);
+    }
+
+    /// <summary>
+    /// An unconstrained <c>bool</c> symbol is populated - as it always was.
+    /// </summary>
+    /// <remarks>
+    /// The quiet half of #51, and the reason it went unnoticed for so long. Booleans are read
+    /// with <c>Expr.IsTrue</c>, which is simply <c>false</c> for any term that is not literally
+    /// true - including an uninterpreted symbol. So a free bool never threw; it silently
+    /// returned <c>false</c> whether or not the model said anything about it. This test passes
+    /// on both sides of the fix and is here to hold that branch still, not to prove the fix.
+    /// </remarks>
+    [TestMethod]
+    public void Solve_UnconstrainedBoolSymbol_ReturnsAResult()
+    {
+        // Arrange
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<Symbols<bool, int>>()
+            .Where(t => t.X2 == 0)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.X2.ShouldBe(0);
+    }
 }

--- a/solutions/Z3.Linq.Tests/TheoremCompositionTests.cs
+++ b/solutions/Z3.Linq.Tests/TheoremCompositionTests.cs
@@ -8,7 +8,7 @@ namespace Z3.Linq.Tests;
 /// <remarks>
 /// Most of these assert without solving at all, which makes them the cheapest tests in the
 /// suite. <c>Where</c> returns a new <see cref="Theorem{T}"/> over a concatenated constraint
-/// sequence (Theorem{T}.cs:60), so composition is immutable and a theorem can be reused.
+/// sequence (Theorem{T}.cs:69), so composition is immutable and a theorem can be reused.
 /// </remarks>
 [TestClass]
 public class TheoremCompositionTests

--- a/solutions/Z3.Linq.Tests/TheoremSolveTests.cs
+++ b/solutions/Z3.Linq.Tests/TheoremSolveTests.cs
@@ -18,6 +18,12 @@ namespace Z3.Linq.Tests;
 /// that was merely slow would pass an "is unsatisfiable" assertion. Keeping these obviously
 /// contradictory removes that risk.
 /// </para>
+/// <para>
+/// A symbol the returned model does not interpret takes an arbitrary value supplied by Z3's
+/// model completion (#51). That value is not part of any contract, so the tests here assert
+/// that the solve completed and that the constrained symbols survived - never what the free
+/// one came back as.
+/// </para>
 /// </remarks>
 [TestClass]
 public class TheoremSolveTests
@@ -72,53 +78,85 @@ public class TheoremSolveTests
     }
 
     /// <summary>
-    /// KNOWN DEFECT: a symbol that no constraint mentions makes <c>Solve</c> throw.
+    /// A symbol that no constraint mentions does not stop the theorem being solved.
     /// </summary>
     /// <remarks>
-    /// Currently: <see cref="InvalidCastException"/>. Z3 only assigns model values to constants
-    /// that appear in the asserted formulas, and <c>model.Eval(expr)</c> defaults to
-    /// <c>completion: false</c>, so an unreferenced symbol evaluates to itself - an
-    /// <c>IntExpr</c> rather than an <c>IntNum</c> - and the cast at Theorem.cs:516 fails.
-    /// Should be: the theorem is satisfiable, so it should return a result with an arbitrary
-    /// value for the free symbol. The fix is <c>model.Eval(expr, completion: true)</c> at all
-    /// four call sites (Theorem.cs:445, 471, 507, 634).
-    /// This test pins current behaviour and must be updated when the defect is fixed.
+    /// The theorem is satisfiable, so X2 takes whatever value Z3's model completion supplies.
+    /// That value is not part of any contract and is deliberately not asserted; what matters is
+    /// that the solve completes and the constrained symbol is untouched. Fixed by #51 - this
+    /// previously threw <see cref="InvalidCastException"/>, because a symbol the model does not
+    /// interpret evaluates to itself rather than to a numeral.
     /// </remarks>
     [TestMethod]
-    public void Solve_TheoremWithUnconstrainedSymbol_ThrowsInvalidCastException()
+    public void Solve_TheoremWithAnUnconstrainedSymbol_ReturnsAResultAndKeepsTheConstrainedValue()
     {
-        // Arrange: X2 is never mentioned, so the model has no assignment for it.
+        // Arrange: X2 is never mentioned, so the solver has no reason to assign it. This is the
+        // repro from #51 verbatim.
         using var context = new Z3Context();
         var theorem = context.NewTheorem<Symbols<int, int>>().Where(t => t.X1 == 1);
 
-        // Act & Assert
-        Should.Throw<InvalidCastException>(() => theorem.Solve());
+        // Act
+        var result = theorem.Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.X1.ShouldBe(1);
     }
 
     /// <summary>
-    /// KNOWN DEFECT: the same failure with no constraints at all.
+    /// A theorem with no constraints at all is trivially satisfiable and returns a result.
     /// </summary>
     /// <remarks>
-    /// An unconstrained theorem is trivially satisfiable and should return a result with
-    /// arbitrary values. See <see cref="Solve_TheoremWithUnconstrainedSymbol_ThrowsInvalidCastException"/>
-    /// for the mechanism. Pins current behaviour.
+    /// The degenerate case of the test above: every symbol is free, so there is nothing to
+    /// assert beyond the solve completing. This is the only test that checks a solver is asked
+    /// to solve without a single assertion.
     /// </remarks>
     [TestMethod]
-    public void Solve_TheoremWithNoConstraints_ThrowsInvalidCastException()
+    public void Solve_TheoremWithNoConstraints_ReturnsAResult()
     {
         // Arrange
         using var context = new Z3Context();
         var theorem = context.NewTheorem<Symbols<int, int>>();
 
-        // Act & Assert
-        Should.Throw<InvalidCastException>(() => theorem.Solve());
+        // Act
+        var result = theorem.Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+    }
+
+    /// <summary>
+    /// A symbol mentioned only by a constraint the solver discards is still populated.
+    /// </summary>
+    /// <remarks>
+    /// "Mentioned by a constraint" is not the condition that matters - "interpreted by the
+    /// returned model" is. A tautology is reduced to true as it is asserted, so X1 is never
+    /// created and has no interpretation, despite the query naming it twice. Before #51 this
+    /// threw for exactly the same reason an unmentioned symbol did, which is why the fix is
+    /// model completion rather than an inspection of the constraints.
+    /// </remarks>
+    [TestMethod]
+    public void Solve_SymbolMentionedOnlyInATautology_ReturnsAResult()
+    {
+        // Arrange
+        using var context = new Z3Context();
+
+        // Act
+        var result = (from t in context.NewTheorem<Symbols<int, int>>()
+                      where t.X1 > 0 || t.X1 <= 0
+                      where t.X2 == 0
+                      select t).Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.X2.ShouldBe(0);
     }
 
     [TestMethod]
     public void Solve_EverySymbolConstrained_ReturnsResult()
     {
-        // Arrange: the working counterpart to the two pins above - once every symbol is
-        // referenced by a constraint, the model assigns all of them and materialisation works.
+        // Arrange: the control for #51. Constraining every symbol was the workaround for that
+        // defect, and it must keep behaving identically now that it is no longer necessary.
         using var context = new Z3Context();
 
         // Act

--- a/solutions/Z3.Linq/Theorem.cs
+++ b/solutions/Z3.Linq/Theorem.cs
@@ -442,7 +442,7 @@ public class Theorem
 
                 for (int i = 0; i < existingLength; i++)
                 {
-                    var numValExpr = model.Eval(context.MkSelect(arrVal, context.MkInt(i)));
+                    var numValExpr = EvaluateWithCompletion(model, context.MkSelect(arrVal, context.MkInt(i)));
 
                     object numVal;
 
@@ -468,9 +468,9 @@ public class Theorem
                             numVal = double.Parse(((RatNum)numValExpr).ToDecimalString(32), CultureInfo.InvariantCulture);
                             break;
                         case TypeCode.Decimal:
-                            Expr val = model.Eval((subEnv.Expr ?? throw new ArgumentException(
+                            Expr val = EvaluateWithCompletion(model, subEnv.Expr ?? throw new ArgumentException(
                     $"nameof(ConvertZ3Expression) requires {nameof(subEnv)}.{nameof(subEnv.Expr)} to be non-null",
-                    nameof(subEnv))));
+                    nameof(subEnv)));
                             string numValue = ((RatNum)val).ToDecimalString(128);
 
                             ReadOnlySpan<char> numValueSpan = numValue.AsSpan();
@@ -504,7 +504,7 @@ public class Theorem
                 $"nameof(ConvertZ3Expression) requires {nameof(subEnv)}.{nameof(subEnv.Expr)} to be non-null",
                 nameof(subEnv));
 
-            Expr val = model.Eval(subEnvExpr);
+            Expr val = EvaluateWithCompletion(model, subEnvExpr);
 
             switch (typeCode)
             {
@@ -631,7 +631,7 @@ public class Theorem
                 // Evaluation of the values though the handle in the environment bindings.
                 var subEnv = environment.Properties[parameter];
 
-                Expr val = model.Eval(subEnv.Expr);
+                Expr val = EvaluateWithCompletion(model, subEnv.Expr);
                 if (parameter.PropertyType == typeof(bool))
                 {
                     field.SetValue(result, val.IsTrue);
@@ -697,4 +697,30 @@ public class Theorem
             return result;
         }
     }
+
+    /// <summary>
+    /// Evaluates an expression under a model, supplying a value for any term the model has no
+    /// interpretation for.
+    /// </summary>
+    /// <param name="model">Z3 model to evaluate under.</param>
+    /// <param name="expr">Term to evaluate.</param>
+    /// <returns>The model value of <paramref name="expr"/>.</returns>
+    /// <remarks>
+    /// <para>
+    /// A Z3 model is partial: it assigns values only to the constants the solver actually
+    /// needed. Evaluating one it does not interpret hands back the term itself - an
+    /// <c>IntExpr</c> rather than an <c>IntNum</c> - and the casts in the marshalling switches
+    /// above then fail. The condition is not "no constraint mentions it" but "the model does
+    /// not interpret it": a constraint the solver simplifies away, such as x == x, leaves its
+    /// symbol uninterpreted just the same.
+    /// </para>
+    /// <para>
+    /// Such a theorem is still satisfiable and its free symbols may take any value, so
+    /// completion is enabled and Z3 supplies one. Completion only fills gaps - it never
+    /// overrides a value the solver chose - so symbols the model does interpret are
+    /// unaffected. See https://github.com/endjin/Z3.Linq/issues/51.
+    /// </para>
+    /// </remarks>
+    private static Expr EvaluateWithCompletion(Model model, Expr? expr)
+        => model.Eval(expr, completion: true);
 }

--- a/solutions/Z3.Linq/Theorem.cs
+++ b/solutions/Z3.Linq/Theorem.cs
@@ -703,7 +703,7 @@ public class Theorem
     /// interpretation for.
     /// </summary>
     /// <param name="model">Z3 model to evaluate under.</param>
-    /// <param name="expr">Term to evaluate.</param>
+    /// <param name="expr">Term to evaluate. Nullable by necessity - see the remarks.</param>
     /// <returns>The model value of <paramref name="expr"/>.</returns>
     /// <remarks>
     /// <para>
@@ -719,6 +719,17 @@ public class Theorem
     /// completion is enabled and Z3 supplies one. Completion only fills gaps - it never
     /// overrides a value the solver chose - so symbols the model does interpret are
     /// unaffected. See https://github.com/endjin/Z3.Linq/issues/51.
+    /// </para>
+    /// <para>
+    /// <paramref name="expr"/> is nullable because <c>Environment.Expr</c> is, and the
+    /// anonymous-type branch of <c>GetSolution</c> passes it without the guard the three sites
+    /// in <c>ConvertZ3Expression</c> use. A null reaches Microsoft.Z3 and surfaces as a
+    /// <c>NullReferenceException</c> - reachable today with an anonymous environment holding a
+    /// nested object, and tracked by https://github.com/endjin/Z3.Linq/issues/75. Declaring the
+    /// parameter nullable states that honestly; a non-nullable one would need a suppression or
+    /// a new guard here, and either would change behaviour that this change deliberately leaves
+    /// alone. Issue 75 proposes the better fix - checking the property type before evaluating,
+    /// so the existing <c>NotSupportedException</c> fires and names the property.
     /// </para>
     /// </remarks>
     private static Expr EvaluateWithCompletion(Model model, Expr? expr)

--- a/solutions/Z3.Linq/Theorem{T}.cs
+++ b/solutions/Z3.Linq/Theorem{T}.cs
@@ -34,6 +34,11 @@ public class Theorem<T> : Theorem, ISolveable<T>
     /// Solves the theorem.
     /// </summary>
     /// <returns>Environment type instance with properties set to theorem-satisfying values.</returns>
+    /// <remarks>
+    /// A symbol that no constraint mentions is free: the theorem is still satisfiable, and Z3
+    /// assigns the symbol an arbitrary value. Only the symbols the constraints pin down are
+    /// determined by the query.
+    /// </remarks>
     public T? Solve()
     {
         return base.Solve<T>();
@@ -45,6 +50,10 @@ public class Theorem<T> : Theorem, ISolveable<T>
     /// <param name="direction">The optimization goal, i.e. whether to minimize or maximize the solution.</param>
     /// <param name="lambda">Expression representing the value to minimize or maximize.</param>
     /// <returns>Environment type instance with properties set to theorem-satisfying values.</returns>
+    /// <remarks>
+    /// As with <see cref="Solve"/>, a symbol that no constraint mentions is free and takes an
+    /// arbitrary value; the objective determines only what it is written in terms of.
+    /// </remarks>
     public T Optimize<TResult>(Optimization direction, Expression<Func<T, TResult>> lambda)
     {
         return base.Optimize<T, TResult>(direction, lambda);


### PR DESCRIPTION
Fixes #51.

## The defect

`Solve()` threw whenever the environment declared a symbol the model did not interpret:

```csharp
using var ctx = new Z3Context();
ctx.NewTheorem<Symbols<int, int>>().Where(t => t.X1 == 1).Solve();
// System.InvalidCastException: Unable to cast object of type 'Microsoft.Z3.IntExpr'
// to type 'Microsoft.Z3.IntNum'   at Theorem.cs:516
```

A Z3 model is partial: it assigns values only to the constants the solver actually needed.
`Model.Eval(Expr t, bool completion = false)` therefore hands back an uninterpreted constant as
*itself*, and the cast fails.

**The condition is not "no constraint mentions it".** A constraint the solver discards as it is
asserted leaves its symbol uninterpreted just the same - measured:

| Query | Before | After |
|---|---|---|
| `where t.X1 > 0` | `{X1 = 1, X2 = 0}` | unchanged |
| `where t.X1 == t.X1` | `InvalidCastException` | `{X1 = 0, X2 = 0}` |
| `where t.X1 > 0 \|\| t.X1 <= 0` | `InvalidCastException` | `{X1 = 0, X2 = 0}` |

That is why the fix is model completion rather than an inspection of the constraint list.

## The change

Four lines, plus one helper. All four evaluation sites now route through
`EvaluateWithCompletion`, so the invariant is stated and enforced in one place rather than
repeated four times - which is how the omission came to exist at all.

The helper is **appended at the end of the class** so that no existing line moves: the test
suite cites `Theorem.cs:NNN` in 23 places and every one of them stays accurate.

## Measured, per type

`Symbols<T, int>` with only `X2` constrained:

| | Before | After |
|---|---|---|
| `int` / `long` / `DateTime` | `InvalidCastException` (`IntExpr`→`IntNum`) | populated |
| `double` / `decimal` | `InvalidCastException` (`RealExpr`→`RatNum`) | populated |
| `string` | **`Z3Exception`: expression is not a string literal** | populated (`""`) |
| `bool` | **passed - silently `false`** | populated |
| `short` / `float` | `InvalidCastException` | `ArgumentException` - #63 / #54, uncovered not caused |

Two things worth calling out. `string` failed differently from everything else, because it is
read with `Expr.String` rather than a cast. And `bool` never failed at all - `Expr.IsTrue` is
`false` for any term that is not literally true, so a free bool silently returned `false`
whether or not the model said anything about it. That is the quiet half of this defect and the
reason it survived so long.

`short` and `float` still fail, at the reflection write rather than at evaluation. Those are
#63 and #54, which this fix uncovers rather than causes. Their pins are unchanged.

## Tests

133 → 145. Two pins rewritten from "throws" to the fixed behaviour; twelve added, one per
distinct code path. No test asserts a free symbol's value - it is arbitrary by definition, and
Dependabot bumps Microsoft.Z3 daily here.

## Mutation results

Reverting the flag fails exactly the 12 intended tests and nothing else. Per site, inlining a
plain `Eval` at one site at a time:

| Site | Path | Tests that fail |
|---|---|---|
| 445 | array element | 1 |
| 507 | scalar, nested, `Optimize`, `OrderBy` | 10 |
| 634 | anonymous type | 1 |
| 471 | decimal array | **0** |

1 + 10 + 1 = 12, a clean partition: every test is bound to exactly one site.

**Site 471 has no coverage, and cannot have any.** A `decimal[]` fails during translation
(#64), so the line is unreachable - `CollectionSymbolTests` pins exactly that. It is changed
for consistency, not because anything can observe it. Reverting it alone fails no test, which
is expected rather than an oversight.

Two of the twelve new tests are deliberately **not** mutation-sensitive and say so in their
doc comments: the free `bool` case (which always worked) and the partially-constrained array
(free elements resolve through the array's else-value, so they were never independently
arbitrary). They are there for the semantics they record.

**Nothing was masked.** All 131 pre-existing tests pass identically with completion on and
off, which is the evidence that completion only fills gaps and never overrides a value the
solver chose.

## Deliberately out of scope

#52-#58, #63, #64 all stay documented-not-fixed with their pins green. Site 471 keeps its
existing wrong argument - it evaluates the whole array rather than the selected element, which
is #55.

One new issue raised: #75. Routing the sites through a helper turned an unguarded null at site
634 into a CS8604 build error. The helper takes `Expr?` so this PR changes no behaviour there;
#75 tracks the underlying inconsistency and the reachable `NullReferenceException` it causes.

## Trade-off worth stating

Today a constraint that silently fails to apply - a rewriter that drops one, a `Where` that
never got composed - surfaces loudly as an exception. After this it surfaces as `0`, `false` or
`""`. That is inherent to the requested semantics, so `Solve` and `Optimize` now document that
a free symbol's value is arbitrary and must not be read as a solved one.

It also makes #57 easier to hit: a satisfiable theorem over a value-type environment with free
symbols now returns all-zeros, which is exactly what an unsatisfiable one returns. That argues
for #57 being the next one fixed.

## Verification

- `dotnet build solutions/Z3.Linq.slnx -c Release` - clean, `TreatWarningsAsErrors` on
- 145/145 in ~1.5s
- `./build.ps1 -Configuration Release` - 46 tasks, 0 errors, 0 warnings
- Coverage unchanged at 75.8% line / 69.3% branch. The new tests exercise arms that were
  already covered by line count, so this change buys behaviour, not coverage.

Releases remain on hold under #60, so this ships to `main` but not to consumers.