### PR TITLE
Read a float symbol back as a float

### DIFF
--- a/solutions/Z3.Linq.Tests/CollectionSymbolTests.cs
+++ b/solutions/Z3.Linq.Tests/CollectionSymbolTests.cs
@@ -179,6 +179,29 @@ public class CollectionSymbolTests
     }
 
     /// <summary>
+    /// KNOWN DEFECT (#64), and the reason the array half of #54 cannot be observed.
+    /// </summary>
+    /// <remarks>
+    /// The element loop has its own <c>TypeCode.Single</c> arm with the same defect #54 fixed on
+    /// the scalar path, and it was corrected in the same commit. No test can reach it: a float
+    /// array declares a floating-point range against a real-valued constraint and never survives
+    /// translation, exactly as a double array does not.
+    /// This test pins current behaviour and must be updated when the defect is fixed.
+    /// </remarks>
+    [TestMethod]
+    public void Solve_FloatArraySymbol_ThrowsZ3Exception()
+    {
+        // Arrange
+        using var context = new Z3Context();
+        var theorem = context.NewTheorem<FloatArrayEnvironment>()
+            .Where(t => t.Values[0] == 1.5f)
+            .Where(t => t.Length == 2);
+
+        // Act & Assert
+        Should.Throw<Microsoft.Z3.Z3Exception>(() => theorem.Solve());
+    }
+
+    /// <summary>
     /// KNOWN DEFECT (#64), and the reason #55 cannot currently be observed.
     /// </summary>
     /// <remarks>
@@ -545,6 +568,13 @@ public class CollectionSymbolTests
     private sealed class DoubleArrayEnvironment
     {
         public double[] Values { get; set; } = new double[2];
+
+        public int Length { get; set; }
+    }
+
+    private sealed class FloatArrayEnvironment
+    {
+        public float[] Values { get; set; } = new float[2];
 
         public int Length { get; set; }
     }

--- a/solutions/Z3.Linq.Tests/CultureInvarianceTests.cs
+++ b/solutions/Z3.Linq.Tests/CultureInvarianceTests.cs
@@ -122,32 +122,34 @@ public class CultureInvarianceTests
     }
 
     /// <summary>
-    /// A <c>float</c> constant gets past translation under a foreign culture and fails at the
-    /// read back instead - which is #54, not #52.
+    /// A <c>float</c> constant survives a foreign culture like the other two real types.
     /// </summary>
     /// <remarks>
     /// <c>float</c> takes the same arm of the constant switch as <c>double</c> and
-    /// <c>decimal</c>, so without this the fix would have a third of its call site untested. It
-    /// cannot be a round-trip test, because a float symbol cannot round-trip at all: the model
-    /// value is parsed into a double and reflection then refuses to write it to a float
-    /// property. Under the defect this threw <c>Z3Exception</c> during translation, so reaching
-    /// <see cref="ArgumentException"/> is itself the evidence that translation now succeeds.
+    /// <c>decimal</c>, so without this the #52 fix would have a third of its call site untested.
+    /// It could only assert an <see cref="ArgumentException"/> when it was written, because a
+    /// float symbol could not round-trip at all: #54 parsed the model value into a double and
+    /// reflection refused to write that to a float property. Now that #54 is fixed it says what
+    /// it always wanted to.
     /// </remarks>
     [TestMethod]
-    public void Solve_FloatConstantUnderANonInvariantCulture_FailsInMarshallingNotTranslation()
+    public void Solve_FloatConstantUnderANonInvariantCulture_RoundTripsTheValue()
     {
         // Arrange
         const string Culture = "de-DE";
         CultureInfo cultureInfo = RequireANonInvariantRendering(Culture, 1.5f);
 
-        // Act & Assert
-        Should.Throw<ArgumentException>(() => SolveOn(cultureInfo, () =>
+        // Act
+        float? value = SolveOn(cultureInfo, () =>
         {
             using var context = new Z3Context();
             return context.NewTheorem<Symbols<float, int>>()
                 .Where(t => t.X1 == 1.5f)
                 .Solve()?.X1;
-        }));
+        });
+
+        // Assert
+        value.ShouldBe(1.5f);
     }
 
     /// <summary>

