### PR TITLE
Render real constants invariantly

### DIFF
--- a/solutions/Z3.Linq.Tests/CultureInvarianceTests.cs
+++ b/solutions/Z3.Linq.Tests/CultureInvarianceTests.cs
@@ -53,10 +53,10 @@ public class CultureInvarianceTests
     {
         // Arrange: the case in #52's title. fa-IR is here because its separator is not a comma
         // either - the defect was never specific to one character.
-        RequireANonInvariantRendering(culture, 1.5);
+        CultureInfo cultureInfo = RequireANonInvariantRendering(culture, 1.5);
 
         // Act
-        double? value = SolveOn(culture, () =>
+        double? value = SolveOn(cultureInfo, () =>
         {
             using var context = new Z3Context();
             return context.NewTheorem<Symbols<double, int>>()
@@ -83,11 +83,11 @@ public class CultureInvarianceTests
         string culture)
     {
         // Arrange
-        CultureInfo.GetCultureInfo(culture).NumberFormat.NegativeSign.ShouldNotBe("-");
-        RequireANonInvariantRendering(culture, -1.5);
+        CultureInfo cultureInfo = RequireANonInvariantRendering(culture, -1.5);
+        cultureInfo.NumberFormat.NegativeSign.ShouldNotBe("-");
 
         // Act
-        double? value = SolveOn(culture, () =>
+        double? value = SolveOn(cultureInfo, () =>
         {
             using var context = new Z3Context();
             return context.NewTheorem<Symbols<double, int>>()
@@ -106,10 +106,10 @@ public class CultureInvarianceTests
     {
         // Arrange: decimal shares the real sort with double and the same arm of the constant
         // switch, but it is a separate CLR formatter, so it gets its own case.
-        RequireANonInvariantRendering(culture, 1.5m);
+        CultureInfo cultureInfo = RequireANonInvariantRendering(culture, 1.5m);
 
         // Act
-        decimal? value = SolveOn(culture, () =>
+        decimal? value = SolveOn(cultureInfo, () =>
         {
             using var context = new Z3Context();
             return context.NewTheorem<Symbols<decimal, int>>()
@@ -138,10 +138,10 @@ public class CultureInvarianceTests
     {
         // Arrange
         const string Culture = "de-DE";
-        RequireANonInvariantRendering(Culture, 1.5f);
+        CultureInfo cultureInfo = RequireANonInvariantRendering(Culture, 1.5f);
 
         // Act & Assert
-        Should.Throw<ArgumentException>(() => SolveOn(Culture, () =>
+        Should.Throw<ArgumentException>(() => SolveOn(cultureInfo, () =>
         {
             using var context = new Z3Context();
             return context.NewTheorem<Symbols<float, int>>()
@@ -165,10 +165,11 @@ public class CultureInvarianceTests
     {
         // Arrange
         const string Culture = "tr-TR";
-        CultureInfo.GetCultureInfo(Culture).TextInfo.ToLower("I").ShouldNotBe("i");
+        CultureInfo cultureInfo = CultureInfo.GetCultureInfo(Culture);
+        cultureInfo.TextInfo.ToLower("I").ShouldNotBe("i");
 
         // Act
-        string? value = SolveOn(Culture, () =>
+        string? value = SolveOn(cultureInfo, () =>
         {
             using var context = new Z3Context();
             return context.NewTheorem<Symbols<string, int>>()
@@ -188,7 +189,7 @@ public class CultureInvarianceTests
         // the fix; if it ever fails, the problem is the harness rather than the culture.
 
         // Act
-        double? value = SolveOn(string.Empty, () =>
+        double? value = SolveOn(CultureInfo.InvariantCulture, () =>
         {
             using var context = new Z3Context();
             return context.NewTheorem<Symbols<double, int>>()
@@ -204,7 +205,8 @@ public class CultureInvarianceTests
     /// Asserts that <paramref name="culture"/> renders <paramref name="probe"/> differently from
     /// the invariant culture, so a test using it can detect the defect it exists for.
     /// </summary>
-    private static void RequireANonInvariantRendering(string culture, IFormattable probe)
+    /// <returns>The resolved culture, so the caller resolves it once.</returns>
+    private static CultureInfo RequireANonInvariantRendering(string culture, IFormattable probe)
     {
         CultureInfo cultureInfo = CultureInfo.GetCultureInfo(culture);
 
@@ -217,6 +219,8 @@ public class CultureInvarianceTests
 
         probe.ToString(null, cultureInfo)
             .ShouldNotBe(probe.ToString(null, CultureInfo.InvariantCulture));
+
+        return cultureInfo;
     }
 
     /// <summary>
@@ -228,14 +232,14 @@ public class CultureInvarianceTests
     /// thread is unhandled, so it takes down the test host and the run reports "zero tests ran"
     /// rather than one failure.
     /// </remarks>
-    private static T SolveOn<T>(string culture, Func<T> body)
+    private static T SolveOn<T>(CultureInfo culture, Func<T> body)
     {
         T result = default!;
         ExceptionDispatchInfo? failure = null;
 
         var thread = new Thread(() =>
         {
-            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo(culture);
+            CultureInfo.CurrentCulture = culture;
 
             try
             {
@@ -245,14 +249,22 @@ public class CultureInvarianceTests
             {
                 failure = ExceptionDispatchInfo.Capture(ex);
             }
-        });
+        })
+        {
+            // Foreground is the default, and a foreground thread that outlives the wait below
+            // holds the whole test host open - measured: a process whose Main has returned does
+            // not exit at all while one is still running. That turns the timeout from a clean
+            // failure into a stalled run, which is the opposite of what it is here for.
+            IsBackground = true,
+        };
 
         thread.Start();
 
         // Bounded, so that a solver that never returns fails the test rather than hanging the
         // whole run with no indication of which test stopped. The work itself takes single-digit
         // milliseconds, so the limit is enormous slack rather than a tuned value.
-        thread.Join(SolveTimeout).ShouldBeTrue($"the solve on the {culture} thread did not finish");
+        string name = culture.Name.Length == 0 ? "invariant" : culture.Name;
+        thread.Join(SolveTimeout).ShouldBeTrue($"the solve on the {name} thread did not finish");
 
         failure?.Throw();
         return result;

--- a/solutions/Z3.Linq.Tests/CultureInvarianceTests.cs
+++ b/solutions/Z3.Linq.Tests/CultureInvarianceTests.cs
@@ -1,0 +1,260 @@
+namespace Z3.Linq.Tests;
+
+using System.Globalization;
+using System.Runtime.ExceptionServices;
+using System.Threading;
+
+/// <summary>
+/// Pins that translating a C# constant into a Z3 term does not depend on the ambient culture.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Z3's parser accepts only <c>.</c> as a decimal separator and only ASCII <c>-</c> as a sign,
+/// so a number handed to it has to be rendered invariantly. Until #52 was fixed,
+/// <c>ExpressionVisitor</c> rendered real constants with the current culture. Measured over the
+/// 606 specific cultures installed on the development machine, 301 of them produced a literal
+/// Z3 rejected with <c>Z3Exception: parser error</c> - about half, and every widely used
+/// European language among them. None produced a wrong value, which is the one merciful thing
+/// about it: the defect always announced itself.
+/// </para>
+/// <para>
+/// Every test here runs its solve on a dedicated thread. <c>CurrentCulture</c> is per-thread,
+/// these tests run in parallel at method level, and the runner hands out pooled threads - so
+/// setting it on the test's own thread could leak into whatever runs next on that thread. A
+/// thread created for the purpose cannot leak anywhere.
+/// </para>
+/// <para>
+/// Each culture test starts by asserting that the culture really does render its probe value
+/// differently from the invariant culture. Under globalization-invariant mode every culture
+/// falls back to invariant data, and without that check these tests would pass while
+/// exercising nothing.
+/// </para>
+/// <para>
+/// The solve, the model and the read back all happen on the foreign-culture thread, so these
+/// cover the whole round trip rather than the write side alone.
+/// </para>
+/// </remarks>
+[TestClass]
+public class CultureInvarianceTests
+{
+    /// <summary>
+    /// How long to wait for a solve running on a dedicated thread. Generous by design - it
+    /// exists to turn a hang into a failure, not to police how long a solve should take.
+    /// </summary>
+    private static readonly TimeSpan SolveTimeout = TimeSpan.FromSeconds(30);
+
+    [TestMethod]
+    [DataRow("de-DE", DisplayName = "German - comma separator")]
+    [DataRow("fr-FR", DisplayName = "French - comma separator")]
+    [DataRow("ru-RU", DisplayName = "Russian - comma separator")]
+    [DataRow("tr-TR", DisplayName = "Turkish - comma separator")]
+    [DataRow("fa-IR", DisplayName = "Persian - U+066B decimal separator")]
+    public void Solve_DoubleConstantUnderANonInvariantCulture_RoundTripsTheValue(string culture)
+    {
+        // Arrange: the case in #52's title. fa-IR is here because its separator is not a comma
+        // either - the defect was never specific to one character.
+        RequireANonInvariantRendering(culture, 1.5);
+
+        // Act
+        double? value = SolveOn(culture, () =>
+        {
+            using var context = new Z3Context();
+            return context.NewTheorem<Symbols<double, int>>()
+                .Where(t => t.X1 == 1.5)
+                .Solve()?.X1;
+        });
+
+        // Assert
+        value.ShouldBe(1.5);
+    }
+
+    /// <summary>
+    /// A negative real constant survives a culture whose negative sign is not ASCII.
+    /// </summary>
+    /// <remarks>
+    /// These cultures render -1.5 with U+2212 MINUS SIGN rather than ASCII <c>-</c>. A fix that
+    /// only swapped the decimal separator would still hand Z3 a sign it cannot parse, so this is
+    /// the case that rules out the obvious wrong fix.
+    /// </remarks>
+    [TestMethod]
+    [DataRow("sv-SE", DisplayName = "Swedish")]
+    [DataRow("fi-FI", DisplayName = "Finnish")]
+    public void Solve_NegativeDoubleConstantUnderACultureWithANonAsciiSign_RoundTripsTheValue(
+        string culture)
+    {
+        // Arrange
+        CultureInfo.GetCultureInfo(culture).NumberFormat.NegativeSign.ShouldNotBe("-");
+        RequireANonInvariantRendering(culture, -1.5);
+
+        // Act
+        double? value = SolveOn(culture, () =>
+        {
+            using var context = new Z3Context();
+            return context.NewTheorem<Symbols<double, int>>()
+                .Where(t => t.X1 == -1.5)
+                .Solve()?.X1;
+        });
+
+        // Assert
+        value.ShouldBe(-1.5);
+    }
+
+    [TestMethod]
+    [DataRow("de-DE", DisplayName = "German")]
+    [DataRow("sv-SE", DisplayName = "Swedish")]
+    public void Solve_DecimalConstantUnderANonInvariantCulture_RoundTripsTheValue(string culture)
+    {
+        // Arrange: decimal shares the real sort with double and the same arm of the constant
+        // switch, but it is a separate CLR formatter, so it gets its own case.
+        RequireANonInvariantRendering(culture, 1.5m);
+
+        // Act
+        decimal? value = SolveOn(culture, () =>
+        {
+            using var context = new Z3Context();
+            return context.NewTheorem<Symbols<decimal, int>>()
+                .Where(t => t.X1 == 1.5m)
+                .Solve()?.X1;
+        });
+
+        // Assert
+        value.ShouldBe(1.5m);
+    }
+
+    /// <summary>
+    /// A <c>float</c> constant gets past translation under a foreign culture and fails at the
+    /// read back instead - which is #54, not #52.
+    /// </summary>
+    /// <remarks>
+    /// <c>float</c> takes the same arm of the constant switch as <c>double</c> and
+    /// <c>decimal</c>, so without this the fix would have a third of its call site untested. It
+    /// cannot be a round-trip test, because a float symbol cannot round-trip at all: the model
+    /// value is parsed into a double and reflection then refuses to write it to a float
+    /// property. Under the defect this threw <c>Z3Exception</c> during translation, so reaching
+    /// <see cref="ArgumentException"/> is itself the evidence that translation now succeeds.
+    /// </remarks>
+    [TestMethod]
+    public void Solve_FloatConstantUnderANonInvariantCulture_FailsInMarshallingNotTranslation()
+    {
+        // Arrange
+        const string Culture = "de-DE";
+        RequireANonInvariantRendering(Culture, 1.5f);
+
+        // Act & Assert
+        Should.Throw<ArgumentException>(() => SolveOn(Culture, () =>
+        {
+            using var context = new Z3Context();
+            return context.NewTheorem<Symbols<float, int>>()
+                .Where(t => t.X1 == 1.5f)
+                .Solve()?.X1;
+        }));
+    }
+
+    /// <summary>
+    /// A <c>string</c> constant is unaffected by the culture.
+    /// </summary>
+    /// <remarks>
+    /// The line that fixes #52 sits two above a <c>MkString(val.ToString())</c> that looks
+    /// identical. That one is safe - <c>String.ToString()</c> returns the instance - and this
+    /// test is here so the asymmetry is a recorded fact rather than an oversight waiting to be
+    /// tidied up. tr-TR because its casing rules are the usual way a string path turns out to
+    /// be culture-sensitive after all.
+    /// </remarks>
+    [TestMethod]
+    public void Solve_StringConstantUnderANonInvariantCulture_RoundTripsTheValue()
+    {
+        // Arrange
+        const string Culture = "tr-TR";
+        CultureInfo.GetCultureInfo(Culture).TextInfo.ToLower("I").ShouldNotBe("i");
+
+        // Act
+        string? value = SolveOn(Culture, () =>
+        {
+            using var context = new Z3Context();
+            return context.NewTheorem<Symbols<string, int>>()
+                .Where(t => t.X1 == "III")
+                .Solve()?.X1;
+        });
+
+        // Assert
+        value.ShouldBe("III");
+    }
+
+    [TestMethod]
+    public void Solve_DoubleConstantUnderTheInvariantCulture_RoundTripsTheValue()
+    {
+        // Arrange: the control. It uses the same dedicated-thread mechanism as the tests above,
+        // so they differ from it by culture and nothing else. This one passed on both sides of
+        // the fix; if it ever fails, the problem is the harness rather than the culture.
+
+        // Act
+        double? value = SolveOn(string.Empty, () =>
+        {
+            using var context = new Z3Context();
+            return context.NewTheorem<Symbols<double, int>>()
+                .Where(t => t.X1 == 1.5)
+                .Solve()?.X1;
+        });
+
+        // Assert
+        value.ShouldBe(1.5);
+    }
+
+    /// <summary>
+    /// Asserts that <paramref name="culture"/> renders <paramref name="probe"/> differently from
+    /// the invariant culture, so a test using it can detect the defect it exists for.
+    /// </summary>
+    private static void RequireANonInvariantRendering(string culture, IFormattable probe)
+    {
+        CultureInfo cultureInfo = CultureInfo.GetCultureInfo(culture);
+
+        cultureInfo.NumberFormat.NumberDecimalSeparator.ShouldNotBe(
+            CultureInfo.InvariantCulture.NumberFormat.NumberDecimalSeparator,
+            $"{culture} formats numbers exactly as the invariant culture does on this machine, "
+            + "so this test cannot detect the defect it exists for - most likely the runtime is "
+            + "in globalization-invariant mode, where every culture falls back to invariant "
+            + "data");
+
+        probe.ToString(null, cultureInfo)
+            .ShouldNotBe(probe.ToString(null, CultureInfo.InvariantCulture));
+    }
+
+    /// <summary>
+    /// Runs <paramref name="body"/> on a thread pinned to <paramref name="culture"/>, and returns
+    /// what it returned or rethrows what it threw.
+    /// </summary>
+    /// <remarks>
+    /// The exception is captured and rethrown rather than left to escape: one escaping a bare
+    /// thread is unhandled, so it takes down the test host and the run reports "zero tests ran"
+    /// rather than one failure.
+    /// </remarks>
+    private static T SolveOn<T>(string culture, Func<T> body)
+    {
+        T result = default!;
+        ExceptionDispatchInfo? failure = null;
+
+        var thread = new Thread(() =>
+        {
+            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo(culture);
+
+            try
+            {
+                result = body();
+            }
+            catch (Exception ex)
+            {
+                failure = ExceptionDispatchInfo.Capture(ex);
+            }
+        });
+
+        thread.Start();
+
+        // Bounded, so that a solver that never returns fails the test rather than hanging the
+        // whole run with no indication of which test stopped. The work itself takes single-digit
+        // milliseconds, so the limit is enormous slack rather than a tuned value.
+        thread.Join(SolveTimeout).ShouldBeTrue($"the solve on the {culture} thread did not finish");
+
+        failure?.Throw();
+        return result;
+    }
+}

--- a/solutions/Z3.Linq.Tests/RewriterTests.cs
+++ b/solutions/Z3.Linq.Tests/RewriterTests.cs
@@ -117,7 +117,7 @@ public class RewriterTests
     {
         // Arrange: the visitor re-visits whatever the rewriter returns, so a rewriter returning
         // its own input would recurse forever. That is detected by reference equality and
-        // rejected (ExpressionVisitor.cs:191) - a guard worth keeping, since the alternative is
+        // rejected (ExpressionVisitor.cs:192) - a guard worth keeping, since the alternative is
         // a hung build rather than a failed one.
         using var context = new Z3Context();
         var theorem = context.NewTheorem<Symbols<int, int>>()
@@ -131,7 +131,7 @@ public class RewriterTests
     public void Solve_PredicateRewriterTypeNotImplementingTheInterface_ThrowsInvalidOperationException()
     {
         // Arrange: as with the global rewriter, the attribute cannot enforce this at compile
-        // time (ExpressionVisitor.cs:179).
+        // time (ExpressionVisitor.cs:180).
         using var context = new Z3Context();
         var theorem = context.NewTheorem<Symbols<int, int>>()
             .Where(t => WrongRewriterType(t.X1, t.X2));

--- a/solutions/Z3.Linq.Tests/SymbolTypeMarshallingTests.cs
+++ b/solutions/Z3.Linq.Tests/SymbolTypeMarshallingTests.cs
@@ -1,8 +1,5 @@
 namespace Z3.Linq.Tests;
 
-using System.Globalization;
-using System.Threading;
-
 /// <summary>
 /// Round-trips a value of each scalar symbol type through <see cref="Theorem{T}.Solve"/>:
 /// C# constant -> Z3 term -> model -> CLR property.
@@ -23,12 +20,6 @@ using System.Threading;
 [TestClass]
 public class SymbolTypeMarshallingTests
 {
-    /// <summary>
-    /// How long to wait for a solve running on a dedicated thread. Generous by design - it
-    /// exists to turn a hang into a failure, not to police how long a solve should take.
-    /// </summary>
-    private static readonly TimeSpan SolveTimeout = TimeSpan.FromSeconds(30);
-
     [TestMethod]
     [DataRow(0, DisplayName = "Zero")]
     [DataRow(42, DisplayName = "Positive")]
@@ -173,7 +164,7 @@ public class SymbolTypeMarshallingTests
     /// <remarks>
     /// A short symbol is created with MkIntConst, but C# widens short to int for the comparison
     /// and ExpressionVisitor.VisitUnary reads that Convert node as a real-to-int conversion,
-    /// casting the IntExpr to RealExpr (ExpressionVisitor.cs:131). A second defect waits behind
+    /// casting the IntExpr to RealExpr (ExpressionVisitor.cs:132). A second defect waits behind
     /// it: TypeCode.Int16 marshals to an int, which a short property rejects.
     /// This test pins current behaviour and must be updated when the defect is fixed.
     /// </remarks>
@@ -263,101 +254,6 @@ public class SymbolTypeMarshallingTests
         result.ShouldNotBeNull();
         result.X1.ShouldBe(5);
         result.X2.ShouldBe("five");
-    }
-
-    /// <summary>
-    /// KNOWN DEFECT (#52): a real-valued constant is written to Z3 using the current culture.
-    /// </summary>
-    /// <remarks>
-    /// <para>
-    /// ExpressionVisitor.cs:304 calls MkReal(val.ToString()) with no format provider, so under a
-    /// comma-decimal culture the literal 1.5 is handed to Z3 as "1,5" and its parser rejects it.
-    /// Every other numeric conversion in the visitor passes InvariantCulture, and so does every
-    /// read back on the marshalling side, which is what makes this one look like an oversight
-    /// rather than a decision.
-    /// </para>
-    /// <para>
-    /// The work runs on a dedicated thread rather than by setting the culture on the test's own
-    /// thread. CurrentCulture is per-thread, these tests run in parallel at method level, and
-    /// the runner hands out pooled threads - so mutating it here could leak into whatever runs
-    /// next on the same thread. A thread created for the purpose cannot leak anywhere.
-    /// </para>
-    /// <para>This test pins current behaviour and must be updated when the defect is fixed.</para>
-    /// </remarks>
-    [TestMethod]
-    public void Solve_DoubleSymbolUnderCommaDecimalCulture_ThrowsZ3ParserError()
-    {
-        // Arrange
-        Exception? captured = null;
-
-        var thread = new Thread(() =>
-        {
-            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("de-DE");
-
-            try
-            {
-                using var context = new Z3Context();
-                _ = context.NewTheorem<Symbols<double, int>>()
-                    .Where(t => t.X1 == 1.5)
-                    .Solve();
-            }
-            catch (Exception ex)
-            {
-                captured = ex;
-            }
-        });
-
-        // Act
-        thread.Start();
-
-        // Bounded, so that a solver that never returns fails this test rather than hanging the
-        // whole run with no indication of which test stopped. The work itself takes single-digit
-        // milliseconds, so the limit is enormous slack rather than a tuned value.
-        thread.Join(SolveTimeout).ShouldBeTrue("the solve on the de-DE thread did not finish");
-
-        // Assert
-        captured.ShouldBeOfType<Microsoft.Z3.Z3Exception>();
-    }
-
-    [TestMethod]
-    public void Solve_DoubleSymbolUnderInvariantCulture_RoundTripsTheValue()
-    {
-        // Arrange: the counterpart to the pin above, on the same dedicated-thread mechanism, so
-        // that the two differ only by culture. This is what the defect above should look like
-        // once it is fixed.
-        double? value = null;
-        Exception? captured = null;
-
-        var thread = new Thread(() =>
-        {
-            CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
-
-            try
-            {
-                using var context = new Z3Context();
-                var result = context.NewTheorem<Symbols<double, int>>()
-                    .Where(t => t.X1 == 1.5)
-                    .Solve();
-
-                value = result?.X1;
-            }
-            catch (Exception ex)
-            {
-                // Captured rather than left to escape: an exception on a bare thread is
-                // unhandled, so it takes down the test host and the run reports "zero tests
-                // ran" rather than one failed test. The pin above already does this; this
-                // counterpart did not, because it was not expected to throw.
-                captured = ex;
-            }
-        });
-
-        // Act
-        thread.Start();
-        thread.Join(SolveTimeout).ShouldBeTrue("the solve on the invariant-culture thread did not finish");
-
-        // Assert
-        captured.ShouldBeNull();
-        value.ShouldBe(1.5);
     }
 
     /// <summary>

--- a/solutions/Z3.Linq.Tests/UnsupportedExpressionTests.cs
+++ b/solutions/Z3.Linq.Tests/UnsupportedExpressionTests.cs
@@ -50,7 +50,7 @@ public class UnsupportedExpressionTests
         // Arrange: only Z3Methods.Distinct, indexed property getters and methods carrying a
         // predicate rewriter attribute are understood. An ordinary method that depends on a
         // theorem symbol cannot be evaluated away, so it reaches the visitor and is rejected
-        // (ExpressionVisitor.cs:277).
+        // (ExpressionVisitor.cs:278).
         using var context = new Z3Context();
         var theorem = context.NewTheorem<Symbols<int, int>>()
             .Where(t => Increment(t.X1) == 2);
@@ -64,7 +64,7 @@ public class UnsupportedExpressionTests
     {
         // Arrange: the Convert case handles conversions to double, int and char only. Widening
         // an int symbol to long is unremarkable C# but has no case, so it falls through to the
-        // catch-all (ExpressionVisitor.cs:140). Note this one is NotImplementedException rather
+        // catch-all (ExpressionVisitor.cs:141). Note this one is NotImplementedException rather
         // than NotSupportedException - the throw sites are not consistent about which they use.
         using var context = new Z3Context();
         var theorem = context.NewTheorem<Symbols<int, int>>()
@@ -119,7 +119,7 @@ public class UnsupportedExpressionTests
     /// <remarks>
     /// An enum's TypeCode is that of its underlying type, so the symbol is created as an
     /// integer - and then C# emits a Convert to int for the comparison, which
-    /// ExpressionVisitor.cs:131 reads as a real-to-int conversion and casts to RealExpr. Same
+    /// ExpressionVisitor.cs:132 reads as a real-to-int conversion and casts to RealExpr. Same
     /// root cause as short, so the same fix covers both.
     /// This test pins current behaviour and must be updated when the defect is fixed.
     /// </remarks>

--- a/solutions/Z3.Linq/ExpressionVisitor.cs
+++ b/solutions/Z3.Linq/ExpressionVisitor.cs
@@ -1,6 +1,7 @@
 ﻿namespace Z3.Linq;
  
 using System.Collections;
+using System.Globalization;
 using System.Linq.Expressions;
 using System.Reflection;
 
@@ -301,7 +302,9 @@ public static class ExpressionVisitor
             case TypeCode.Single:
             case TypeCode.Double:
             case TypeCode.Decimal:
-                return context.MkReal(val.ToString());
+                // Invariant, not current: Z3's parser accepts only '.' as the decimal separator,
+                // and about half of all cultures render 1.5 as something else. See #52.
+                return context.MkReal(((IFormattable)val).ToString(null, CultureInfo.InvariantCulture));
             case TypeCode.DateTime:
                 return context.MkInt(((DateTime)val).ToFileTimeUtc());
             case TypeCode.String:


### PR DESCRIPTION
Fixes #52.

## The defect

`ExpressionVisitor` rendered every real constant with the ambient culture:

```csharp
return context.MkReal(val.ToString());
```

Z3's parser accepts only `.` as a decimal separator and only ASCII `-` as a sign, so under a
comma-decimal culture the literal `1.5` arrived as `"1,5"`:

```csharp
CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("de-DE");
using var ctx = new Z3Context();
ctx.NewTheorem<Symbols<double, int>>().Where(t => t.X1 == 1.5).Solve();
// Microsoft.Z3.Z3Exception: parser error
```

**It is much wider than the comma.** Sweeping all 606 specific cultures installed on this
machine, solving `X1 == 1.5`:

| | Before | After |
|---|---|---|
| Round-tripped correctly | 305 | **606** |
| Rejected with `parser error` | **301** | 0 |
| Silently wrong value | 0 | 0 |

About half of all cultures, including every widely used European language. The one merciful
thing is the last row: no culture produced a wrong answer, so the defect always announced
itself rather than quietly corrupting a model.

The separator is not the only character involved:

| Culture | `(1.5).ToString()` | `(-1.5).ToString()` |
|---|---|---|
| en-GB, hi-IN | `1.5` | `-1.5` |
| de-DE, fr-FR, ru-RU, tr-TR | `1,5` | `-1,5` |
| sv-SE, fi-FI, nb-NO | `1,5` | `−1,5` - U+2212 MINUS SIGN, not ASCII |
| fa-IR, ar-EG | `1٫5` - U+066B | `؜-1٫5` |

## The change

One line, plus the `using` it needs:

```csharp
case TypeCode.Single:
case TypeCode.Double:
case TypeCode.Decimal:
    return context.MkReal(((IFormattable)val).ToString(null, CultureInfo.InvariantCulture));
```

`val` is an `object`, and `object.ToString()` has no format-provider overload. The
`IFormattable` cast is safe here and preserves the existing formatting exactly: the switch is on
`Type.GetTypeCode(val.GetType())`, so the runtime type is `float`, `double` or `decimal`, all of
which implement it, and `ToString(null, provider)` is what each type's own
`ToString(IFormatProvider)` calls. Only the provider changes.

The `using System.Globalization;` shifts every line in the file by one, so the six
`ExpressionVisitor.cs:NNN` citations in the test suite are updated in the same commit. Each was
checked against its target line before and after.

**The rest of the file was already right.** `Convert.ToInt64` for the integer arm performs no
formatting, and the `MkString(val.ToString())` two lines below is `String.ToString()`, which
returns the instance. That asymmetry now has a test rather than being left to look like an
oversight.

## Tests

145 → 155. The two culture tests move out of `SymbolTypeMarshallingTests` into
`CultureInvarianceTests`: the subject is the constant visitor rather than symbol marshalling,
the dedicated-thread harness is now shared by six tests, and the extraction takes
`System.Threading` and `SolveTimeout` out of a file that no longer needs them.

The solve threads are background threads. Measured: a process whose `Main` has returned does not
exit at all while a foreground thread is still running, so a solve that outlived the bounded
`Join` would have held the whole test host open - turning the timeout from a clean failure into
a stalled run. The two tests this replaces had the same flaw; it is worth fixing once now that
six tests share the harness.

| Test | Cultures | Why |
|---|---|---|
| `Solve_DoubleConstantUnderANonInvariantCulture_RoundTripsTheValue` | de-DE, fr-FR, ru-RU, tr-TR, fa-IR | the case in the issue title, plus a non-comma separator |
| `Solve_NegativeDoubleConstantUnderACultureWithANonAsciiSign_RoundTripsTheValue` | sv-SE, fi-FI | U+2212 minus - the case a separator-only fix would miss |
| `Solve_DecimalConstantUnderANonInvariantCulture_RoundTripsTheValue` | de-DE, sv-SE | separate CLR formatter, same switch arm |
| `Solve_FloatConstantUnderANonInvariantCulture_FailsInMarshallingNotTranslation` | de-DE | the third type on that arm - see below |
| `Solve_StringConstantUnderANonInvariantCulture_RoundTripsTheValue` | tr-TR | pins the neighbouring line as deliberately unchanged |
| `Solve_DoubleConstantUnderTheInvariantCulture_RoundTripsTheValue` | invariant | the control, on the same harness |

Each culture test first asserts that the culture really does render its probe differently from
the invariant one. Under globalization-invariant mode every culture falls back to invariant data
and these tests would otherwise pass while exercising nothing - a green that means the opposite
of what it looks like.

The `float` case cannot be a round-trip test, because a `float` symbol cannot round-trip at all
(#54). It asserts `ArgumentException` instead: under the defect it threw `Z3Exception` during
translation, so *reaching* the marshalling failure is the evidence that the `TypeCode.Single`
arm is now correct. Without it, a third of the fixed call site would be untested.

The issue says the defect was "deliberately not covered by a test", on the grounds that
`CurrentCulture` is per-thread and the suite runs in parallel at method level. That reasoning
holds for setting the culture on the test's own thread, but the pin added later already solved
it by running the solve on a thread created for the purpose, which cannot leak anywhere. This
PR generalises that harness rather than working around the constraint again.

## Mutation results

| Mutation | Failures | Which |
|---|---|---|
| Revert to `val.ToString()` | **10** | all five double rows, both negative rows, both decimal rows, and the float test. The string test and the invariant control stay green. |
| `val.ToString().Replace(',', '.')` - the naive fix | **3** | fa-IR (U+066B separator), sv-SE and fi-FI (U+2212 sign). Everything a comma-only fix handles passes, which is the point of those three rows. |
| Hard-code `MkReal("0")` | **17** | all 11 culture cases that assert a value, plus 6 pre-existing tests. Confirms the new tests assert the value rather than the absence of an exception. |

## Verification

- `dotnet build solutions/Z3.Linq.slnx -c Release` - clean, `TreatWarningsAsErrors` on
- 155/155 locally, 1.7s
- `./build.ps1 -Configuration Release` - 46 tasks, 0 errors, 0 warnings
- Coverage unchanged at 75.8% line / 69.3% branch: the new tests exercise lines the suite
  already reached, under a different culture

## Found along the way

**#76** - comparing a real symbol against a `float` *variable* throws `InvalidCastException`.
C# inserts a `Convert(Single -> Double)`, and `VisitUnary` picks the conversion from the target
type alone, so it treats an already-real operand as an integer. Same root cause as #63, one arm
along. Raised, not fixed.

Considered and rejected: running the whole suite under a foreign culture via an
`AssemblyInitialize` hook. It would have caught this class of defect everywhere rather than at
one call site, but it changes the environment of all 155 tests to catch a defect at one, and
makes every future failure culture-dependent to reproduce.

## Release note

Releases remain on hold under #60 until Microsoft.Z3 5.x reaches nuget.org, so this reaches
`main` but not consumers. Nothing about the hold changes.
