### PR TITLE
Read a DateTime back as UTC

### DIFF
--- a/solutions/Z3.Linq.Tests/OptimizationTests.cs
+++ b/solutions/Z3.Linq.Tests/OptimizationTests.cs
@@ -375,4 +375,41 @@ public class OptimizationTests
         result.ShouldNotBeNull();
         result.X1.ShouldBe(5);
     }
+
+    /// <summary>
+    /// An optimisation over a <see cref="DateTime"/> symbol returns the latest instant in range.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A DateTime is encoded as an integer file time, so ordering it is ordering that integer -
+    /// which is only the same thing as ordering the instants because every constant on the way in
+    /// is converted the same way, whatever kind it carried. This test puts one bound in local time
+    /// and one in UTC to say so: they are half an hour apart on the timeline, not the seven-and-a-
+    /// half hours their wall-clock readings suggest in some zones.
+    /// </para>
+    /// <para>
+    /// The range is closed, so the maximum is exactly the upper bound and can be asserted
+    /// outright. That the answer comes back as UTC is #56; that it is the right instant is what
+    /// this file is for.
+    /// </para>
+    /// </remarks>
+    [TestMethod]
+    public void OrderByDescending_DateTimeSymbolInAClosedRange_ReturnsTheLatestInstant()
+    {
+        // Arrange
+        using var context = new Z3Context();
+        var earliest = new DateTime(2026, 6, 1, 12, 0, 0, DateTimeKind.Local);
+        DateTime latest = earliest.ToUniversalTime().AddMinutes(30);
+
+        // Act
+        var result = (from t in context.NewTheorem<Symbols<DateTime, int>>()
+                      where t.X1 >= earliest && t.X1 <= latest && t.X2 == 0
+                      orderby t.X1 descending
+                      select t).Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.X1.ShouldBe(latest);
+        result.X1.Kind.ShouldBe(DateTimeKind.Utc);
+    }
 }

--- a/solutions/Z3.Linq.Tests/SymbolTypeMarshallingTests.cs
+++ b/solutions/Z3.Linq.Tests/SymbolTypeMarshallingTests.cs
@@ -11,10 +11,11 @@ namespace Z3.Linq.Tests;
 /// which solution was chosen.
 /// </para>
 /// <para>
-/// Two of the types listed as supported do not work, and are pinned as characterisation tests
-/// rather than skipped - short (#63) and DateTime (#56). Both fail in the marshalling layer,
-/// which no example in the repository exercises, which is why they went unnoticed. float was a
-/// third until #54 was fixed.
+/// One of the types listed as supported still does not work, and is pinned as a characterisation
+/// test rather than skipped - short (#63). It fails in the marshalling layer, which no example in
+/// the repository exercises, which is why it went unnoticed. float was a second until #54 was
+/// fixed, and DateTime a third until #56 - that one returned a value rather than throwing, so it
+/// took a test asserting the value to find it at all.
 /// </para>
 /// </remarks>
 [TestClass]
@@ -309,18 +310,24 @@ public class SymbolTypeMarshallingTests
     }
 
     /// <summary>
-    /// KNOWN DEFECT (#56): a DateTime does not compare equal to the value put in.
+    /// A <see cref="DateTime"/> symbol round-trips: what comes back equals what went in, as UTC.
     /// </summary>
     /// <remarks>
-    /// The instant itself survives - the value is written with ToFileTimeUtc and read with
-    /// DateTime.FromFileTime, which is its correct inverse for the instant - but the result
-    /// comes back as <see cref="DateTimeKind.Local"/>. Since <see cref="DateTime"/> equality
-    /// compares ticks and ignores Kind, a caller comparing the result against the UTC value it
-    /// supplied gets false anywhere with a non-zero UTC offset. Asserted in a form that holds in
-    /// any time zone, including UTC where the offset is zero and the shift vanishes.
+    /// <para>
+    /// A DateTime is carried through Z3 as a Windows file time - a position on the UTC timeline -
+    /// so the kind cannot survive the trip and the read path has to choose one. It chooses UTC, to
+    /// match the <c>ToFileTimeUtc</c> the write path already used. Before #56 it chose local time,
+    /// and the same theorem answered differently on every machine that ran it.
+    /// </para>
+    /// <para>
+    /// The kind assertion is the load-bearing one. Comparing ticks alone would have passed on UTC
+    /// CI both before and after the fix, because the shift is the machine's UTC offset and that
+    /// offset is zero there - which is how the defect survived a green build for so long. The kind
+    /// was wrong in every zone, UTC included.
+    /// </para>
     /// </remarks>
     [TestMethod]
