### PR TITLE
Read the decimal element the loop selected

### DIFF
--- a/solutions/Z3.Linq.Tests/CollectionSymbolTests.cs
+++ b/solutions/Z3.Linq.Tests/CollectionSymbolTests.cs
@@ -217,7 +217,6 @@ public class CollectionSymbolTests
     /// is where the three tests below observe the #55 fix.
     /// This test pins current behaviour and must be updated when the defect is fixed.
     /// </remarks>
-    /// </remarks>
     [TestMethod]
     public void Solve_DecimalArraySymbol_ThrowsZ3Exception()
     {

--- a/solutions/Z3.Linq.Tests/CollectionSymbolTests.cs
+++ b/solutions/Z3.Linq.Tests/CollectionSymbolTests.cs
@@ -14,9 +14,11 @@ namespace Z3.Linq.Tests;
 /// </para>
 /// <para>
 /// Only <c>int</c> elements work. Every other element type declares a domain or range that
-/// contradicts how the elements are constrained or read, and throws during translation; those
-/// cases are pinned below against #64. The Sudoku examples are all <c>int</c>, which is why the
-/// limitation has gone unnoticed.
+/// contradicts how the elements are constrained or read; those cases are pinned below against
+/// #64. Where they fail depends on the constraint - one naming a constant of the element type
+/// fails during translation, while elements left free solve cleanly and fail in the marshalling
+/// loop instead. The Sudoku examples are all <c>int</c>, which is why the limitation has gone
+/// unnoticed.
 /// </para>
 /// <para>
 /// A collection symbol can be a property or a public field, and since #53 the two behave
@@ -112,7 +114,7 @@ public class CollectionSymbolTests
     {
         // Arrange: the non-array branch, reached for a generic type implementing IEnumerable.
         // It is reconstructed by passing the element array to the collection's constructor
-        // (Theorem.cs:497), which List<int> supports.
+        // (Theorem.cs:496), which List<int> supports.
         using var context = new Z3Context();
 
         // Act
@@ -183,9 +185,13 @@ public class CollectionSymbolTests
     /// </summary>
     /// <remarks>
     /// The element loop has its own <c>TypeCode.Single</c> arm with the same defect #54 fixed on
-    /// the scalar path, and it was corrected in the same commit. No test can reach it: a float
-    /// array declares a floating-point range against a real-valued constraint and never survives
-    /// translation, exactly as a double array does not.
+    /// the scalar path, and it was corrected in the same commit. Nothing reaches the parse it
+    /// contains. The shape below fails during translation, because a float array declares a
+    /// floating-point range against a real-valued constraint, exactly as a double array does;
+    /// leaving the elements free instead gets past translation but no further than the cast on
+    /// the line before the parse, as
+    /// <see cref="Solve_DecimalArrayWithFreeElements_CastsTheElementNotTheArray"/> shows for the
+    /// neighbouring arm.
     /// This test pins current behaviour and must be updated when the defect is fixed.
     /// </remarks>
     [TestMethod]
@@ -202,12 +208,15 @@ public class CollectionSymbolTests
     }
 
     /// <summary>
-    /// KNOWN DEFECT (#64), and the reason #55 cannot currently be observed.
+    /// KNOWN DEFECT (#64): a decimal array constrained against a decimal constant does not survive
+    /// translation.
     /// </summary>
     /// <remarks>
-    /// #55 describes the decimal element branch evaluating the whole array expression instead of
-    /// the selected element (Theorem.cs:474-477), which would give every element the same value.
-    /// That code is still wrong, but unreachable: a decimal array never survives translation.
+    /// This is the shape #64 lists, and the reason it concluded the element loop was unreachable
+    /// for a decimal. It is not the only shape: leaving the elements free reaches the loop, which
+    /// is where the three tests below observe the #55 fix.
+    /// This test pins current behaviour and must be updated when the defect is fixed.
+    /// </remarks>
     /// </remarks>
     [TestMethod]
     public void Solve_DecimalArraySymbol_ThrowsZ3Exception()
@@ -220,6 +229,98 @@ public class CollectionSymbolTests
 
         // Act & Assert
         Should.Throw<Microsoft.Z3.Z3Exception>(() => theorem.Solve());
+    }
+
+    /// <summary>
+    /// The defect in #55: the decimal arm of the element loop evaluated the whole array constant
+    /// instead of the element the loop had just selected.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Every other arm of that loop reads <c>numValExpr</c>, the result of
+    /// <c>MkSelect(arrVal, MkInt(i))</c>. The decimal arm called <c>Eval</c> a second time on
+    /// <c>subEnv.Expr</c> - the array itself - and cast the result to
+    /// <see cref="Microsoft.Z3.RatNum"/>, which an array expression can never satisfy. The issue
+    /// describes the symptom as every element taking the same value or the cast failing; measured,
+    /// it is always the cast, in every shape a decimal collection can take.
+    /// </para>
+    /// <para>
+    /// A decimal collection still cannot be solved, because #64 declares its range as a
+    /// floating-point sort, so the assertion here is about which expression the cast rejects
+    /// rather than about a value. The load-bearing half is that the message no longer names an
+    /// array: that is #55, and reverting the fix fails on it. The element type it does name is
+    /// #64's sort mapping, and that half must be updated when #64 is fixed.
+    /// </para>
+    /// <para>
+    /// #64 records this code as unreachable. That holds only for a constraint naming a decimal
+    /// constant, which fails during translation; with the elements left free the theorem solves
+    /// and the element loop runs.
+    /// </para>
+    /// </remarks>
+    [TestMethod]
+    public void Solve_DecimalArrayWithFreeElements_CastsTheElementNotTheArray()
+    {
+        // Arrange
+        using var context = new Z3Context();
+        var theorem = context.NewTheorem<DecimalArrayEnvironment>()
+            .Where(t => t.Length == 2);
+
+        // Act
+        InvalidCastException exception = Should.Throw<InvalidCastException>(() => theorem.Solve());
+
+        // Assert
+        exception.Message.ShouldNotContain("ArrayExpr");
+        exception.Message.ShouldContain("FPNum");
+    }
+
+    /// <summary>
+    /// A generic collection takes the same element loop as an array, so the #55 fix reaches it
+    /// too.
+    /// </summary>
+    /// <remarks>
+    /// Worth its own case because the collection branch materialises the result differently -
+    /// <c>Activator.CreateInstance</c> against the constructed type rather than
+    /// <c>ToArray</c> - and only the element read is shared.
+    /// </remarks>
+    [TestMethod]
+    public void Solve_DecimalListWithFreeElements_CastsTheElementNotTheArray()
+    {
+        // Arrange
+        using var context = new Z3Context();
+        var theorem = context.NewTheorem<DecimalListEnvironment>()
+            .Where(t => t.Length == 2);
+
+        // Act
+        InvalidCastException exception = Should.Throw<InvalidCastException>(() => theorem.Solve());
+
+        // Assert
+        exception.Message.ShouldNotContain("ArrayExpr");
+        exception.Message.ShouldContain("FPNum");
+    }
+
+    /// <summary>
+    /// The element loop is reached by a theorem that genuinely constrains the elements, not only
+    /// by one that leaves them out of the constraints altogether.
+    /// </summary>
+    /// <remarks>
+    /// Relating two elements to each other puts both selects in the formula while naming no
+    /// decimal constant, so nothing forces the sort mismatch #64 describes and translation
+    /// succeeds. Without this the fix could be dismissed as only mattering to empty theorems.
+    /// </remarks>
+    [TestMethod]
+    public void Solve_DecimalArrayWithElementsConstrainedToEachOther_CastsTheElementNotTheArray()
+    {
+        // Arrange
+        using var context = new Z3Context();
+        var theorem = context.NewTheorem<DecimalArrayEnvironment>()
+            .Where(t => t.Values[0] == t.Values[1]);
+
+        // Act
+        InvalidCastException exception = Should.Throw<InvalidCastException>(() => theorem.Solve());
+
+        // Assert
+        exception.Message.ShouldNotContain("ArrayExpr");
+        exception.Message.ShouldContain("FPNum");
     }
 
     /// <summary>
