### PR TITLE
Read the value a collection field holds

### DIFF
--- a/solutions/Z3.Linq.Tests/CollectionSymbolTests.cs
+++ b/solutions/Z3.Linq.Tests/CollectionSymbolTests.cs
@@ -8,7 +8,7 @@ namespace Z3.Linq.Tests;
 /// <para>
 /// A collection symbol is declared as a Z3 array with a domain (index) sort and a range
 /// (element) sort chosen per element type (Theorem.cs:205-235). Elements are always read with
-/// an integer index (Theorem.cs:446), and the number read is the <c>Count</c> of the collection
+/// an integer index (Theorem.cs:448), and the number read is the <c>Count</c> of the collection
 /// already on the instance - so an environment must pre-size its collections, and a solution
 /// never changes their length.
 /// </para>
@@ -17,6 +17,11 @@ namespace Z3.Linq.Tests;
 /// contradicts how the elements are constrained or read, and throws during translation; those
 /// cases are pinned below against #64. The Sudoku examples are all <c>int</c>, which is why the
 /// limitation has gone unnoticed.
+/// </para>
+/// <para>
+/// A collection symbol can be a property or a public field, and since #53 the two behave
+/// identically. A collection the environment leaves null throws either way, which is #78 - and
+/// unavoidable for a ValueTuple, whose elements are fields it has no way to pre-size.
 /// </para>
 /// </remarks>
 [TestClass]
@@ -107,7 +112,7 @@ public class CollectionSymbolTests
     {
         // Arrange: the non-array branch, reached for a generic type implementing IEnumerable.
         // It is reconstructed by passing the element array to the collection's constructor
-        // (Theorem.cs:490), which List<int> supports.
+        // (Theorem.cs:497), which List<int> supports.
         using var context = new Z3Context();
 
         // Act
@@ -178,7 +183,7 @@ public class CollectionSymbolTests
     /// </summary>
     /// <remarks>
     /// #55 describes the decimal element branch evaluating the whole array expression instead of
-    /// the selected element (Theorem.cs:471-474), which would give every element the same value.
+    /// the selected element (Theorem.cs:474-477), which would give every element the same value.
     /// That code is still wrong, but unreachable: a decimal array never survives translation.
     /// </remarks>
     [TestMethod]
@@ -195,27 +200,261 @@ public class CollectionSymbolTests
     }
 
     /// <summary>
-    /// KNOWN DEFECT (#53): a collection held in a public field cannot be marshalled.
+    /// A collection held in a public field round-trips exactly as one held in a property does.
     /// </summary>
     /// <remarks>
-    /// Determining how many elements to read casts the reflection object itself rather than the
-    /// value it holds - <c>((ICollection)info1).Count</c> where <c>info1</c> is the
-    /// <see cref="System.Reflection.FieldInfo"/> (Theorem.cs:439). The property branch beside it
-    /// correctly calls <c>GetValue</c> first, which is why an array property works and an array
-    /// field does not.
-    /// This test pins current behaviour and must be updated when the defect is fixed.
+    /// <para>
+    /// The case in #53. Working out how many elements to read cast the reflection object itself -
+    /// <c>((ICollection)info1).Count</c>, where <c>info1</c> was the
+    /// <see cref="System.Reflection.FieldInfo"/> - so every collection field threw
+    /// <see cref="InvalidCastException"/>, while the property branch beside it, which calls
+    /// <c>GetValue</c> first, worked.
+    /// </para>
+    /// <para>
+    /// Fixing it made the whole element-materialisation loop reachable through a field for the
+    /// first time, so the tests below walk that path rather than stopping at this one case.
+    /// </para>
     /// </remarks>
     [TestMethod]