-    public void Solve_DateTimeSymbol_ReturnsTheSameInstantAsLocalTime()
+    public void Solve_DateTimeSymbol_RoundTripsTheValueAsUtc()
     {
         // Arrange
         using var context = new Z3Context();
@@ -333,15 +340,148 @@ public class SymbolTypeMarshallingTests
 
         // Assert
         result.ShouldNotBeNull();
+        result.X1.Kind.ShouldBe(DateTimeKind.Utc);
+        result.X1.ShouldBe(utc);
+    }
 
-        // The instant is preserved...
-        result.X1.Kind.ShouldBe(DateTimeKind.Local);
-        result.X1.ToUniversalTime().ShouldBe(utc);
+    /// <summary>
+    /// A DateTime constant with no kind is read as UTC, not as local time.
+    /// </summary>
+    /// <remarks>
+    /// <c>new DateTime(2026, 6, 1, 12, 0, 0)</c> - the ordinary way to write a date into a
+    /// constraint - carries <see cref="DateTimeKind.Unspecified"/>, and the two file-time
+    /// conversions disagree about what that means: <c>ToFileTime</c> reads it as local time,
+    /// <c>ToFileTimeUtc</c> as UTC. The write path uses the second, which is why #56 was fixed on
+    /// the read path: switching the write to <c>ToFileTime</c> instead would have made this shape
+    /// agree while leaving an explicitly-UTC constant, the issue's own repro, still shifted.
+    /// </remarks>
+    [TestMethod]
+    public void Solve_DateTimeSymbolWithNoKind_RoundTripsTheValueAsUtc()
+    {
+        // Arrange
+        using var context = new Z3Context();
+        var unspecified = new DateTime(2026, 6, 1, 12, 0, 0);
 
-        // ...but the value is shifted by the local UTC offset, so a direct comparison against
-        // what went in only succeeds where that offset happens to be zero.
-        TimeSpan offset = TimeZoneInfo.Local.GetUtcOffset(utc);
-        result.X1.Ticks.ShouldBe(utc.Ticks + offset.Ticks);
+        // Act
+        var result = context.NewTheorem<Symbols<DateTime, int>>()
+            .Where(t => t.X1 == unspecified)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.X1.Kind.ShouldBe(DateTimeKind.Utc);
+        result.X1.Ticks.ShouldBe(unspecified.Ticks);
+    }
+
+    /// <summary>
+    /// A local DateTime comes back as the same instant, expressed in UTC.
+    /// </summary>
+    /// <remarks>
+    /// The one shape #56 changed rather than repaired. A local constant used to come back as local
+    /// time with identical ticks - the single case the old read path got right - and now comes back
+    /// as UTC, so a caller comparing the result against what it supplied gets false where it used
+    /// to get true. The instant is the same either way and one <see cref="DateTime.ToLocalTime"/>
+    /// recovers the old answer. The trade is deliberate: only one kind can be exact, and choosing
+    /// UTC is what makes the result independent of the machine that computed it.
+    /// </remarks>
+    [TestMethod]
+    public void Solve_DateTimeSymbolWithLocalKind_ReturnsTheSameInstantAsUtc()
+    {
+        // Arrange
+        using var context = new Z3Context();
+        var local = new DateTime(2026, 6, 1, 12, 0, 0, DateTimeKind.Local);
+
+        // Act
+        var result = context.NewTheorem<Symbols<DateTime, int>>()
+            .Where(t => t.X1 == local)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.X1.Kind.ShouldBe(DateTimeKind.Utc);
+        result.X1.ShouldBe(local.ToUniversalTime());
+        result.X1.ToLocalTime().ShouldBe(local);
+    }
+
+    /// <summary>
+    /// <see cref="DateTime.MaxValue"/> survives the round trip.
+    /// </summary>
+    /// <remarks>
+    /// The top of the range, and a case the old read path got right only by luck: converting the
+    /// maximum to local time overflows, and <c>ToLocalTime</c> clamps instead of throwing, so east
+    /// of Greenwich the ticks happened to match. West of it they did not. Reading as UTC removes
+    /// the conversion, so there is nothing left to clamp. The bottom of the range is #83.
+    /// </remarks>
+    [TestMethod]
+    public void Solve_DateTimeSymbolAtMaxValue_RoundTripsTheValue()
+    {
+        // Arrange
+        using var context = new Z3Context();
+        DateTime max = DateTime.MaxValue;
+
+        // Act
+        var result = context.NewTheorem<Symbols<DateTime, int>>()
+            .Where(t => t.X1 == max)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.X1.Kind.ShouldBe(DateTimeKind.Utc);
+        result.X1.ShouldBe(max);
+    }
+
+    /// <summary>
+    /// KNOWN DEFECT (#83): a DateTime constant before 1601 fails during translation.
+    /// </summary>
+    /// <remarks>
+    /// A Windows file time counts from 1601-01-01 UTC and cannot express anything earlier, so the
+    /// constant throws out of <c>ToFileTimeUtc</c> before Z3 sees the theorem. Unchanged by #56 -
+    /// the range belongs to the encoding, not to the conversion that inverts it. The null
+    /// <c>ParamName</c> is what identifies this as the write path; the read path supplies one.
+    /// </remarks>
+    [TestMethod]
+    public void Solve_DateTimeSymbolBeforeTheFileTimeEpoch_ThrowsArgumentOutOfRangeException()
+    {
+        // Arrange
+        using var context = new Z3Context();
+        DateTime min = DateTime.MinValue;
+        var theorem = context.NewTheorem<Symbols<DateTime, int>>()
+            .Where(t => t.X1 == min);
+
+        // Act
+        ArgumentOutOfRangeException exception =
+            Should.Throw<ArgumentOutOfRangeException>(() => theorem.Solve());
+
+        // Assert
+        exception.ParamName.ShouldBeNull();
+    }
+
+    /// <summary>
+    /// KNOWN DEFECT (#83): a satisfiable theorem whose only models lie before 1601 throws while
+    /// its solution is being marshalled.
+    /// </summary>
+    /// <remarks>
+    /// The other half of #83, and the worse one: nothing here is malformed. The constraints are
+    /// well-formed, Z3 finds a model, and the read path then refuses to express it. Every model
+    /// satisfying this theorem is a negative file time, so the throw does not depend on which one
+    /// Z3 picks. <c>ParamName</c> distinguishes this from the write-side case above, so a fix to
+    /// one half cannot pass as a fix to both.
+    /// </remarks>
+    [TestMethod]
+    public void Solve_DateTimeSymbolConstrainedBeforeTheFileTimeEpoch_ThrowsArgumentOutOfRangeException()
+    {
+        // Arrange
+        using var context = new Z3Context();
+        var epoch = new DateTime(1601, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var theorem = context.NewTheorem<Symbols<DateTime, int>>()
+            .Where(t => t.X1 < epoch && t.X2 == 0);
+
+        // Act
+        ArgumentOutOfRangeException exception =
+            Should.Throw<ArgumentOutOfRangeException>(() => theorem.Solve());
+
+        // Assert
+        exception.ParamName.ShouldBe("fileTime");
     }
 
     [TestMethod]
@@ -368,7 +508,7 @@ public class SymbolTypeMarshallingTests
     /// </summary>
     /// <remarks>
     /// <para>
-    /// The tests above pin what each type does with a value; these six pin what each does with
+    /// The tests above pin what each type does with a value; these seven pin what each does with
     /// no value at all. Every type takes a different arm of the marshalling switch, so each can
     /// regress on its own, and all but <c>bool</c> threw before #51. The value a free symbol
     /// comes back with is supplied by model completion and is deliberately not asserted.
@@ -377,7 +517,9 @@ public class SymbolTypeMarshallingTests
     /// <c>short</c> is absent on purpose: an unconstrained one evaluates cleanly and then fails
     /// at the reflection write, which is #63 rather than anything to do with completion. Its pin
     /// above is unchanged. <c>float</c> failed the same way until #54 was fixed, and now has a
-    /// case here like every other working type.
+    /// case here like every other working type. <c>DateTime</c> never threw here, but read back
+    /// in local time until #56, so its case asserts the kind rather than only that a result
+    /// appeared.
     /// </para>
     /// </remarks>
     [TestMethod]
@@ -497,5 +639,27 @@ public class SymbolTypeMarshallingTests
         // Assert
         result.ShouldNotBeNull();
         result.X2.ShouldBe(0);
+    }
+
+    [TestMethod]
+    public void Solve_UnconstrainedDateTimeSymbol_ReturnsAResult()
+    {
+        // Arrange: DateTime shares the integer sort with long but has its own read-back through
+        // the file-time encoding, which can only express 1601 onwards - so completion has to
+        // supply a value that encoding can carry, not merely an integer.
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<Symbols<DateTime, int>>()
+            .Where(t => t.X2 == 0)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.X2.ShouldBe(0);
+
+        // The instant is completion's to choose, but the kind is not: it is fixed by the read
+        // path, so it can be asserted where the value cannot.
+        result.X1.Kind.ShouldBe(DateTimeKind.Utc);
     }
 }