@@ -582,6 +683,13 @@ public class CollectionSymbolTests
     private sealed class DecimalArrayEnvironment
     {
         public decimal[] Values { get; set; } = new decimal[2];
+
+        public int Length { get; set; }
+    }
+
+    private sealed class DecimalListEnvironment
+    {
+        public List<decimal> Values { get; set; } = [0m, 0m];
 
         public int Length { get; set; }
     }

--- a/solutions/Z3.Linq.Tests/EnvironmentTypeTests.cs
+++ b/solutions/Z3.Linq.Tests/EnvironmentTypeTests.cs
@@ -9,7 +9,7 @@ namespace Z3.Linq.Tests;
 /// Two code paths sit behind these. A compiler-generated type - an anonymous type - is created
 /// uninitialised and populated by writing to the compiler's backing fields, matched by name
 /// (Theorem.cs:610-651). Everything else is created with <c>Activator.CreateInstance</c> and
-/// populated through its properties and fields (Theorem.cs:654-699).
+/// populated through its properties and fields (Theorem.cs:653-699).
 /// </para>
 /// <para>
 /// The split matters because the two support different types. The anonymous path handles only
@@ -107,7 +107,7 @@ public class EnvironmentTypeTests
     /// The anonymous-type path supports only <c>bool</c> and <c>int</c>.
     /// </summary>
     /// <remarks>