-    public void Solve_CollectionInAPublicField_ThrowsInvalidCastException()
+    public void Solve_IntArrayInAPublicField_RoundTripsEveryElement()
     {
         // Arrange
         using var context = new Z3Context();
-        var theorem = context.NewTheorem<FieldCollectionEnvironment>()
+
+        // Act
+        var result = context.NewTheorem<FieldCollectionEnvironment>()
             .Where(t => t.Values[0] == 1)
-            .Where(t => t.Length == 2);
+            .Where(t => t.Values[1] == 2)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.Values.ShouldBe([1, 2]);
+    }
+
+    [TestMethod]
+    public void Solve_GenericIntCollectionInAPublicField_RoundTripsEveryElement()
+    {
+        // Arrange: the non-array branch of the same block, which reconstructs the collection
+        // through its constructor rather than materialising an array.
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<FieldListEnvironment>()
+            .Where(t => t.Values[0] == 7)
+            .Where(t => t.Values[1] == 8)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.Values.ShouldBe([7, 8]);
+    }
+
+    /// <summary>
+    /// A field collection and a property collection in the same environment both round-trip.
+    /// </summary>
+    /// <remarks>
+    /// The direct evidence that the two branches now agree: one environment, one solve, and each
+    /// arm produces its own answer rather than one of them throwing.
+    /// </remarks>
+    [TestMethod]
+    public void Solve_CollectionsInAFieldAndAPropertySideBySide_RoundTripBoth()
+    {
+        // Arrange
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<FieldAndPropertyCollectionEnvironment>()
+            .Where(t => t.FieldValues[0] == 1)
+            .Where(t => t.PropertyValues[0] == 2)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.FieldValues.ShouldBe([1]);
+        result.PropertyValues.ShouldBe([2]);
+    }
+
+    [TestMethod]
+    public void Solve_CollectionInAPublicFieldOfANestedObject_RoundTripsEveryElement()
+    {
+        // Arrange: the count is read from the object the field lives on, which for a nested
+        // environment is the inner instance rather than the one being returned. Worth its own
+        // case, because that argument is exactly what the defect got wrong.
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<NestedFieldCollectionEnvironment>()
+            .Where(t => t.Inner.Values[0] == 9)
+            .Where(t => t.Inner.Values[1] == 10)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.Inner.Values.ShouldBe([9, 10]);
+    }
+
+    /// <summary>
+    /// A <c>readonly</c> collection field is written anyway.
+    /// </summary>
+    /// <remarks>
+    /// The solution is assigned with <c>FieldInfo.SetValue</c>, which the runtime permits on an
+    /// initonly instance field, so the modifier buys no protection here - the field ends up
+    /// holding a different array from the one its initialiser created. Recorded because it is the
+    /// opposite of what the declaration suggests, and because <c>readonly</c> is a natural thing
+    /// to write on a collection that only exists to be pre-sized.
+    /// </remarks>
+    [TestMethod]
+    public void Solve_CollectionInAReadOnlyField_RoundTripsEveryElement()
+    {
+        // Arrange
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<ReadOnlyFieldCollectionEnvironment>()
+            .Where(t => t.Values[0] == 3)
+            .Where(t => t.Values[1] == 4)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.Values.ShouldBe([3, 4]);
+    }
+
+    [TestMethod]
+    public void Solve_EmptyCollectionInAPublicField_ReturnsAnEmptyCollection()
+    {
+        // Arrange: the boundary at the other end - a count of zero, so the element loop never
+        // runs and the field is assigned an empty array.
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<EmptyFieldCollectionEnvironment>().Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.Values.ShouldBeEmpty();
+    }
+
+    /// <summary>
+    /// A collection field no constraint touches keeps the length it was initialised with.
+    /// </summary>
+    /// <remarks>
+    /// The length comes from the instance rather than from the model, so it survives a theorem
+    /// that says nothing at all. The element values come from model completion (#51) and are not
+    /// asserted.
+    /// </remarks>
+    [TestMethod]
+    public void Solve_UnconstrainedCollectionInAPublicField_PreservesTheInitialisedLength()
+    {
+        // Arrange
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<FieldCollectionEnvironment>().Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.Values.Length.ShouldBe(2);
+    }
+
+    [TestMethod]
+    public void OrderByDescending_OverAnElementOfACollectionField_ReturnsTheOptimum()
+    {
+        // Arrange: the optimiser reads its solution back through the same marshalling code, so
+        // the fix has to hold on that path too.
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<FieldCollectionEnvironment>()
+            .Where(t => t.Values[0] > 0)
+            .Where(t => t.Values[0] < 10)
+            .OrderByDescending(t => t.Values[0])
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.Values[0].ShouldBe(9);
+    }
+
+    /// <summary>
+    /// KNOWN DEFECT (#64): a field is no better off than a property for element types other than
+    /// <c>int</c>.
+    /// </summary>
+    /// <remarks>
+    /// Translation fails before any marshalling happens, so this failed identically before #53 was
+    /// fixed. It is here so the fix cannot be mistaken for having widened the element types a
+    /// field supports. See <see cref="Solve_LongArraySymbol_ThrowsZ3Exception"/>.
+    /// This test pins current behaviour and must be updated when the defect is fixed.
+    /// </remarks>
+    [TestMethod]
+    public void Solve_LongArrayInAPublicField_ThrowsZ3Exception()
+    {
+        // Arrange
+        using var context = new Z3Context();
+        var theorem = context.NewTheorem<LongFieldCollectionEnvironment>()
+            .Where(t => t.Values[0] == 1L);
 
         // Act & Assert
-        Should.Throw<InvalidCastException>(() => theorem.Solve());
+        Should.Throw<Microsoft.Z3.Z3Exception>(() => theorem.Solve());
+    }
+
+    /// <summary>
+    /// KNOWN DEFECT (#78): a collection that is null on a freshly constructed environment throws
+    /// <see cref="NullReferenceException"/>.
+    /// </summary>
+    /// <remarks>
+    /// The count is read straight off the value the member holds, with no null check, so an
+    /// environment that declares a collection without initialising it fails with nothing naming
+    /// the member at fault. This predates #53 - the property form below has always behaved this
+    /// way - so fixing #53 gave fields the same behaviour rather than introducing it.
+    /// These tests pin current behaviour and must be updated when the defect is fixed.
+    /// </remarks>
+    [TestMethod]
+    public void Solve_NullCollectionInAPublicField_ThrowsNullReferenceException()
+    {
+        // Arrange
+        using var context = new Z3Context();
+        var theorem = context.NewTheorem<NullFieldCollectionEnvironment>();
+
+        // Act & Assert
+        Should.Throw<NullReferenceException>(() => theorem.Solve());
+    }
+
+    /// <summary>
+    /// KNOWN DEFECT (#78). The property form, which behaved this way before #53 was fixed too.
+    /// </summary>
+    [TestMethod]
+    public void Solve_NullCollectionInAPublicProperty_ThrowsNullReferenceException()
+    {
+        // Arrange
+        using var context = new Z3Context();
+        var theorem = context.NewTheorem<NullPropertyCollectionEnvironment>();
+
+        // Act & Assert
+        Should.Throw<NullReferenceException>(() => theorem.Solve());
+    }
+
+    /// <summary>
+    /// KNOWN DEFECT (#78): a collection in a tuple environment can never work.
+    /// </summary>
+    /// <remarks>
+    /// A <c>ValueTuple</c> exposes its elements as public fields, so a tuple environment takes the
+    /// branch #53 fixed. It still cannot hold a collection: the length comes from the instance,
+    /// the instance is created with <c>Activator.CreateInstance</c>, and a tuple has nowhere to
+    /// put an initialiser - so the element is always null. #78 is structural for tuples rather
+    /// than a matter of remembering to initialise something.
+    /// This test pins current behaviour and must be updated when the defect is fixed.
+    /// </remarks>
+    [TestMethod]
+    public void Solve_CollectionInAValueTupleEnvironment_ThrowsNullReferenceException()
+    {
+        // Arrange
+        using var context = new Z3Context();
+        var theorem = context.NewTheorem<(int[] Values, int Other)>().Where(t => t.Other == 1);
+
+        // Act & Assert
+        Should.Throw<NullReferenceException>(() => theorem.Solve());
     }
 
     /// <summary>