--- a/solutions/Z3.Linq/ExpressionVisitor.cs
+++ b/solutions/Z3.Linq/ExpressionVisitor.cs
@@ -306,6 +306,8 @@ public static class ExpressionVisitor
                 // and about half of all cultures render 1.5 as something else. See #52.
                 return context.MkReal(((IFormattable)val).ToString(null, CultureInfo.InvariantCulture));
             case TypeCode.DateTime:
+                // A DateTime is encoded as its position on the UTC timeline. ToFileTimeUtc reads a
+                // Kind of Unspecified as UTC, so that is the convention the read path inverts. See #56.
                 return context.MkInt(((DateTime)val).ToFileTimeUtc());
             case TypeCode.String:
                 return context.MkString(val.ToString());

--- a/solutions/Z3.Linq/Theorem.cs
+++ b/solutions/Z3.Linq/Theorem.cs
@@ -462,7 +462,8 @@ public class Theorem
                             numVal = ((IntNum)numValExpr).Int64;
                             break;
                         case TypeCode.DateTime:
-                            numVal = DateTime.FromFileTime(((IntNum)numValExpr).Int64);
+                            // FromFileTimeUtc, for the reason given on the scalar arm below. See #56.
+                            numVal = DateTime.FromFileTimeUtc(((IntNum)numValExpr).Int64);
                             break;
                         case TypeCode.Boolean:
                             numVal = numValExpr.IsTrue;