-    /// Theorem.cs:648 throws for any other property type, so a double that is perfectly usable
+    /// Theorem.cs:647 throws for any other property type, so a double that is perfectly usable
     /// in a named environment cannot be used in an anonymous one. This is a real restriction
     /// rather than a defect - the branch never grew the other cases - but it is undocumented,
     /// and the failure names the property rather than explaining the restriction.
@@ -185,7 +185,7 @@ public class EnvironmentTypeTests
     /// A positional record cannot be used as an environment.
     /// </summary>
     /// <remarks>
-    /// Environments are constructed with <c>Activator.CreateInstance(t)</c> (Theorem.cs:657),
+    /// Environments are constructed with <c>Activator.CreateInstance(t)</c> (Theorem.cs:656),
     /// and a positional record's only constructor takes its members, so there is nothing to
     /// call. This is the distinction the stale comment on RecordTheorem was probably reaching
     /// for: records work, positional records do not.

--- a/solutions/Z3.Linq/Theorem.cs
+++ b/solutions/Z3.Linq/Theorem.cs
@@ -471,10 +471,9 @@ public class Theorem
                             numVal = float.Parse(((RatNum)numValExpr).ToDecimalString(32), CultureInfo.InvariantCulture);
                             break;
                         case TypeCode.Decimal:
-                            Expr val = EvaluateWithCompletion(model, subEnv.Expr ?? throw new ArgumentException(
-                    $"nameof(ConvertZ3Expression) requires {nameof(subEnv)}.{nameof(subEnv.Expr)} to be non-null",
-                    nameof(subEnv)));
-                            string numValue = ((RatNum)val).ToDecimalString(128);
+                            // Read the element the loop selected, not the array constant it was
+                            // selected from - every other arm here uses numValExpr. See #55.
+                            string numValue = ((RatNum)numValExpr).ToDecimalString(128);
 
                             ReadOnlySpan<char> numValueSpan = numValue.AsSpan();
                             if (numValue.EndsWith('?'))


### PR DESCRIPTION
Fixes #55.

## The defect

Inside the array element loop, every arm reads `numValExpr` - the element the loop selected with
`MkSelect(arrVal, MkInt(i))`. The `Decimal` arm did not. It called `Eval` a second time, on
`subEnv.Expr`, which is the array constant itself:

```csharp
case TypeCode.Decimal:
    Expr val = EvaluateWithCompletion(model, subEnv.Expr ?? throw new ArgumentException(...));
    string numValue = ((RatNum)val).ToDecimalString(128);
```

## What actually happens - the issue overstates one half and #64 overstates the other

**The issue** says every element gets the same wrong value *or* the cast fails outright. Measured, it
is always the cast: `subEnv.Expr` is an `ArrayExpr`, and no `ArrayExpr` is a `RatNum`. There is no
input that produces the same-value symptom - including with #64's sort mapping corrected locally, so
this is not #64 masking it.

**#64** says this code is unreachable because a `decimal[]` never survives translation. That is true
only of a constraint naming a decimal constant, which is the shape #64 tested. Leave the elements
free and the theorem solves normally, and the element loop runs:

| Shape | Before | After |
|---|---|---|
| `decimal[]`, elements free | `InvalidCastException: ... 'ArrayExpr' to type 'RatNum'` | `InvalidCastException: ... 'FPNum' to type 'RatNum'` |
| `List<decimal>`, elements free | `... 'ArrayExpr' ...` | `... 'FPNum' ...` |
| `decimal[]`, `Values[0] == Values[1]` | `... 'ArrayExpr' ...` | `... 'FPNum' ...` |
| `decimal[]`, `Values[0] == 1.5m` | `Z3Exception` (#64) | `Z3Exception` (#64) |

So #55 is observable, and the tests below observe it. What the fix changes is *which expression the
cast rejects*: after it, the decimal arm fails exactly where the `float` and `double` arms beside it
fail, on #64's floating-point range sort, rather than on a mistake of its own.

This reachability applies to the other element types too - `float[]`, `double[]` and `long[]` with
free elements all reach marshalling and fail at their cast rather than in translation. That is #64's
territory, not this PR's, but it does make the remark added for #54's array arm in #80 imprecise, so
that remark is corrected here in the file this PR already edits.

## The change

```csharp
case TypeCode.Decimal:
    // Read the element the loop selected, not the array constant it was
    // selected from - every other arm here uses numValExpr. See #55.
    string numValue = ((RatNum)numValExpr).ToDecimalString(128);
```

Three lines below `Theorem.cs:477` shift up by one; the four affected citations were checked against
their targets rather than shifted blindly, and one (`Theorem.cs:654-699`) was already off by a line
before this change.

## Evidence that the fix is right, not just different

The tests can only assert on the failure, because #64 still declares a decimal array's range as a
floating-point sort. To check the fix actually produces correct values, #64's `Decimal` mapping was
corrected locally - `IntSort` domain, `RealSort` range, two sites - and the probe re-run. **This
change is not in this PR**; it is how the fix was verified.

| Probe, with #64's decimal mapping corrected locally | #55 fixed | #55 reverted |
|---|---|---|
| `Values[0] == 1.5m`, `Values[1] == 2.5m` | `1.5, 2.5` | `InvalidCastException` |
| the same over a `List<decimal>` | `1.5, 2.5` | `InvalidCastException` |
| `decimal[3]`, first two constrained | `1.5, 2.5, 2.5` | `InvalidCastException` |
| `0.1m` and `decimal.MaxValue` | `0.1, 79228162514264337593543950335` | `InvalidCastException` |
| elements free | `0, 0` | `InvalidCastException` |

Each element takes its own value, at full decimal precision. That is the behaviour #55 asks for, and
it arrives the moment #64 stops standing in the way.

## Tests

177 -> 180, all in `CollectionSymbolTests`.

| Test | What it covers |
|---|---|
| `Solve_DecimalArrayWithFreeElements_CastsTheElementNotTheArray` | the fix itself: the cast rejects the element, not the array |
| `Solve_DecimalListWithFreeElements_CastsTheElementNotTheArray` | the generic-collection branch, which materialises its result through a constructor rather than `ToArray` and shares only the element read |
| `Solve_DecimalArrayWithElementsConstrainedToEachOther_CastsTheElementNotTheArray` | the loop is reached by a theorem that genuinely constrains the elements, not only by one that leaves them out |

Each asserts two things, deliberately split: the message **must not** name an array - that is #55,
and it is what the fix changes - and it **does** name `FPNum`, which pins #64's sort mapping and
must be updated when #64 is fixed. These are the first message-based assertions in the suite; they
are here because the value cannot be asserted while #64 stands.

Three remarks were corrected rather than left to rot: the class remarks (failures split between
translation and marshalling depending on the constraint), the existing `decimal[]` pin (it is one
shape of #64, not proof of unreachability), and the `float[]` pin added by #80.

## Mutation results

| Mutation | Failures |
|---|---|
| Revert to `EvaluateWithCompletion(model, subEnv.Expr)` | **3** - exactly the three new tests |

The value-level mutations are the probe table above: with the sort mapping corrected, reverting the
fix turns every correct answer into an exception, so the tests are not merely pinning an exception
type that happens to have changed.

## Verification

- `dotnet build solutions/Z3.Linq.slnx -c Release` - clean, `TreatWarningsAsErrors` on
- 180/180 locally, 0.95s
- `./build.ps1 -Configuration Release` - 46 tasks, 0 errors, 0 warnings
- Coverage 76.7% -> 77.5% line (643 of 829), 69.6% -> 70.3% branch (442 of 628)

## Release note

Releases remain on hold under #60 until Microsoft.Z3 5.x reaches nuget.org, so this reaches `main`
but not consumers. Nothing about the hold changes.