@@ -320,7 +559,52 @@ public class CollectionSymbolTests
     private sealed class FieldCollectionEnvironment
     {
         public int[] Values = new int[2];
+    }
 
-        public int Length { get; set; }
+    private sealed class FieldListEnvironment
+    {
+        public List<int> Values = [0, 0];
+    }
+
+    private sealed class FieldAndPropertyCollectionEnvironment
+    {
+        public int[] FieldValues = new int[1];
+
+        public int[] PropertyValues { get; set; } = new int[1];
+    }
+
+    private sealed class FieldCollectionHolder
+    {
+        public int[] Values = new int[2];
+    }
+
+    private sealed class NestedFieldCollectionEnvironment
+    {
+        public FieldCollectionHolder Inner { get; set; } = new();
+    }
+
+    private sealed class ReadOnlyFieldCollectionEnvironment
+    {
+        public readonly int[] Values = new int[2];
+    }
+
+    private sealed class EmptyFieldCollectionEnvironment
+    {
+        public int[] Values = [];
+    }
+
+    private sealed class LongFieldCollectionEnvironment
+    {
+        public long[] Values = new long[2];
+    }
+
+    private sealed class NullFieldCollectionEnvironment
+    {
+        public int[]? Values = null;
+    }
+
+    private sealed class NullPropertyCollectionEnvironment
+    {
+        public int[]? Values { get; set; }
     }
 }