@@ -521,7 +522,11 @@ public class Theorem
                     value = ((IntNum)val).Int64;
                     break;
                 case TypeCode.DateTime:
-                    value = DateTime.FromFileTime(((IntNum)val).Int64);
+                    // The write path encodes the instant with ToFileTimeUtc (ExpressionVisitor.cs:311),
+                    // whose inverse is FromFileTimeUtc. FromFileTime converts to local time, which
+                    // shifts the value by the machine's UTC offset and makes the same theorem answer
+                    // differently on different machines. See #56.
+                    value = DateTime.FromFileTimeUtc(((IntNum)val).Int64);
                     break;
                 case TypeCode.Boolean:
                     value = val.IsTrue;

--- a/solutions/Z3.Linq/Theorem{T}.cs
+++ b/solutions/Z3.Linq/Theorem{T}.cs
@@ -35,9 +35,18 @@ public class Theorem<T> : Theorem, ISolveable<T>
     /// </summary>
     /// <returns>Environment type instance with properties set to theorem-satisfying values.</returns>
     /// <remarks>
+    /// <para>
     /// A symbol that no constraint mentions is free: the theorem is still satisfiable, and Z3
     /// assigns the symbol an arbitrary value. Only the symbols the constraints pin down are
     /// determined by the query.
+    /// </para>
+    /// <para>
+    /// A <see cref="DateTime"/> symbol travels through Z3 as an instant on the UTC timeline and
+    /// comes back with <see cref="DateTimeKind.Utc"/>, whatever kind the constants constraining
+    /// it had. A constant whose kind is <see cref="DateTimeKind.Unspecified"/> is read as UTC
+    /// rather than as local time. The result is therefore the same on every machine; a caller
+    /// working in local time needs <see cref="DateTime.ToLocalTime"/> on the way out.
+    /// </para>
     /// </remarks>
     public T? Solve()
     {


### PR DESCRIPTION
Fixes #56.

## The defect

The write path encodes a `DateTime` as a Windows file time with `ToFileTimeUtc`
(`ExpressionVisitor.cs:311`). Both read paths decoded it with `DateTime.FromFileTime`
(`Theorem.cs:466`, `:529`), which returns **local** time. The inverse of `ToFileTimeUtc` is
`FromFileTimeUtc`.

```csharp
using var ctx = new Z3Context();
var utc = new DateTime(2026, 6, 1, 12, 0, 0, DateTimeKind.Utc);
ctx.NewTheorem<Symbols<DateTime, int>>().Where(t => t.X1 == utc).Solve()!.X1;
// 2026-06-01T13:00:00.0000000+01:00 - an hour out, in BST
```

Nothing about the solve was wrong. Declaring the symbol, translating the constant and solving all
succeeded; only the last step moved the answer. Measured on `GMT Standard Time`, +01:00 in June:

| Shape | Before | After |
|---|---|---|
| constant with `DateTimeKind.Utc` | `13:00+01:00` - shifted | `12:00Z` - exact |
| constant with no kind - `new DateTime(2026, 6, 1, 12, 0, 0)` | `13:00+01:00` - shifted | `12:00Z` - exact |
| constant with `DateTimeKind.Local` | `12:00+01:00` - exact | `11:00Z` - the same instant, as UTC |
| `DateTime.MaxValue` | exact, by clamping | exact |
| unconstrained symbol | `1601-01-01T00:00:00+00:00`, kind `Local` | `1601-01-01T00:00:00Z` |
| `OrderByDescending` over a closed range | the upper bound `+01:00` - not equal to that bound | the bound, exactly |
| `DateTime[]`, `List<DateTime>` | `InvalidCastException` / `Z3Exception` (#64) | unchanged (#64) |
| anything before 1601 | `ArgumentOutOfRangeException` (#83) | unchanged (#83) |

How wrong the answer is depends on the machine rather than the query: the same theorem returns
different values in London, New York and Tokyo, and the right one only where the offset happens to
be zero.

## Why the read path, and not the write path

The issue offers either - "`DateTime.FromFileTimeUtc` on the read path, or `ToFileTime` on the
write path - but consistently". Measured, only one of those works:

| | `Utc` constant | no-kind constant | `Local` constant |
|---|---|---|---|
| today | shifted | shifted | exact |
| `FromFileTimeUtc` on the read path (this PR) | **exact** | **exact** | same instant, as UTC |
| `ToFileTime` on the write path | **still shifted** | exact | exact |

For a `DateTime` whose kind is `Utc`, `ToFileTime()` and `ToFileTimeUtc()` return the same number -
verified against all three kinds - so changing the write path does nothing at all for the issue's
own repro. The two conversions differ only for `Unspecified`, which `ToFileTime` reads as local
time and `ToFileTimeUtc` reads as UTC.

The deeper reason for choosing UTC is that only one kind can round-trip exactly. The model holds a
single integer and the kind cannot survive it, so the read path has to pick one. Picking UTC makes
the result a property of the theorem; picking local time makes it a property of the machine that
ran it.

## What this changes for callers

A constant with `DateTimeKind.Local` used to come back as local time with identical ticks - the one
shape the old read path got right - and now comes back as the same instant expressed in UTC, so a
caller comparing the result against what it supplied gets `false` where it used to get `true`. One
`ToLocalTime()` recovers the old answer. That is the whole of the behavioural cost, and it is
pinned by a test rather than left to be discovered.

`Theorem<T>.Solve`'s remarks now state the convention, including that a constant with no kind is
read as UTC rather than as local time. It had no documentation anywhere before.

## The array element site

`Theorem.cs:466` carried the same defect and is corrected in the same commit. **No test in this PR
reaches it.** A `DateTime[]` declares an `Int -> BitVec 64` array, so the element read fails on the
cast before the conversion is ever called: `InvalidCastException: BitVecNum -> IntNum` with free
elements, or `Z3Exception: Sorts (_ BitVec 64) and Int are incompatible` when a constant is named.
That is #64, and reverting this site alone fails nothing.

So it was verified out of band instead. Changing the `DateTime` row of #64's sort mapping to
`Int -> Int` locally - **not** part of this PR - makes the element path reachable, and then:

| Under a locally corrected #64 mapping | element site fixed | element site reverted |
|---|---|---|
| `DateTime[]` pinned to `12:00Z` and `09:30Z` | `12:00Z`, `09:30Z` - exact | `13:00+01:00`, `10:30+01:00` |
| `List<DateTime>` pinned to `12:00Z` | exact | `13:00+01:00` |
| free elements | `1601-01-01T00:00:00Z` | `1601-01-01T00:00:00+00:00`, kind `Local` |

The site is right, and demonstrably so rather than by argument. Worth noting on #64 as well: the
`DateTime` row needs only its range changed, exactly as `Int64` does, and that one change makes
`DateTime` collections work end to end.

## Tests

180 -> 187. The `#56` pin becomes a round-trip test; the rest are new.

| Test | What it covers |
|---|---|
| `Solve_DateTimeSymbol_RoundTripsTheValueAsUtc` | rewritten from `Solve_DateTimeSymbol_ReturnsTheSameInstantAsLocalTime` - the issue's repro |
| `Solve_DateTimeSymbolWithNoKind_RoundTripsTheValueAsUtc` | `new DateTime(...)`, the ordinary way to write a date into a constraint, and the only shape that tells the two write conversions apart |
| `Solve_DateTimeSymbolWithLocalKind_ReturnsTheSameInstantAsUtc` | the one shape this PR changes rather than repairs |
| `Solve_DateTimeSymbolAtMaxValue_RoundTripsTheValue` | the top of the range, which the old path got right only because `ToLocalTime` clamps instead of overflowing - and only east of Greenwich |
| `Solve_UnconstrainedDateTimeSymbol_ReturnsAResult` | fills the hole in the unconstrained-symbol family, which covered six of the seven working types |
| `OrderByDescending_DateTimeSymbolInAClosedRange_ReturnsTheLatestInstant` | ordering the encoded integer is ordering the instants - asserted with one bound in local time and one in UTC, half an hour apart on the timeline whatever their wall clocks read |
| `Solve_DateTimeSymbolBeforeTheFileTimeEpoch_ThrowsArgumentOutOfRangeException` | #83 pin, write side |
| `Solve_DateTimeSymbolConstrainedBeforeTheFileTimeEpoch_ThrowsArgumentOutOfRangeException` | #83 pin, read side - distinguished from the write side by `ParamName` |

**Every assertion holds in any time zone.** The issue warns that a naive test would be green on UTC
CI and red for a UK developer in summer, and it is right about the ticks: the shift is the machine's
UTC offset, which is zero on CI. The kind assertion is what makes these tests independent of where
they run - `FromFileTime` returns `DateTimeKind.Local` whatever the offset is, measured here on a
date where this machine's offset *is* zero (`1601-01-01T00:00:00+00:00 Kind=Local`). The kind was
wrong in every zone, UTC included.

## Mutation results

| Mutation | Failures | Which |
|---|---|---|
| Revert the scalar read site to `FromFileTime` | **6** | the four round-trip cases, the unconstrained case and the optimisation case |
| Revert the array element site to `FromFileTime` | **0** | unreachable behind #64, exactly as stated above |
| `ToFileTime` on the write path, keeping the read fix | **1** | only the no-kind case - the two conversions agree for every other kind, which is the measurement behind the table above |
| The issue's alternative in full - `ToFileTime` write, `FromFileTime` read | **6** | and a `Utc` constant still comes back as `13:00+01:00` |
| Scalar read returns a fixed instant | **6** | the five value assertions, plus the #83 read-side pin, which stops throwing - confirming that pin asserts a real conversion rather than incidental behaviour. The unconstrained case survives, correctly: it asserts a kind, not a value |

## Verification

- `dotnet build solutions/Z3.Linq.slnx -c Release --no-incremental` - clean, `TreatWarningsAsErrors` on
- 187/187 locally, 2.5s
- `./build.ps1 -Configuration Release` - 46 tasks, 0 errors, 0 warnings
- Coverage is **flat** at 77.5% line (643 of 829) and 70.3% branch (442 of 628). The `DateTime` arm
  was already a covered line - the old pin executed it - so this fix adds none. The defect lived on
  a line that had been green all along, which is the argument for what the tests assert rather than
  for the coverage number

## New issue

**#83** - a `DateTime` before 1601 cannot be represented at all. A file time counts from
1601-01-01 UTC, so `DateTime.MinValue` throws out of the write path during translation, and a
satisfiable theorem whose only models lie before 1601 throws out of the read path while its
solution is being marshalled. Both raise a bare `ArgumentOutOfRangeException: Not a valid Win32
FileTime` naming nothing the caller controls. Unchanged by this PR - the range belongs to the
encoding, not to the conversion that inverts it - and pinned by the two tests above so that a fix
to either half cannot pass as a fix to both. Raised rather than fixed, per the standing convention.

## Release note

Releases remain on hold under #60 until Microsoft.Z3 5.x reaches nuget.org, so this reaches `main`
but not consumers. Nothing about the hold changes.