--- a/solutions/Z3.Linq.Tests/SymbolTypeMarshallingTests.cs
+++ b/solutions/Z3.Linq.Tests/SymbolTypeMarshallingTests.cs
@@ -11,10 +11,10 @@ namespace Z3.Linq.Tests;
 /// which solution was chosen.
 /// </para>
 /// <para>
-/// Three of the types listed as supported do not work, and are pinned as characterisation tests
-/// rather than skipped - short (#63), float (#54) and DateTime (#56). All three fail in the
-/// marshalling layer, which no example in the repository exercises, which is why they went
-/// unnoticed.
+/// Two of the types listed as supported do not work, and are pinned as characterisation tests
+/// rather than skipped - short (#63) and DateTime (#56). Both fail in the marshalling layer,
+/// which no example in the repository exercises, which is why they went unnoticed. float was a
+/// third until #54 was fixed.
 /// </para>
 /// </remarks>
 [TestClass]
@@ -181,24 +181,131 @@ public class SymbolTypeMarshallingTests
     }
 
     /// <summary>
-    /// KNOWN DEFECT (#54): a float symbol solves but cannot be marshalled back.
+    /// A <c>float</c> symbol round-trips the value it was constrained to.
     /// </summary>
     /// <remarks>
-    /// TypeCode.Single parses the model value into a double (Theorem.cs:530) and then writes it
-    /// to a float property, which reflection rejects. Note this fails later than short does -
-    /// translation and solving both succeed, so only the result is lost.
+    /// The case in #54. <c>TypeCode.Single</c> parsed the model value with <c>double.Parse</c>,
+    /// so a perfectly good answer was boxed as a <c>double</c> and reflection then refused to
+    /// write it to a <c>float</c> member. Nothing about the solve was wrong - translation, the
+    /// solver and the model were all fine, and only the last step lost the result.
+    /// </remarks>
+    [TestMethod]
+    [DataRow(1.5f, DisplayName = "Exactly representable")]
+    [DataRow(0f, DisplayName = "Zero")]
+    [DataRow(-2.25f, DisplayName = "Negative")]
+    [DataRow(0.1f, DisplayName = "Not exactly representable in binary")]
+    [DataRow(1.2345678f, DisplayName = "Eight significant digits")]
+    [DataRow(float.MaxValue, DisplayName = "Single.MaxValue")]
+    public void Solve_FloatSymbol_RoundTripsTheValue(float value)
+    {
+        // Arrange
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<Symbols<float, int>>()
+            .Where(t => t.X1 == value)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.X1.ShouldBe(value);
+    }
+
+    /// <summary>
+    /// A <c>float</c> and a <c>double</c> in one environment each come back as their own type.
+    /// </summary>
+    /// <remarks>
+    /// The two share the real sort and sit on adjacent arms of the marshalling switch, differing
+    /// only in how many decimal places they ask the model for. A fix that made <c>float</c> work
+    /// by treating it as a <c>double</c> would pass every test above and fail here.
+    /// </remarks>
+    [TestMethod]
+    public void Solve_FloatAndDoubleSymbolsTogether_MarshalEachToItsOwnType()
+    {
+        // Arrange
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<Symbols<float, double>>()
+            .Where(t => t.X1 == 1.5f)
+            .Where(t => t.X2 == 2.5)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.X1.ShouldBe(1.5f);
+        result.X2.ShouldBe(2.5);
+    }
+
+    /// <summary>
+    /// KNOWN DEFECT (#6): a value whose decimal expansion does not terminate cannot be read back.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <c>RatNum.ToDecimalString</c> marks a truncated expansion by appending <c>?</c>, and
+    /// neither the <c>Single</c> nor the <c>Double</c> arm strips it before parsing - only the
+    /// <c>Decimal</c> arm does. A third solves perfectly well and then fails on the way out with
+    /// <c>The input string '0.33333333333333333333333333333333?' was not in a correct format</c>.
+    /// </para>
+    /// <para>
+    /// This is not #54 and was not introduced by fixing it: the <c>double</c> case below fails
+    /// identically, at 64 decimal places rather than 32. Both are here so the defect is recorded
+    /// as shared rather than looking like a float problem.
+    /// These tests pin current behaviour and must be updated when the defect is fixed.
+    /// </para>
+    /// </remarks>
+    [TestMethod]
+    public void Solve_FloatSymbolWithANonTerminatingValue_ThrowsFormatException()
+    {
+        // Arrange: a third has no finite decimal expansion, so the model value comes back
+        // truncated and flagged.
+        using var context = new Z3Context();
+        var theorem = context.NewTheorem<Symbols<float, int>>()
+            .Where(t => t.X1 * 3 == 1);
+
+        // Act & Assert
+        Should.Throw<FormatException>(() => theorem.Solve());
+    }
+
+    /// <summary>
+    /// KNOWN DEFECT (#6). The <c>double</c> form, which behaves identically.
+    /// See <see cref="Solve_FloatSymbolWithANonTerminatingValue_ThrowsFormatException"/>.
+    /// </summary>
+    [TestMethod]
+    public void Solve_DoubleSymbolWithANonTerminatingValue_ThrowsFormatException()
+    {
+        // Arrange
+        using var context = new Z3Context();
+        var theorem = context.NewTheorem<Symbols<double, int>>()
+            .Where(t => t.X1 * 3 == 1);
+
+        // Act & Assert
+        Should.Throw<FormatException>(() => theorem.Solve());
+    }
+
+    /// <summary>
+    /// KNOWN DEFECT (#6): the smallest positive <c>float</c> cannot be read back either, because
+    /// 32 decimal places cannot express it at all.
+    /// </summary>
+    /// <remarks>
+    /// The <c>Single</c> arm asks the model for 32 decimal places, which reads as a nod to
+    /// float's 32 bits but is a count of decimal digits after the point. <c>Single.Epsilon</c> is
+    /// about 1.4e-45, so every one of those 32 places is a zero and the value is reported as
+    /// <c>0.00000000000000000000000000000000?</c> - truncated to nothing. The <c>Double</c> arm
+    /// has the same shape at 64 places against a range reaching 5e-324, so this is a property of
+    /// the pair rather than of float.
     /// This test pins current behaviour and must be updated when the defect is fixed.
     /// </remarks>
     [TestMethod]
