### PR TITLE
Drop the constraints that only existed to dodge #51

### DIFF
--- a/solutions/Z3.Linq.Tests/DistinctSelectorTheoremTests.cs
+++ b/solutions/Z3.Linq.Tests/DistinctSelectorTheoremTests.cs
@@ -118,7 +118,6 @@ public class DistinctSelectorTheoremTests
         var result = (from t in context.NewTheorem<Symbols<int, int>>()
                       where Z3Methods.Distinct(multipliers.Select(m => t.X1 * m).ToArray())
                       where t.X1 > 0
-                      where t.X2 == 0
                       select t).Solve();
 
         // Assert

--- a/solutions/Z3.Linq.Tests/EnvironmentTypeTests.cs
+++ b/solutions/Z3.Linq.Tests/EnvironmentTypeTests.cs
@@ -234,7 +234,6 @@ public class EnvironmentTypeTests
         var result = context.NewTheorem<OuterEnvironment>()
             .Where(t => t.Inner.A == t.Top * 2)
             .Where(t => t.Top == 5)
-            .Where(t => t.Inner.B == 0)
             .Solve();
 
         // Assert

--- a/solutions/Z3.Linq.Tests/OptimizationTests.cs
+++ b/solutions/Z3.Linq.Tests/OptimizationTests.cs
@@ -31,7 +31,6 @@ public class OptimizationTests
         var result = context.NewTheorem<Symbols<int, int>>()
             .Where(t => t.X1 >= 5)
             .Where(t => t.X1 <= 9)
-            .Where(t => t.X2 == 0)
             .Optimize(Optimization.Minimize, t => t.X1);
 
         // Assert
@@ -49,7 +48,6 @@ public class OptimizationTests
         var result = context.NewTheorem<Symbols<int, int>>()
             .Where(t => t.X1 >= 5)
             .Where(t => t.X1 <= 9)
-            .Where(t => t.X2 == 0)
             .Optimize(Optimization.Maximize, t => t.X1);
 
         // Assert
@@ -66,8 +64,7 @@ public class OptimizationTests
         using var context = new Z3Context();
         var theorem = context.NewTheorem<Symbols<int, int>>()
             .Where(t => t.X1 >= 5)
-            .Where(t => t.X1 <= 9)
-            .Where(t => t.X2 == 0);
+            .Where(t => t.X1 <= 9);
 
         // Act
         var minimum = theorem.Optimize(Optimization.Minimize, t => t.X1);
@@ -87,8 +84,7 @@ public class OptimizationTests
         using var context = new Z3Context();
         var theorem = context.NewTheorem<Symbols<int, int>>()
             .Where(t => t.X1 >= 3)
-            .Where(t => t.X1 <= 8)
-            .Where(t => t.X2 == 0);
+            .Where(t => t.X1 <= 8);
 
         // Act
         var viaOptimize = theorem.Optimize(Optimization.Minimize, t => t.X1);
@@ -107,8 +103,7 @@ public class OptimizationTests
         using var context = new Z3Context();
         var theorem = context.NewTheorem<Symbols<int, int>>()
             .Where(t => t.X1 >= 3)
-            .Where(t => t.X1 <= 8)
-            .Where(t => t.X2 == 0);
+            .Where(t => t.X1 <= 8);
 
         // Act
         var viaOptimize = theorem.Optimize(Optimization.Maximize, t => t.X1);
@@ -129,8 +124,7 @@ public class OptimizationTests
         using var log = new StringWriter();
         using var context = new Z3Context { Log = log };
         var theorem = context.NewTheorem<Symbols<int, int>>()
-            .Where(t => t.X1 >= 3)
-            .Where(t => t.X2 == 0);
+            .Where(t => t.X1 >= 3);
 
         // Act
         var deferred = theorem.OrderBy(t => t.X1);
@@ -150,8 +144,7 @@ public class OptimizationTests
         using var log = new StringWriter();
         using var context = new Z3Context { Log = log };
         var theorem = context.NewTheorem<Symbols<int, int>>()
-            .Where(t => t.X1 >= 3)
-            .Where(t => t.X2 == 0);
+            .Where(t => t.X1 >= 3);
 
         // Act
         var deferred = theorem.OrderByDescending(t => t.X1);