--- a/solutions/Z3.Linq.Tests/EnvironmentTypeTests.cs
+++ b/solutions/Z3.Linq.Tests/EnvironmentTypeTests.cs
@@ -8,8 +8,8 @@ namespace Z3.Linq.Tests;
 /// <para>
 /// Two code paths sit behind these. A compiler-generated type - an anonymous type - is created
 /// uninitialised and populated by writing to the compiler's backing fields, matched by name
-/// (Theorem.cs:607-648). Everything else is created with <c>Activator.CreateInstance</c> and
-/// populated through its properties and fields (Theorem.cs:651-696).
+/// (Theorem.cs:610-651). Everything else is created with <c>Activator.CreateInstance</c> and
+/// populated through its properties and fields (Theorem.cs:654-699).
 /// </para>
 /// <para>
 /// The split matters because the two support different types. The anonymous path handles only
@@ -107,7 +107,7 @@ public class EnvironmentTypeTests
     /// The anonymous-type path supports only <c>bool</c> and <c>int</c>.
     /// </summary>
     /// <remarks>
-    /// Theorem.cs:645 throws for any other property type, so a double that is perfectly usable
+    /// Theorem.cs:648 throws for any other property type, so a double that is perfectly usable
     /// in a named environment cannot be used in an anonymous one. This is a real restriction
     /// rather than a defect - the branch never grew the other cases - but it is undocumented,
     /// and the failure names the property rather than explaining the restriction.
@@ -185,7 +185,7 @@ public class EnvironmentTypeTests
     /// A positional record cannot be used as an environment.
     /// </summary>
     /// <remarks>
-    /// Environments are constructed with <c>Activator.CreateInstance(t)</c> (Theorem.cs:653),
+    /// Environments are constructed with <c>Activator.CreateInstance(t)</c> (Theorem.cs:657),
     /// and a positional record's only constructor takes its members, so there is nothing to
     /// call. This is the distinction the stale comment on RecordTheorem was probably reaching
     /// for: records work, positional records do not.

--- a/solutions/Z3.Linq.Tests/SymbolTypeMarshallingTests.cs
+++ b/solutions/Z3.Linq.Tests/SymbolTypeMarshallingTests.cs
@@ -184,7 +184,7 @@ public class SymbolTypeMarshallingTests
     /// KNOWN DEFECT (#54): a float symbol solves but cannot be marshalled back.
     /// </summary>
     /// <remarks>