-    public void Solve_FloatSymbol_ThrowsArgumentException()
+    public void Solve_FloatSymbolAtItsSmallestPositiveValue_ThrowsFormatException()
     {
         // Arrange
         using var context = new Z3Context();
         var theorem = context.NewTheorem<Symbols<float, int>>()
-            .Where(t => t.X1 == 1.5f);
+            .Where(t => t.X1 == float.Epsilon);
 
         // Act & Assert
-        Should.Throw<ArgumentException>(() => theorem.Solve());
+        Should.Throw<FormatException>(() => theorem.Solve());
     }
 
     /// <summary>
@@ -261,15 +368,16 @@ public class SymbolTypeMarshallingTests
     /// </summary>
     /// <remarks>
     /// <para>
-    /// The tests above pin what each type does with a value; these five pin what each does with
+    /// The tests above pin what each type does with a value; these six pin what each does with
     /// no value at all. Every type takes a different arm of the marshalling switch, so each can
     /// regress on its own, and all but <c>bool</c> threw before #51. The value a free symbol
     /// comes back with is supplied by model completion and is deliberately not asserted.
     /// </para>
     /// <para>
-    /// <c>short</c> and <c>float</c> are absent on purpose: an unconstrained one now evaluates
-    /// cleanly and then fails at the reflection write, which is #63 and #54 respectively rather
-    /// than anything to do with completion. Their pins above are unchanged.
+    /// <c>short</c> is absent on purpose: an unconstrained one evaluates cleanly and then fails
+    /// at the reflection write, which is #63 rather than anything to do with completion. Its pin
+    /// above is unchanged. <c>float</c> failed the same way until #54 was fixed, and now has a
+    /// case here like every other working type.
     /// </para>
     /// </remarks>
     [TestMethod]
@@ -297,6 +405,23 @@ public class SymbolTypeMarshallingTests
 
         // Act
         var result = context.NewTheorem<Symbols<double, int>>()