@@ -223,8 +216,7 @@ public class OptimizationTests
         using var context = new Z3Context();
         var theorem = context.NewTheorem<Symbols<int, int>>()
             .Where(t => t.X1 >= 5)
-            .Where(t => t.X1 <= 100)
-            .Where(t => t.X2 == 0);
+            .Where(t => t.X1 <= 100);
 
         // Act
         var minimised = theorem.Optimize(Optimization.Minimize, t => t.X1);
@@ -243,8 +235,7 @@ public class OptimizationTests
         using var context = new Z3Context();
         var theorem = context.NewTheorem<Symbols<int, int>>()
             .Where(t => t.X1 >= 1)
-            .Where(t => t.X1 <= 4)
-            .Where(t => t.X2 == 0);
+            .Where(t => t.X1 <= 4);
 
         // Act
         var first = theorem.Optimize(Optimization.Minimize, t => t.X1);
@@ -267,8 +258,7 @@ public class OptimizationTests
         // than defaulting to one of them (Theorem.cs:118).
         using var context = new Z3Context();
         var theorem = context.NewTheorem<Symbols<int, int>>()
-            .Where(t => t.X1 == 1)
-            .Where(t => t.X2 == 0);
+            .Where(t => t.X1 == 1);
 
         // Act & Assert
         Should.Throw<ArgumentOutOfRangeException>(
@@ -329,8 +319,7 @@ public class OptimizationTests
         using var context = new Z3Context();
         var parent = context.NewTheorem<Symbols<int, int>>()
             .Where(t => t.X1 >= 1)
-            .Where(t => t.X1 <= 10)
-            .Where(t => t.X2 == 0);
+            .Where(t => t.X1 <= 10);
         var child = parent.Where(t => t.X1 >= 6);
 
         // Act

--- a/solutions/Z3.Linq.Tests/SymbolTypeMarshallingTests.cs
+++ b/solutions/Z3.Linq.Tests/SymbolTypeMarshallingTests.cs
@@ -43,7 +43,6 @@ public class SymbolTypeMarshallingTests
         // Act
         var result = context.NewTheorem<Symbols<int, int>>()
             .Where(t => t.X1 == value)
-            .Where(t => t.X2 == 0)
             .Solve();
 
         // Assert
@@ -65,7 +64,6 @@ public class SymbolTypeMarshallingTests
         // Act
         var result = context.NewTheorem<Symbols<long, int>>()
             .Where(t => t.X1 == value)
-            .Where(t => t.X2 == 0)
             .Solve();
 
         // Assert
@@ -84,7 +82,6 @@ public class SymbolTypeMarshallingTests
         // Act
         var result = context.NewTheorem<Symbols<bool, int>>()
             .Where(t => t.X1 == value)
-            .Where(t => t.X2 == 0)
             .Solve();
 
         // Assert
@@ -106,7 +103,6 @@ public class SymbolTypeMarshallingTests
         // Act
         var result = context.NewTheorem<Symbols<double, int>>()
             .Where(t => t.X1 == value)
-            .Where(t => t.X2 == 0)
             .Solve();
 
         // Assert
@@ -125,7 +121,6 @@ public class SymbolTypeMarshallingTests
         // Act
         var result = context.NewTheorem<Symbols<decimal, int>>()
             .Where(t => t.X1 == Value)
-            .Where(t => t.X2 == 0)
             .Solve();
 
         // Assert
@@ -145,7 +140,6 @@ public class SymbolTypeMarshallingTests
         // Act
         var result = context.NewTheorem<Symbols<string, int>>()
             .Where(t => t.X1 == value)
-            .Where(t => t.X2 == 0)
             .Solve();
 
         // Assert
@@ -165,7 +159,6 @@ public class SymbolTypeMarshallingTests
         var result = context.NewTheorem<Symbols<double, int>>()
             .Where(t => t.X1 > 10.5)
             .Where(t => t.X1 < 11.0)
-            .Where(t => t.X2 == 0)
             .Solve();
 
         // Assert
@@ -190,8 +183,7 @@ public class SymbolTypeMarshallingTests
         // Arrange
         using var context = new Z3Context();
         var theorem = context.NewTheorem<Symbols<short, short>>()
-            .Where(t => t.X1 == 7)
-            .Where(t => t.X2 == 1);
+            .Where(t => t.X1 == 7);
 
         // Act & Assert
         Should.Throw<InvalidCastException>(() => theorem.Solve());
@@ -212,8 +204,7 @@ public class SymbolTypeMarshallingTests
         // Arrange
         using var context = new Z3Context();
         var theorem = context.NewTheorem<Symbols<float, int>>()
-            .Where(t => t.X1 == 1.5f)
-            .Where(t => t.X2 == 0);
+            .Where(t => t.X1 == 1.5f);
 
         // Act & Assert
         Should.Throw<ArgumentException>(() => theorem.Solve());
@@ -240,7 +231,6 @@ public class SymbolTypeMarshallingTests
         // Act
         var result = context.NewTheorem<Symbols<DateTime, int>>()
             .Where(t => t.X1 == utc)
-            .Where(t => t.X2 == 0)
             .Solve();
 
         // Assert
@@ -309,7 +299,6 @@ public class SymbolTypeMarshallingTests
                 using var context = new Z3Context();
                 _ = context.NewTheorem<Symbols<double, int>>()
                     .Where(t => t.X1 == 1.5)
-                    .Where(t => t.X2 == 0)
                     .Solve();
             }
             catch (Exception ex)