-    /// TypeCode.Single parses the model value into a double (Theorem.cs:527) and then writes it
+    /// TypeCode.Single parses the model value into a double (Theorem.cs:530) and then writes it
     /// to a float property, which reflection rejects. Note this fails later than short does -
     /// translation and solving both succeed, so only the result is lost.
     /// This test pins current behaviour and must be updated when the defect is fixed.

--- a/solutions/Z3.Linq/Theorem.cs
+++ b/solutions/Z3.Linq/Theorem.cs
@@ -435,8 +435,11 @@ public class Theorem
 
                 int existingLength = parameter switch
                 {
-                    PropertyInfo info => ((ICollection)info.GetValue(destinationObject, null)!).Count,
-                    FieldInfo info1 => ((ICollection)info1).Count,
+                    // Both branches read the value the member holds on the instance. The field
+                    // branch used to cast the FieldInfo itself, which no environment could
+                    // satisfy - see #53.
+                    PropertyInfo property => ((ICollection)property.GetValue(destinationObject, null)!).Count,
+                    FieldInfo field => ((ICollection)field.GetValue(destinationObject)!).Count,
                     _ => 0
                 };
 


### PR DESCRIPTION
Fixes #53.

## The defect

Working out how many elements of a collection symbol to marshal cast the reflection object itself:

```csharp
int existingLength = parameter switch
{
    PropertyInfo info => ((ICollection)info.GetValue(destinationObject, null)!).Count,
    FieldInfo info1 => ((ICollection)info1).Count,   // the FieldInfo, not its value
    _ => 0
};
```

A `FieldInfo` is not an `ICollection`, so this could never succeed for any environment:

```csharp
private sealed class Env
{
    public int[] Values = new int[2];
}

using var ctx = new Z3Context();
ctx.NewTheorem<Env>().Where(t => t.Values[0] == 1).Solve();
// System.InvalidCastException: Unable to cast object of type
// 'System.Reflection.RtFieldInfo' to type 'System.Collections.ICollection'.
```

Measured across the shapes a collection field can take, solving for the values shown:

| Environment shape | Before | After |
|---|---|---|
| `int[]` field | `InvalidCastException` | `[1, 2]` |
| `List<int>` field | `InvalidCastException` | `[7, 8]` |
| `int[]` field on a nested object | `InvalidCastException` | `[9, 10]` |
| `readonly int[]` field | `InvalidCastException` | `[3, 4]` |
| empty `int[]` field | `InvalidCastException` | `[]` |
| `int[]` field, nothing constrained | `InvalidCastException` | length preserved |
| `int[]` field and `int[]` property together | `InvalidCastException` | both round-trip |
| `int[]` field, optimised with `OrderByDescending` | `InvalidCastException` | `9` |
| `long[]` field | `Z3Exception` (#64) | `Z3Exception` (#64) |
| `int[]?` field left null | `InvalidCastException` | `NullReferenceException` (#78) |
| `int` scalar field | `42` | `42` |

The last row is why this went unnoticed: scalar fields were always fine, and the library's own
examples put collections in properties. The `long[]` row is there to show the fix does not widen
which element types a field supports - #64 still rules everything but `int` out, for fields
exactly as for properties.

## The change

```csharp
int existingLength = parameter switch
{
    PropertyInfo property => ((ICollection)property.GetValue(destinationObject, null)!).Count,
    FieldInfo field => ((ICollection)field.GetValue(destinationObject)!).Count,
    _ => 0
};
```

The rename is part of the fix rather than tidying. `info` and `info1` are indistinguishable at a
glance, which is how a branch that reads nothing at all sat next to one that reads correctly; with
the two arms named after what they match, the asymmetry would have been visible.

The three added lines shift everything below by three, so the nine `Theorem.cs:NNN` citations in
the test suite are corrected in the same commit. Four of them had already drifted by up to seven
lines - `Theorem.cs:490` for the collection constructor is really 497 - so each was checked against
its target rather than blindly shifted.

## Tests

155 -> 166. The `#53` pin is rewritten as a round-trip test; the other eleven walk the
materialisation loop that the fix makes reachable through a field, since none of it had ever run
that way before.

| Test | What it covers |
|---|---|
| `Solve_IntArrayInAPublicField_RoundTripsEveryElement` | the case in the issue |
| `Solve_GenericIntCollectionInAPublicField_RoundTripsEveryElement` | the non-array branch, reconstructed through the collection's constructor |
| `Solve_CollectionsInAFieldAndAPropertySideBySide_RoundTripBoth` | one environment, both arms, neither throwing |
| `Solve_CollectionInAPublicFieldOfANestedObject_RoundTripsEveryElement` | the count is read from the inner instance, which is the argument the defect got wrong |
| `Solve_CollectionInAReadOnlyField_RoundTripsEveryElement` | `readonly` buys no protection - `FieldInfo.SetValue` writes it anyway |
| `Solve_EmptyCollectionInAPublicField_ReturnsAnEmptyCollection` | count of zero, loop never runs |
| `Solve_UnconstrainedCollectionInAPublicField_PreservesTheInitialisedLength` | length comes from the instance, not the model |
| `OrderByDescending_OverAnElementOfACollectionField_ReturnsTheOptimum` | the optimiser reads back through the same code |
| `Solve_LongArrayInAPublicField_ThrowsZ3Exception` | #64 pin, so the fix cannot be mistaken for widening element types |
| `Solve_NullCollectionInAPublicField_ThrowsNullReferenceException` | #78 pin |
| `Solve_NullCollectionInAPublicProperty_ThrowsNullReferenceException` | #78 pin - the property form, which behaved this way already |
| `Solve_CollectionInAValueTupleEnvironment_ThrowsNullReferenceException` | #78 pin - the case that cannot be worked around |

## Mutation results

| Mutation | Failures | Which |
|---|---|---|
| Revert the field arm to `((ICollection)info1).Count` | **10** | every new test except the `long[]` pin, which fails during translation first, and the null-*property* pin, which never touches the field arm |
| `FieldInfo field => 0` | **9** | the same ten minus the empty-collection test, which expects zero anyway - that test is the one case a zero-count mutation is invisible to, which is the point of having it |
| `numVal = 0` in the int element arm | **13** | 6 of the new field tests, 4 existing property-collection tests, and all 3 Missionaries and Cannibals acceptance tests. Confirms the value assertions have teeth rather than the tests only checking that nothing threw |

## Found along the way

**#78** - a collection symbol that is null on a freshly constructed environment throws
`NullReferenceException`, with nothing naming the member at fault. That predates this fix for
properties, and fields now share it rather than it being introduced here. The sharper half is that
a **collection in a `ValueTuple` environment can never work**: a tuple exposes its elements as
public fields, so it takes the branch fixed here, but the instance is built with
`Activator.CreateInstance` and a tuple has nowhere to put an initialiser, so the element is always
null. Raised, not fixed; all three shapes are pinned.

## Verification

- `dotnet build solutions/Z3.Linq.slnx -c Release` - clean, `TreatWarningsAsErrors` on
- 166/166 locally, 1.6s
- `./build.ps1 -Configuration Release` - 46 tasks, 0 errors, 0 warnings
- Coverage 75.8% -> 76.0% line (635 of 835), branch unchanged at 69.3%. Only +2 lines, because the
  materialisation block was already reached through properties - the fix opens a second door onto
  code that was mostly covered, and the value of the new tests is in the paths they distinguish
  rather than the lines they add

## Release note

Releases remain on hold under #60 until Microsoft.Z3 5.x reaches nuget.org, so this reaches `main`
but not consumers. Nothing about the hold changes.