+            .Where(t => t.X2 == 0)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.X2.ShouldBe(0);
+    }
+
+    [TestMethod]
+    public void Solve_UnconstrainedFloatSymbol_ReturnsAResult()
+    {
+        // Arrange: the other real-sorted arm, which needs both #51 and #54 to get here - model
+        // completion to produce a numeral at all, and a float.Parse to write it anywhere.
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<Symbols<float, int>>()
             .Where(t => t.X2 == 0)
             .Solve();
 

--- a/solutions/Z3.Linq/Theorem.cs
+++ b/solutions/Z3.Linq/Theorem.cs
@@ -468,7 +468,7 @@ public class Theorem
                             numVal = numValExpr.IsTrue;
                             break;
                         case TypeCode.Single:
-                            numVal = double.Parse(((RatNum)numValExpr).ToDecimalString(32), CultureInfo.InvariantCulture);
+                            numVal = float.Parse(((RatNum)numValExpr).ToDecimalString(32), CultureInfo.InvariantCulture);
                             break;
                         case TypeCode.Decimal:
                             Expr val = EvaluateWithCompletion(model, subEnv.Expr ?? throw new ArgumentException(
@@ -528,7 +528,7 @@ public class Theorem
                     value = val.IsTrue;
                     break;
                 case TypeCode.Single:
-                    value = double.Parse(((RatNum)val).ToDecimalString(32), CultureInfo.InvariantCulture);
+                    value = float.Parse(((RatNum)val).ToDecimalString(32), CultureInfo.InvariantCulture);
                     break;
                 case TypeCode.Decimal:
 


### PR DESCRIPTION
Fixes #54.

## The defect

`TypeCode.Single` read the model value with `double.Parse`:

```csharp
case TypeCode.Single:
    value = double.Parse(((RatNum)val).ToDecimalString(32), CultureInfo.InvariantCulture);
```

so a solved `float` symbol came back boxed as a `double`, and the reflection write that follows
refused it:

```csharp
using var ctx = new Z3Context();
ctx.NewTheorem<Symbols<float, int>>().Where(t => t.X1 == 1.5f).Solve();
// System.ArgumentException: Object of type 'System.Double' cannot be converted to
// type 'System.Single'.
```

Nothing else about the solve was wrong. Declaring the symbol (`MkRealConst`), translating the
constant and solving all succeeded; only the last step lost the answer. Measured across the shapes
a float symbol can take:

| Shape | Before | After |
|---|---|---|
| `X1 == 1.5f` | `ArgumentException` | `1.5` |
| `X1 == 0.1f` - not exactly representable in binary | `ArgumentException` | `0.1` |
| `X1 == 1.2345678f` - eight significant digits | `ArgumentException` | `1.2345678` |
| `X1 == -2.75f` | `ArgumentException` | `-2.75` |
| `X1 == float.MaxValue` | `ArgumentException` | `3.4028235E+38` |
| `2.5f < X1 < 2.75f` | `ArgumentException` | `2.625` |
| unconstrained | `ArgumentException` | `0` |
| maximised with `OrderByDescending` | `ArgumentException` | `4.5` |
| in a public field, and in a nested object | `ArgumentException` | `1.5` |
| alongside a `double` symbol | `ArgumentException` | `1.5` / `2.5` |
| `float[]` | `Z3Exception` (#64) | `Z3Exception` (#64) |
| `X1 * 3 == 1` | `FormatException` (#6) | `FormatException` (#6) |
| `X1 == float.Epsilon` | `FormatException` (#6) | `FormatException` (#6) |

## The change

Two characters at each of two sites:

```csharp
case TypeCode.Single:
    value = float.Parse(((RatNum)val).ToDecimalString(32), CultureInfo.InvariantCulture);
```

**Why `float.Parse` rather than `(float)double.Parse`.** The issue notes a design choice about
precision here. Parsing to `double` and narrowing rounds twice - to the nearest double, then to the
nearest float - and the two roundings can disagree with a single rounding to float. Parsing
straight to float rounds once, which is the answer the model actually names.

Being straight about the evidence: **I could not make that difference observable.** Both forms were
tried against the strings this path produces, including the classic double-rounding candidates
`16777217` and `1.00000005960464477539062`, and every result was bit-identical; the whole suite
passes either way. So the choice rests on the argument rather than on a failing test, and the PR
should not pretend otherwise.

**The array element arm** at `Theorem.cs:471` carried the same defect and is corrected in the same
commit, on the issue's own reading. It cannot be verified: a `float[]` declares a floating-point
range against a real-valued constraint and dies during translation under #64, so reverting that
site alone fails nothing at all. Stated plainly rather than counted as covered - the same position
PR #73 took on the decimal element site.

**What is deliberately not changed** is the `32` in `ToDecimalString(32)`. It reads as a nod to
float's 32 bits but is a count of decimal places, and it is too coarse for float's range - which is
why `float.Epsilon` comes back as `0.00000000000000000000000000000000?` and fails to parse. That is
#6, not #54: the `Double` arm has exactly the same shape at 64 places against a range reaching
5e-324, and `X1 * 3 == 1` over a `double` fails identically today. Fixing the type without
disturbing the precision keeps the two arms parallel and leaves #6 as one defect rather than half of
one.

## Tests

166 -> 177. The `#54` pin becomes a round-trip test, and the `#52` culture test that could only
assert an `ArgumentException` now says what it always wanted to.

| Test | What it covers |
|---|---|
| `Solve_FloatSymbol_RoundTripsTheValue` (6 rows) | exactly representable, zero, negative, not representable in binary, eight significant digits, `Single.MaxValue` |
| `Solve_FloatAndDoubleSymbolsTogether_MarshalEachToItsOwnType` | the two share the real sort and adjacent switch arms - a fix that made float work by treating it as a double passes every other test and fails this one |
| `Solve_UnconstrainedFloatSymbol_ReturnsAResult` | fills the one hole in the existing unconstrained-symbol family, which listed float as absent because of this defect |
| `Solve_FloatConstantUnderANonInvariantCulture_RoundTripsTheValue` | rewritten from `_FailsInMarshallingNotTranslation` |
| `Solve_FloatSymbolWithANonTerminatingValue_ThrowsFormatException` | #6 pin |
| `Solve_DoubleSymbolWithANonTerminatingValue_ThrowsFormatException` | #6 pin - the double form, so the defect is recorded as shared rather than looking like a float problem |
| `Solve_FloatSymbolAtItsSmallestPositiveValue_ThrowsFormatException` | #6 pin - 32 decimal places cannot express `Single.Epsilon` at all |
| `Solve_FloatArraySymbol_ThrowsZ3Exception` | #64 pin, and the record of why the array half of this fix is unverifiable |

The three #6 pins are the first coverage that defect has had. It was found by measuring rather than
inferred: `float.Epsilon` and a third both fail before ever reaching the write this PR fixes.

## Mutation results

| Mutation | Failures | Which |
|---|---|---|
| Revert the scalar site to `double.Parse` | **9** | all six round-trip rows, the float/double pair, the unconstrained float, and the culture test |
| Revert the array site to `double.Parse` | **0** | unreachable behind #64, exactly as stated above |
| `(float)double.Parse(...)` - the alternative fix | **0** | the tests do not distinguish the two, and neither did any input I could construct |
| `value = 0f` | **9** | the five non-zero round-trip rows, the float/double pair, and - the interesting part - both #6 pins, which stop throwing. Confirms they assert a real parse attempt rather than incidental behaviour |

## Verification

- `dotnet build solutions/Z3.Linq.slnx -c Release` - clean, `TreatWarningsAsErrors` on
- 177/177 locally, 1.8s
- `./build.ps1 -Configuration Release` - 46 tasks, 0 errors, 0 warnings
- Coverage 76.0% -> 76.7% line (641 of 835), 69.3% -> 69.6% branch. The float marshalling path
  previously ran into a dead end, so these are lines that had never completed before

## Release note

Releases remain on hold under #60 until Microsoft.Z3 5.x reaches nuget.org, so this reaches `main`
but not consumers. Nothing about the hold changes.