@@ -337,18 +326,29 @@ public class SymbolTypeMarshallingTests
         // that the two differ only by culture. This is what the defect above should look like
         // once it is fixed.
         double? value = null;
+        Exception? captured = null;
 
         var thread = new Thread(() =>
         {
             CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
 
-            using var context = new Z3Context();
-            var result = context.NewTheorem<Symbols<double, int>>()
-                .Where(t => t.X1 == 1.5)
-                .Where(t => t.X2 == 0)
-                .Solve();
+            try
+            {
+                using var context = new Z3Context();
+                var result = context.NewTheorem<Symbols<double, int>>()
+                    .Where(t => t.X1 == 1.5)
+                    .Solve();
 
-            value = result?.X1;
+                value = result?.X1;
+            }
+            catch (Exception ex)
+            {
+                // Captured rather than left to escape: an exception on a bare thread is
+                // unhandled, so it takes down the test host and the run reports "zero tests
+                // ran" rather than one failed test. The pin above already does this; this
+                // counterpart did not, because it was not expected to throw.
+                captured = ex;
+            }
         });
 
         // Act
@@ -356,6 +356,7 @@ public class SymbolTypeMarshallingTests
         thread.Join(SolveTimeout).ShouldBeTrue("the solve on the invariant-culture thread did not finish");
 
         // Assert
+        captured.ShouldBeNull();
         value.ShouldBe(1.5);
     }
 

--- a/solutions/Z3.Linq.Tests/TheoremCompositionTests.cs
+++ b/solutions/Z3.Linq.Tests/TheoremCompositionTests.cs
@@ -68,8 +68,7 @@ public class TheoremCompositionTests
         // child's extra constraint did not leak backwards.
         using var context = new Z3Context();
         var parent = context.NewTheorem<Symbols<int, int>>()
-            .Where(t => t.X1 == 3)
-            .Where(t => t.X2 == 0);
+            .Where(t => t.X1 == 3);
         var child = parent.Where(t => t.X1 == 4);
 
         // Act
@@ -137,7 +136,6 @@ public class TheoremCompositionTests
         // Act
         var result = (from t in context.NewTheorem<Symbols<int, int>>()
                       where t.X1 == 1
-                      where t.X2 == 0
                       select t).Solve();
 
         // Assert
@@ -159,7 +157,6 @@ public class TheoremCompositionTests
 
         var result = (from t in context.NewTheorem<Symbols<int, int>>()
                       where t.X1 == 11
-                      where t.X2 == 0
                       select t).Solve();
 
         // Assert

--- a/solutions/Z3.Linq.Tests/UnsupportedExpressionTests.cs
+++ b/solutions/Z3.Linq.Tests/UnsupportedExpressionTests.cs
@@ -38,8 +38,7 @@ public class UnsupportedExpressionTests
         // express if-then-else, so this is a gap rather than a fundamental limit.
         using var context = new Z3Context();
         var theorem = context.NewTheorem<Symbols<int, int>>()
-            .Where(t => (t.X1 > 0 ? t.X1 : 0) == 1)
-            .Where(t => t.X2 == 0);
+            .Where(t => (t.X1 > 0 ? t.X1 : 0) == 1);
 
         // Act & Assert
         Should.Throw<NotSupportedException>(() => theorem.Solve());
@@ -54,8 +53,7 @@ public class UnsupportedExpressionTests
         // (ExpressionVisitor.cs:277).
         using var context = new Z3Context();
         var theorem = context.NewTheorem<Symbols<int, int>>()
-            .Where(t => Increment(t.X1) == 2)
-            .Where(t => t.X2 == 0);
+            .Where(t => Increment(t.X1) == 2);
 
         // Act & Assert
         Should.Throw<NotSupportedException>(() => theorem.Solve());
@@ -70,8 +68,7 @@ public class UnsupportedExpressionTests
         // than NotSupportedException - the throw sites are not consistent about which they use.
         using var context = new Z3Context();
         var theorem = context.NewTheorem<Symbols<int, int>>()
-            .Where(t => (long)t.X1 == 1L)
-            .Where(t => t.X2 == 0);
+            .Where(t => (long)t.X1 == 1L);
 
         // Act & Assert
         Should.Throw<NotImplementedException>(() => theorem.Solve());
@@ -162,7 +159,6 @@ public class UnsupportedExpressionTests
         using var context = new Z3Context();
         var theorem = context.NewTheorem<Symbols<int, int>>()
             .Where(t => t.X1 > 0)
-            .Where(t => t.X2 == 0)
             .Where(t => (t.X1 > 5 ? t.X1 : 0) == 6);
 
         // Act & Assert


### PR DESCRIPTION
Stacked on #73, which fixes #51.

## Why

Thirty-two tests carried a constraint - usually `.Where(t => t.X2 == 0)` - whose only purpose
was to keep the second symbol referenced, because an unreferenced one made `Solve` throw. They
were spread across six files and were actively misleading: a reader could not tell which
constraints belonged to a test's subject and which were there to work around a defect.

This is the cost of #51 made visible, and removing it is the last part of fixing it.

## What it buys

The workarounds become regression coverage. With them gone, reverting the completion flag
fails **51 tests instead of 12** - the 32 removals expand to 39 extra cases through their
`DataRow`s.

That is a better guarantee than any test I could write deliberately: the marshalling of every
supported type, the whole optimisation surface, and most of the documented throw sites now
exercise the free-symbol path as a side effect of testing what they were already testing.

## Not mechanical

Removal was per-site, not a search-and-replace. A constraint stays wherever the test asserts
the value it pins - `result.X2.ShouldBe(0)` and friends - because dropping the constraint but
keeping the assertion would leave a test asserting a value on a now-free symbol, which is
exactly the flake the suite's determinism rule exists to prevent.

Kept for that reason: three tests in `DistinctSelectorTheoremTests`, one in `RewriterTests`,
two in `DistinctInlineArrayTheoremTests`, the multi-symbol tests in `EnvironmentTypeTests`
(where `X2 == 2` is the subject, not a workaround), and `SymbolsToString`. Also kept:
`Solve_EverySymbolConstrained_ReturnsResult`, whose entire subject is that every symbol is
constrained.

## One test that could not fail properly

`Solve_DoubleSymbolUnderInvariantCulture_RoundTripsTheValue` ran its solve on a bare `Thread`
with no `try`/`catch`. Once its workaround was removed, the mutation check made that solve
throw - and because the exception was unhandled on a background thread, it took down the test
host. The run reported:

```
Zero tests ran (782ms)
Exit code: -532462766
  Error output: Unhandled exception. System.InvalidCastException: ...
```

"Zero tests ran" rather than "one test failed" - which makes the mutation check above
unreadable, and would do the same to any future regression on that path. It now captures the
exception and asserts on it, exactly as its sibling pin already did.

## Verification

- 145/145, unchanged count and unchanged assertions
- `./build.ps1 -Configuration Release` - 46 tasks, 0 errors, 0 warnings
- Mutation: 51 failures with the fix reverted, 0 with it in place