### PR TITLE
Report satisfiability separately from the solution

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,61 @@ using (var ctx = new Z3Context())
 }
 ```
 
+### When there is no solution
+
+`Solve()` reports an unsatisfiable theorem by returning `default`. For a class environment such as
+`Symbols<int, int>` that is `null` and reads correctly. For a value type - a value tuple, a struct,
+a record struct - `default` is a fully populated instance with every symbol zero, which is also the
+answer to plenty of satisfiable theorems, and it cannot even be compared against `null`:
+
+```csharp
+using (var ctx = new Z3Context())
+{
+    var theorem = from t in ctx.NewTheorem<(int a, int b)>()
+                  where t.a == t.b && t.a > 4 && t.b < 2
+                  select t;
+
+    Console.WriteLine(theorem.Solve());   // (0, 0) - and so is a theorem solved by (0, 0)
+}
+```
+
+Use `TrySolve` where the difference matters. It works for every environment type:
+
+```csharp
+if (theorem.TrySolve(out var result))
+{
+    Console.WriteLine($"{result.a}, {result.b}");
+}
+else
+{
+    Console.WriteLine("No solution.");
+}
+```
+
+For a value-type environment, `SolveOrNull()` gives back a `Nullable<T>` instead, so the usual null
+checks apply:
+
+```csharp
+(int a, int b)? result = theorem.SolveOrNull();
+
+if (result is null)
+{
+    Console.WriteLine("No solution.");
+}
+```
+
+Both have optimisation counterparts - `TryOptimize` and `OptimizeOrNull` - and `TrySolve` is
+available on the deferred form an `orderby` query returns:
+
+```csharp
+var solveable = from t in ctx.NewTheorem<(int a, int b)>()
+                where t.a >= 5 && t.a <= 9
+                orderby t.a
+                select t;
+
+if (solveable.TrySolve(out var cheapest)) { /* ... */ }
+```
+
 ## Getting Started
 
 You can install the [Z3.Linq NuGet Package](https://www.nuget.org/packages/Z3.Linq/).

--- a/solutions/Z3.Linq.Tests/OptimizationTests.cs
+++ b/solutions/Z3.Linq.Tests/OptimizationTests.cs
@@ -281,7 +281,7 @@ public class OptimizationTests
     /// reference environment, a null the compiler had been told could not happen, so the caller
     /// dereferenced it and got a <see cref="NullReferenceException"/> far from the cause. The
     /// value has not changed; what changed is that the declaration now admits it, which turned
-    /// six unchecked dereferences in this very file into compiler errors.
+    /// ten unchecked dereferences across six tests in this very file into compiler errors.
     /// </remarks>
     [TestMethod]
     public void Optimize_WithUnsatisfiableTheorem_ReturnsNull()

--- a/solutions/Z3.Linq.Tests/OptimizationTests.cs
+++ b/solutions/Z3.Linq.Tests/OptimizationTests.cs
@@ -71,6 +71,8 @@ public class OptimizationTests
         var maximum = theorem.Optimize(Optimization.Maximize, t => t.X1);
 
         // Assert
+        minimum.ShouldNotBeNull();
+        maximum.ShouldNotBeNull();
         minimum.X1.ShouldBe(5);
         maximum.X1.ShouldBe(9);
         minimum.X1.ShouldBeLessThan(maximum.X1);
@@ -91,6 +93,7 @@ public class OptimizationTests
         var viaOrderBy = theorem.OrderBy(t => t.X1).Solve();
 
         // Assert
+        viaOptimize.ShouldNotBeNull();
         viaOrderBy.ShouldNotBeNull();
         viaOrderBy.X1.ShouldBe(viaOptimize.X1);
         viaOrderBy.X1.ShouldBe(3);
@@ -110,6 +113,7 @@ public class OptimizationTests
         var viaOrderBy = theorem.OrderByDescending(t => t.X1).Solve();
 
         // Assert
+        viaOptimize.ShouldNotBeNull();
         viaOrderBy.ShouldNotBeNull();
         viaOrderBy.X1.ShouldBe(viaOptimize.X1);
         viaOrderBy.X1.ShouldBe(8);
@@ -223,6 +227,8 @@ public class OptimizationTests
         var maximised = theorem.Optimize(Optimization.Maximize, t => t.X1);
 
         // Assert
+        minimised.ShouldNotBeNull();
+        maximised.ShouldNotBeNull();
         minimised.X1.ShouldBe(5);
         maximised.X1.ShouldBe(100);
     }
@@ -243,6 +249,8 @@ public class OptimizationTests
         var solved = theorem.Solve();
 
         // Assert
+        first.ShouldNotBeNull();
+        second.ShouldNotBeNull();
         first.X1.ShouldBe(1);
         second.X1.ShouldBe(1);
 
@@ -266,19 +274,17 @@ public class OptimizationTests
     }
 
     /// <summary>
-    /// KNOWN DEFECT (#58): an unsatisfiable optimisation returns null through a signature that
-    /// promises it will not.
+    /// An unsatisfiable optimisation returns null through a signature that says so.
     /// </summary>
     /// <remarks>
-    /// <c>Solve</c> returns <c>T?</c> and callers are expected to check it, but <c>Optimize</c>
-    /// returns a non-nullable <c>T</c> while returning <c>default!</c> when the status is not
-    /// SATISFIABLE (Theorem.cs:126). For a reference environment type that is a null the
-    /// compiler has been told cannot happen, so the caller dereferences it and gets a
-    /// <see cref="NullReferenceException"/> far from the cause.
-    /// This test pins current behaviour and must be updated when the defect is fixed.
+    /// <c>Optimize</c> returned <c>default!</c> through a non-nullable <c>T</c> until #58 - for a
+    /// reference environment, a null the compiler had been told could not happen, so the caller
+    /// dereferenced it and got a <see cref="NullReferenceException"/> far from the cause. The
+    /// value has not changed; what changed is that the declaration now admits it, which turned
+    /// six unchecked dereferences in this very file into compiler errors.
     /// </remarks>
     [TestMethod]
-    public void Optimize_WithUnsatisfiableTheorem_ReturnsNullDespiteNonNullableSignature()
+    public void Optimize_WithUnsatisfiableTheorem_ReturnsNull()
     {
         // Arrange: a direct contradiction, so the optimiser has nothing to optimise over.
         using var context = new Z3Context();
@@ -296,8 +302,8 @@ public class OptimizationTests
     [TestMethod]
     public void OrderBy_OnAnUnsatisfiableTheorem_ReturnsNull()
     {
-        // Arrange: the query-syntax route to the same place. Here the null is at least
-        // well-typed, since ISolveable<T>.Solve is declared to return T?.
+        // Arrange: the query-syntax route to the same place. This one was always well-typed,
+        // since ISolveable<T>.Solve has always been declared to return T?.
         using var context = new Z3Context();
 
         // Act
@@ -327,6 +333,8 @@ public class OptimizationTests
         var childMinimum = child.Optimize(Optimization.Minimize, t => t.X1);
 
         // Assert
+        parentMinimum.ShouldNotBeNull();
+        childMinimum.ShouldNotBeNull();
         parentMinimum.X1.ShouldBe(1);
         childMinimum.X1.ShouldBe(6);
     }

--- a/solutions/Z3.Linq.Tests/UnsatisfiabilityTests.cs
+++ b/solutions/Z3.Linq.Tests/UnsatisfiabilityTests.cs
@@ -1,0 +1,370 @@
+namespace Z3.Linq.Tests;
+
+/// <summary>
+/// Telling "there is no solution" apart from "there is a solution, and it is all zeroes".
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>Solve</c> reports no solution by returning <c>default(T)</c>. For a reference environment
+/// that is <see langword="null"/> and reads correctly. For a value type - a value tuple, a struct,
+/// a record struct - <c>default(T)</c> is a fully populated instance with every symbol zero, which
+/// is also the answer to plenty of satisfiable theorems. The caller cannot tell the two apart and
+/// cannot even write <c>result is null</c>: that is <c>error CS0037</c> on a non-nullable value
+/// type. This file pins both halves - the ambiguity that remains on <c>Solve</c>, and the forms
+/// added by #57 that resolve it.
+/// </para>
+/// <para>
+/// Every test that asserts a negative is paired with one that asserts the positive over the same
+/// value, because the whole difficulty is that the two look identical. A test that only checked
+/// the unsatisfiable case would pass against an implementation that always answered "no solution".
+/// </para>
+/// </remarks>
+[TestClass]
+public class UnsatisfiabilityTests
+{
+    /// <summary>
+    /// The ambiguity itself: two different theorems, the same result.
+    /// </summary>
+    /// <remarks>
+    /// The reason #57 exists, kept as a test rather than as prose. One of these theorems has no
+    /// solution and the other has exactly one; <c>Solve</c> answers both with <c>(0, 0)</c>. This
+    /// is characterisation, not approval - the behaviour is deliberately left alone so that
+    /// existing callers keep compiling, and the tests below cover the forms that answer properly.
+    /// </remarks>
+    [TestMethod]
+    public void Solve_UnsatisfiableValueTupleTheorem_ReturnsWhatASatisfiableAllZeroTheoremReturns()
+    {
+        // Arrange
+        using var context = new Z3Context();
+
+        // Act
+        var noSolution = (from t in context.NewTheorem<(int a, int b)>()
+                          where t.a == t.b && t.a > 4 && t.b < 2
+                          select t).Solve();
+
+        var oneSolution = (from t in context.NewTheorem<(int a, int b)>()
+                           where t.a == 0 && t.b == 0
+                           select t).Solve();
+
+        // Assert
+        noSolution.ShouldBe((0, 0));
+        oneSolution.ShouldBe((0, 0));
+        noSolution.ShouldBe(oneSolution);
+    }
+
+    [TestMethod]
+    public void TrySolve_UnsatisfiableValueTupleTheorem_ReturnsFalse()
+    {
+        // Arrange: the original report's theorem, from #28.
+        using var context = new Z3Context();
+        var theorem = from t in context.NewTheorem<(int a, int b)>()
+                      where t.a == t.b && t.a > 4 && t.b < 2
+                      select t;
+
+        // Act
+        bool satisfiable = theorem.TrySolve(out (int a, int b) result);
+
+        // Assert
+        satisfiable.ShouldBeFalse();
+        result.ShouldBe(default);
+    }
+
+    /// <summary>
+    /// The satisfiable half of the same value.
+    /// </summary>
+    /// <remarks>
+    /// The load-bearing test in this file. The result here is <c>(0, 0)</c>, exactly what the
+    /// unsatisfiable theorem above produces, so the two are distinguished only by the return
+    /// value of <c>TrySolve</c>. An implementation that inferred satisfiability from the solution
+    /// - by comparing it against <c>default</c>, say - would pass every other test and fail this
+    /// one.
+    /// </remarks>
+    [TestMethod]
+    public void TrySolve_SatisfiableAllZeroValueTupleTheorem_ReturnsTrue()
+    {
+        // Arrange
+        using var context = new Z3Context();
+        var theorem = from t in context.NewTheorem<(int a, int b)>()
+                      where t.a == 0 && t.b == 0
+                      select t;
+
+        // Act
+        bool satisfiable = theorem.TrySolve(out (int a, int b) result);
+
+        // Assert
+        satisfiable.ShouldBeTrue();
+        result.ShouldBe((0, 0));
+    }
+
+    [TestMethod]
+    public void TrySolve_SatisfiableTheorem_ReturnsTheSolutionSolveWouldHaveReturned()
+    {
+        // Arrange: the two forms must not disagree about the answer, only about how they report
+        // the absence of one.
+        using var context = new Z3Context();
+        var theorem = context.NewTheorem<Symbols<int, int>>()
+            .Where(t => t.X1 == 3 && t.X2 == 7);
+
+        // Act
+        bool satisfiable = theorem.TrySolve(out Symbols<int, int>? tried);
+        var solved = theorem.Solve();
+
+        // Assert
+        satisfiable.ShouldBeTrue();
+        tried.ShouldNotBeNull();
+        solved.ShouldNotBeNull();
+        tried.X1.ShouldBe(solved.X1);
+        tried.X2.ShouldBe(solved.X2);
+        tried.X1.ShouldBe(3);
+    }
+
+    [TestMethod]
+    public void TrySolve_UnsatisfiableReferenceTypeTheorem_ReturnsFalse()
+    {
+        // Arrange: a reference environment could already report this by returning null, so this
+        // is here to keep the two paths answering the same way rather than to fix anything.
+        using var context = new Z3Context();
+        var theorem = context.NewTheorem<Symbols<int, int>>()
+            .Where(t => t.X1 > 4 && t.X1 < 2);
+
+        // Act
+        bool satisfiable = theorem.TrySolve(out Symbols<int, int>? result);
+
+        // Assert
+        satisfiable.ShouldBeFalse();
+        result.ShouldBeNull();
+    }
+
+    /// <summary>
+    /// A struct environment behaves like a value tuple, because the problem is the value type
+    /// rather than the tuple.
+    /// </summary>
+    /// <remarks>
+    /// A value tuple is how the defect was first reported (#28), but nothing about it is
+    /// tuple-specific: a plain struct and a record struct both come back as a populated all-zero
+    /// instance from an unsatisfiable theorem. Covered here so that a fix which special-cased
+    /// <c>ValueTuple</c> would not look complete.
+    /// </remarks>
+    [TestMethod]
+    public void TrySolve_UnsatisfiableStructTheorems_ReturnFalse()
+    {
+        // Arrange
+        using var context = new Z3Context();
+
+        // Act
+        bool structSatisfiable = context.NewTheorem<PointEnvironment>()
+            .Where(t => t.X > 4 && t.X < 2)
+            .TrySolve(out PointEnvironment fromStruct);
+
+        bool recordSatisfiable = context.NewTheorem<PointRecord>()
+            .Where(t => t.X > 4 && t.X < 2)
+            .TrySolve(out PointRecord fromRecord);
+
+        // Assert
+        structSatisfiable.ShouldBeFalse();
+        recordSatisfiable.ShouldBeFalse();
+
+        // And the values they hand back are exactly the ones a caller could not have interpreted.
+        fromStruct.X.ShouldBe(0);
+        fromRecord.X.ShouldBe(0);
+    }
+
+    [TestMethod]
+    public void SolveOrNull_UnsatisfiableValueTupleTheorem_ReturnsNull()
+    {
+        // Arrange
+        using var context = new Z3Context();
+        var theorem = from t in context.NewTheorem<(int a, int b)>()
+                      where t.a == t.b && t.a > 4 && t.b < 2
+                      select t;
+
+        // Act
+        (int a, int b)? result = theorem.SolveOrNull();
+
+        // Assert
+        result.ShouldBeNull();
+    }
+
+    /// <summary>
+    /// The satisfiable half, again over the value that used to be unreadable.
+    /// </summary>
+    /// <remarks>
+    /// <c>SolveOrNull</c> lifts the environment to <see cref="System.Nullable{T}"/>, so
+    /// <c>result is null</c> compiles and means what it says - the comparison that is
+    /// <c>error CS0037</c> on the result of <c>Solve</c>. The value inside is still <c>(0, 0)</c>,
+    /// which is the point: the wrapper carries the answer that the value cannot.
+    /// </remarks>
+    [TestMethod]
+    public void SolveOrNull_SatisfiableAllZeroValueTupleTheorem_ReturnsTheAllZeroSolution()
+    {
+        // Arrange
+        using var context = new Z3Context();
+        var theorem = from t in context.NewTheorem<(int a, int b)>()
+                      where t.a == 0 && t.b == 0
+                      select t;
+
+        // Act
+        (int a, int b)? result = theorem.SolveOrNull();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.Value.ShouldBe((0, 0));
+    }
+
+    [TestMethod]
+    public void TryOptimize_UnsatisfiableTheorem_ReturnsFalse()
+    {
+        // Arrange
+        using var context = new Z3Context();
+        var theorem = context.NewTheorem<(int a, int b)>()
+            .Where(t => t.a > 10 && t.a < 5);
+
+        // Act
+        bool satisfiable = theorem.TryOptimize(Optimization.Minimize, t => t.a, out (int a, int b) result);
+
+        // Assert
+        satisfiable.ShouldBeFalse();
+        result.ShouldBe(default);
+    }
+
+    [TestMethod]
+    public void TryOptimize_SatisfiableTheoremWhoseOptimumIsZero_ReturnsTrue()
+    {
+        // Arrange: the optimum is zero, so the solution is again indistinguishable from the
+        // no-solution value - the same trap as Solve, on the optimiser's own path.
+        using var context = new Z3Context();
+        var theorem = context.NewTheorem<(int a, int b)>()
+            .Where(t => t.a >= 0 && t.a <= 9 && t.b == 0);
+
+        // Act
+        bool satisfiable = theorem.TryOptimize(Optimization.Minimize, t => t.a, out (int a, int b) result);
+
+        // Assert
+        satisfiable.ShouldBeTrue();
+        result.ShouldBe((0, 0));
+    }
+
+    [TestMethod]
+    public void OptimizeOrNull_UnsatisfiableTheorem_ReturnsNull()
+    {
+        // Arrange
+        using var context = new Z3Context();
+        var theorem = context.NewTheorem<(int a, int b)>()
+            .Where(t => t.a > 10 && t.a < 5);
+
+        // Act
+        (int a, int b)? result = theorem.OptimizeOrNull(Optimization.Minimize, t => t.a);
+
+        // Assert
+        result.ShouldBeNull();
+    }
+
+    [TestMethod]
+    public void OptimizeOrNull_SatisfiableTheorem_ReturnsTheOptimum()
+    {
+        // Arrange
+        using var context = new Z3Context();
+        var theorem = context.NewTheorem<(int a, int b)>()
+            .Where(t => t.a >= 5 && t.a <= 9 && t.b == 0);
+
+        // Act
+        (int a, int b)? result = theorem.OptimizeOrNull(Optimization.Minimize, t => t.a);
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.Value.a.ShouldBe(5);
+    }
+
+    /// <summary>
+    /// The deferred <c>orderby</c> path answers the same way.
+    /// </summary>
+    /// <remarks>
+    /// <c>OrderBy</c> and <c>OrderByDescending</c> return a deferred solvable with its own
+    /// implementation of the interface, separate from the one on the theorem, so it can regress on
+    /// its own. It has to carry satisfiability alongside the solution rather than returning the
+    /// solution alone, which is the whole reason its shape changed under #57.
+    /// </remarks>
+    [TestMethod]
+    public void TrySolve_OnADeferredOrderBy_ReportsSatisfiabilityEitherWay()
+    {
+        // Arrange
+        using var context = new Z3Context();
+
+        var unsatisfiable = from t in context.NewTheorem<(int a, int b)>()
+                            where t.a > 10 && t.a < 5
+                            orderby t.a
+                            select t;
+
+        var satisfiable = from t in context.NewTheorem<(int a, int b)>()
+                          where t.a >= 0 && t.a <= 9 && t.b == 0
+                          orderby t.a
+                          select t;
+
+        // Act
+        bool unsatisfiableSolved = unsatisfiable.TrySolve(out (int a, int b) noSolution);
+        bool satisfiableSolved = satisfiable.TrySolve(out (int a, int b) optimum);
+
+        // Assert
+        unsatisfiableSolved.ShouldBeFalse();
+        satisfiableSolved.ShouldBeTrue();
+
+        // Both values are (0, 0). Only the booleans differ.
+        noSolution.ShouldBe(optimum);
+        optimum.ShouldBe((0, 0));
+    }
+
+    [TestMethod]
+    public void SolveOrNull_OnADeferredOrderByDescending_ReturnsTheOptimum()
+    {
+        // Arrange: the extension hangs off ISolveable, so it reaches the deferred form too.
+        using var context = new Z3Context();
+        var solveable = from t in context.NewTheorem<(int a, int b)>()
+                        where t.a >= 5 && t.a <= 9 && t.b == 0
+                        orderby t.a descending
+                        select t;
+
+        // Act
+        (int a, int b)? result = solveable.SolveOrNull();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.Value.a.ShouldBe(9);
+    }
+
+    /// <summary>
+    /// The workaround suggested in the original report does not work.
+    /// </summary>
+    /// <remarks>
+    /// #28 noted that declaring the environment as <c>(int a, int b)?</c> returns null for an
+    /// unsatisfiable theorem, and offered it as a way round the ambiguity. It only appears to
+    /// work because the satisfiable case was never tried: <see cref="System.Nullable{T}"/> exposes
+    /// <c>HasValue</c> and <c>Value</c>, both get-only, so the moment there is a solution to write
+    /// the marshalling layer fails on the property set. The unsatisfiable case never reaches that
+    /// code, which is why it looked fine. Pinned so the record is unambiguous: before #57 there
+    /// was no way to distinguish, not even the documented one.
+    /// </remarks>
+    [TestMethod]
+    public void Solve_NullableValueTupleEnvironment_ThrowsWhenTheTheoremIsSatisfiable()
+    {
+        // Arrange
+        using var context = new Z3Context();
+        var theorem = from t in context.NewTheorem<(int a, int b)?>()
+                      where t!.Value.a == 3 && t.Value.b == 7
+                      select t;
+
+        // Act
+        ArgumentException exception = Should.Throw<ArgumentException>(() => theorem.Solve());
+
+        // Assert
+        exception.Message.ShouldContain("Property set method not found");
+    }
+
+    private struct PointEnvironment
+    {
+        public int X { get; set; }
+
+        public int Y { get; set; }
+    }
+
+    private record struct PointRecord(int X, int Y);
+}

--- a/solutions/Z3.Linq/ISolveable{T}.cs
+++ b/solutions/Z3.Linq/ISolveable{T}.cs
@@ -1,5 +1,7 @@
-﻿namespace Z3.Linq
+namespace Z3.Linq
 {
+    using System.Diagnostics.CodeAnalysis;
+
     /// <summary>
     /// Enables optimization constraints as expressed by OrderBy to be deferred, just like
     /// everything else.
@@ -7,6 +9,27 @@
     /// <typeparam name="T">Result type.</typeparam>
     public interface ISolveable<T>
     {
+        /// <summary>
+        /// Solves the theorem.
+        /// </summary>
+        /// <returns>
+        /// Environment type instance with properties set to theorem-satisfying values, or
+        /// <c>default(T)</c> if the theorem cannot be satisfied.
+        /// </returns>
+        /// <remarks>
+        /// For a value-type environment <c>default(T)</c> is a populated all-zero instance and
+        /// cannot be told apart from a solution in which every symbol is zero. Use
+        /// <see cref="TrySolve(out T)"/>, or <c>SolveOrNull</c>, where that matters. See #57.
+        /// </remarks>
         T? Solve();
+
+        /// <summary>
+        /// Solves the theorem, reporting satisfiability separately from the solution.
+        /// </summary>
+        /// <param name="result">The solution, when the theorem could be satisfied.</param>
+        /// <returns>
+        /// <see langword="true"/> if the theorem was satisfiable; otherwise <see langword="false"/>.
+        /// </returns>
+        bool TrySolve([MaybeNullWhen(false)] out T result);
     }
 }

--- a/solutions/Z3.Linq/SolveableExtensions.cs
+++ b/solutions/Z3.Linq/SolveableExtensions.cs
@@ -1,0 +1,61 @@
+namespace Z3.Linq;
+
+using System;
+using System.Linq.Expressions;
+
+/// <summary>
+/// Solve and optimize forms that lift a value-type environment to <see cref="Nullable{T}"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// For a reference-type environment, <c>Solve</c> already returns <see langword="null"/> when a
+/// theorem cannot be satisfied and nothing here is needed. For a value type it returns
+/// <c>default(T)</c> - a populated all-zero instance that cannot be told apart from a solution in
+/// which every symbol is zero, and cannot be compared against <see langword="null"/> at all. These
+/// methods give that case the same shape the reference-type case already has. See #57.
+/// </para>
+/// <para>
+/// They are extension methods rather than members because the <c>struct</c> constraint that makes
+/// <c>T?</c> mean <see cref="Nullable{T}"/> cannot be applied to a member of <c>Theorem&lt;T&gt;</c>,
+/// whose <c>T</c> is unconstrained.
+/// </para>
+/// </remarks>
+public static class SolveableExtensions
+{
+    /// <summary>
+    /// Solves the theorem, returning <see langword="null"/> if it cannot be satisfied.
+    /// </summary>
+    /// <typeparam name="TEnvironment">Value-type environment over which the theorem is defined.</typeparam>
+    /// <param name="solveable">The theorem, or a deferred optimisation over one.</param>
+    /// <returns>The solution, or <see langword="null"/> if the theorem cannot be satisfied.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="solveable"/> is null.</exception>
+    public static TEnvironment? SolveOrNull<TEnvironment>(this ISolveable<TEnvironment> solveable)
+        where TEnvironment : struct
+    {
+        ArgumentNullException.ThrowIfNull(solveable);
+
+        return solveable.TrySolve(out TEnvironment solution) ? solution : null;
+    }
+
+    /// <summary>
+    /// Finds an optimal solution, returning <see langword="null"/> if the theorem cannot be
+    /// satisfied.
+    /// </summary>
+    /// <typeparam name="TEnvironment">Value-type environment over which the theorem is defined.</typeparam>
+    /// <typeparam name="TResult">Type of the value being optimized.</typeparam>
+    /// <param name="theorem">The theorem to optimize over.</param>
+    /// <param name="direction">The optimization goal, i.e. whether to minimize or maximize the solution.</param>
+    /// <param name="lambda">Expression representing the value to minimize or maximize.</param>
+    /// <returns>The optimal solution, or <see langword="null"/> if the theorem cannot be satisfied.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="theorem"/> is null.</exception>
+    public static TEnvironment? OptimizeOrNull<TEnvironment, TResult>(
+        this Theorem<TEnvironment> theorem,
+        Optimization direction,
+        Expression<Func<TEnvironment, TResult>> lambda)
+        where TEnvironment : struct
+    {
+        ArgumentNullException.ThrowIfNull(theorem);
+
+        return theorem.TryOptimize(direction, lambda, out TEnvironment solution) ? solution : null;
+    }
+}

--- a/solutions/Z3.Linq/Theorem.cs
+++ b/solutions/Z3.Linq/Theorem.cs
@@ -5,6 +5,7 @@ using Microsoft.Z3;
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using System.Linq.Expressions;
@@ -69,8 +70,24 @@ public class Theorem
     /// Solves the theorem using Z3.
     /// </summary>
     /// <typeparam name="T">Theorem environment type.</typeparam>
-    /// <returns>Result of solving the theorem; default(T) if the theorem cannot be satisfied.</returns>
+    /// <returns>Result of solving the theorem; <c>default(T)</c> if the theorem cannot be satisfied.</returns>
+    /// <remarks>
+    /// For a value-type environment <c>default(T)</c> is a real, populated instance - all zeroes -
+    /// and so cannot be told apart from a solution in which every symbol happens to be zero. Use
+    /// <see cref="TrySolve{T}(out T)"/> where that matters. See #57.
+    /// </remarks>
     protected T? Solve<T>()
+    {
+        return this.TrySolve<T>(out T? result) ? result : default;
+    }
+
+    /// <summary>
+    /// Solves the theorem using Z3, reporting satisfiability separately from the solution.
+    /// </summary>
+    /// <typeparam name="T">Theorem environment type.</typeparam>
+    /// <param name="result">The solution, when the theorem could be satisfied.</param>
+    /// <returns><see langword="true"/> if the theorem was satisfiable; otherwise <see langword="false"/>.</returns>
+    protected bool TrySolve<T>([MaybeNullWhen(false)] out T result)
     {
         using Context ctx = this.context.CreateContext();
         var environment = GetEnvironment(ctx, typeof(T));
@@ -84,19 +101,45 @@ public class Theorem
 
         if (status != Status.SATISFIABLE)
         {
-            return default;
+            result = default;
+            return false;
         }
 
-        return GetSolution<T>(ctx, solver.Model, environment);
+        result = GetSolution<T>(ctx, solver.Model, environment);
+        return true;
     }
 
     /// <summary>
-    /// Solves the theorem using Z3.
+    /// Finds an optimal solution using Z3.
     /// </summary>
     /// <typeparam name="T">Theorem environment type.</typeparam>
     /// <typeparam name="TResult">The Theorem Result.</typeparam>
-    /// <returns>Result of solving the theorem; default(T) if the theorem cannot be satisfied.</returns>
-    protected T Optimize<T, TResult>(Optimization direction, Expression<Func<T, TResult>> lambda)
+    /// <param name="direction">The optimization goal, i.e. whether to minimize or maximize the solution.</param>
+    /// <param name="lambda">Expression representing the value to minimize or maximize.</param>
+    /// <returns>Result of solving the theorem; <c>default(T)</c> if the theorem cannot be satisfied.</returns>
+    /// <remarks>
+    /// Carries the same ambiguity as <see cref="Solve{T}"/> for a value-type environment. Use
+    /// <see cref="TryOptimize{T, TResult}(Optimization, Expression{Func{T, TResult}}, out T)"/>
+    /// where that matters. See #57.
+    /// </remarks>
+    protected T? Optimize<T, TResult>(Optimization direction, Expression<Func<T, TResult>> lambda)
+    {
+        return this.TryOptimize<T, TResult>(direction, lambda, out T? result) ? result : default;
+    }
+
+    /// <summary>
+    /// Finds an optimal solution using Z3, reporting satisfiability separately from the solution.
+    /// </summary>
+    /// <typeparam name="T">Theorem environment type.</typeparam>
+    /// <typeparam name="TResult">The Theorem Result.</typeparam>
+    /// <param name="direction">The optimization goal, i.e. whether to minimize or maximize the solution.</param>
+    /// <param name="lambda">Expression representing the value to minimize or maximize.</param>
+    /// <param name="result">The optimal solution, when the theorem could be satisfied.</param>
+    /// <returns><see langword="true"/> if the theorem was satisfiable; otherwise <see langword="false"/>.</returns>
+    protected bool TryOptimize<T, TResult>(
+        Optimization direction,
+        Expression<Func<T, TResult>> lambda,
+        [MaybeNullWhen(false)] out T result)
     {
         using Context ctx = this.context.CreateContext();
         var environment = GetEnvironment(ctx, typeof(T));
@@ -123,10 +166,12 @@ public class Theorem
 
         if (status != Status.SATISFIABLE)
         {
-            return default!;
+            result = default;
+            return false;
         }
 
-        return GetSolution<T>(ctx, optimizer.Model, environment);
+        result = GetSolution<T>(ctx, optimizer.Model, environment);
+        return true;
     }
 
     /// <summary>

--- a/solutions/Z3.Linq/Theorem{T}.cs
+++ b/solutions/Z3.Linq/Theorem{T}.cs
@@ -1,7 +1,8 @@
-﻿namespace Z3.Linq;
+namespace Z3.Linq;
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Linq.Expressions;
 
@@ -33,8 +34,19 @@ public class Theorem<T> : Theorem, ISolveable<T>
     /// <summary>
     /// Solves the theorem.
     /// </summary>
-    /// <returns>Environment type instance with properties set to theorem-satisfying values.</returns>
+    /// <returns>
+    /// Environment type instance with properties set to theorem-satisfying values, or
+    /// <c>default(T)</c> if the theorem cannot be satisfied.
+    /// </returns>
     /// <remarks>
+    /// <para>
+    /// Where <typeparamref name="T"/> is a value type - a value tuple, a struct, a record struct -
+    /// <c>default(T)</c> is a populated instance with every symbol zero, which is also a perfectly
+    /// good solution to some theorems. The two cannot be told apart here, and the result cannot
+    /// even be compared against <see langword="null"/>. Use <see cref="TrySolve(out T)"/>, or
+    /// <see cref="SolveableExtensions.SolveOrNull{TEnvironment}(ISolveable{TEnvironment})"/>, when
+    /// the difference matters. See #57.
+    /// </para>
     /// <para>
     /// A symbol that no constraint mentions is free: the theorem is still satisfiable, and Z3
     /// assigns the symbol an arbitrary value. Only the symbols the constraints pin down are
@@ -54,18 +66,59 @@ public class Theorem<T> : Theorem, ISolveable<T>
     }
 
     /// <summary>
+    /// Solves the theorem, reporting satisfiability separately from the solution.
+    /// </summary>
+    /// <param name="result">The solution, when the theorem could be satisfied.</param>
+    /// <returns>
+    /// <see langword="true"/> if the theorem was satisfiable; otherwise <see langword="false"/>.
+    /// </returns>
+    /// <remarks>
+    /// The only form that answers "is there a solution?" for every environment type. What is
+    /// written into <paramref name="result"/> when this returns <see langword="true"/> is exactly
+    /// what <see cref="Solve"/> would have returned.
+    /// </remarks>
+    public bool TrySolve([MaybeNullWhen(false)] out T result)
+    {
+        return base.TrySolve(out result);
+    }
+
+    /// <summary>
     /// Finds an optimal solution.
     /// </summary>
+    /// <typeparam name="TResult">Type of the value being optimized.</typeparam>
     /// <param name="direction">The optimization goal, i.e. whether to minimize or maximize the solution.</param>
     /// <param name="lambda">Expression representing the value to minimize or maximize.</param>
-    /// <returns>Environment type instance with properties set to theorem-satisfying values.</returns>
+    /// <returns>
+    /// Environment type instance with properties set to theorem-satisfying values, or
+    /// <c>default(T)</c> if the theorem cannot be satisfied.
+    /// </returns>
     /// <remarks>
-    /// As with <see cref="Solve"/>, a symbol that no constraint mentions is free and takes an
+    /// Carries the same ambiguity as <see cref="Solve"/>, and answers it the same way - through
+    /// <see cref="TryOptimize{TResult}(Optimization, Expression{Func{T, TResult}}, out T)"/>. As
+    /// with <see cref="Solve"/>, a symbol that no constraint mentions is free and takes an
     /// arbitrary value; the objective determines only what it is written in terms of.
     /// </remarks>
-    public T Optimize<TResult>(Optimization direction, Expression<Func<T, TResult>> lambda)
+    public T? Optimize<TResult>(Optimization direction, Expression<Func<T, TResult>> lambda)
     {
         return base.Optimize<T, TResult>(direction, lambda);
+    }
+
+    /// <summary>
+    /// Finds an optimal solution, reporting satisfiability separately from the solution.
+    /// </summary>
+    /// <typeparam name="TResult">Type of the value being optimized.</typeparam>
+    /// <param name="direction">The optimization goal, i.e. whether to minimize or maximize the solution.</param>
+    /// <param name="lambda">Expression representing the value to minimize or maximize.</param>
+    /// <param name="result">The optimal solution, when the theorem could be satisfied.</param>
+    /// <returns>
+    /// <see langword="true"/> if the theorem was satisfiable; otherwise <see langword="false"/>.
+    /// </returns>
+    public bool TryOptimize<TResult>(
+        Optimization direction,
+        Expression<Func<T, TResult>> lambda,
+        [MaybeNullWhen(false)] out T result)
+    {
+        return base.TryOptimize(direction, lambda, out result);
     }
 
     /// <summary>
@@ -81,28 +134,47 @@ public class Theorem<T> : Theorem, ISolveable<T>
     /// <summary>
     /// OrderBy query operator, used to optimize a solution using query expression syntax.
     /// </summary>
+    /// <typeparam name="TResult">Type of the value being minimized.</typeparam>
     /// <param name="lambda">Expression representing the value to minimize.</param>
     /// <returns>Environment type instance with properties set to theorem-satisfying values.</returns>
     public ISolveable<T> OrderBy<TResult>(Expression<Func<T, TResult>> lambda)
-        => new DeferredSolvable(() => Optimize(Optimization.Minimize, lambda));
+        => new DeferredSolvable(() =>
+            TryOptimize(Optimization.Minimize, lambda, out T? solution) ? (true, solution) : (false, default));
 
     /// <summary>
     /// OrderBy query operator, used to optimize a solution using query expression syntax.
     /// </summary>
+    /// <typeparam name="TResult">Type of the value being maximized.</typeparam>
     /// <param name="lambda">Expression representing the value to maximize.</param>
     /// <returns>Environment type instance with properties set to theorem-satisfying values.</returns>
     public ISolveable<T> OrderByDescending<TResult>(Expression<Func<T, TResult>> lambda)
-        => new DeferredSolvable(() => Optimize(Optimization.Maximize, lambda));
+        => new DeferredSolvable(() =>
+            TryOptimize(Optimization.Maximize, lambda, out T? solution) ? (true, solution) : (false, default));
 
-    private class DeferredSolvable : ISolveable<T>
+    /// <summary>
+    /// An optimisation that has not run yet.
+    /// </summary>
+    /// <remarks>
+    /// The deferred call carries satisfiability alongside the solution rather than returning the
+    /// solution alone, because for a value-type environment the solution on its own cannot say
+    /// whether there was one. See #57.
+    /// </remarks>
+    private sealed class DeferredSolvable : ISolveable<T>
     {
-        private readonly Func<T> solve;
+        private readonly Func<(bool Satisfiable, T? Solution)> optimize;
 
-        public DeferredSolvable(Func<T> solve)
+        public DeferredSolvable(Func<(bool Satisfiable, T? Solution)> optimize)
         {
-            this.solve = solve;
+            this.optimize = optimize;
         }
 
-        public T? Solve() => this.solve();
+        public T? Solve() => this.optimize().Solution;
+
+        public bool TrySolve([MaybeNullWhen(false)] out T result)
+        {
+            (bool satisfiable, T? solution) = this.optimize();
+            result = solution!;
+            return satisfiable;
+        }
     }
 }

--- a/solutions/Z3.Linq/Theorem{T}.cs
+++ b/solutions/Z3.Linq/Theorem{T}.cs
@@ -136,17 +136,23 @@ public class Theorem<T> : Theorem, ISolveable<T>
     /// </summary>
     /// <typeparam name="TResult">Type of the value being minimized.</typeparam>
     /// <param name="lambda">Expression representing the value to minimize.</param>
-    /// <returns>Environment type instance with properties set to theorem-satisfying values.</returns>
+    /// <returns>
+    /// A deferred minimization. Nothing reaches Z3 until <see cref="ISolveable{T}.Solve"/> or
+    /// <see cref="ISolveable{T}.TrySolve(out T)"/> is called on the result.
+    /// </returns>
     public ISolveable<T> OrderBy<TResult>(Expression<Func<T, TResult>> lambda)
         => new DeferredSolvable(() =>
             TryOptimize(Optimization.Minimize, lambda, out T? solution) ? (true, solution) : (false, default));
 
     /// <summary>
-    /// OrderBy query operator, used to optimize a solution using query expression syntax.
+    /// OrderByDescending query operator, used to optimize a solution using query expression syntax.
     /// </summary>
     /// <typeparam name="TResult">Type of the value being maximized.</typeparam>
     /// <param name="lambda">Expression representing the value to maximize.</param>
-    /// <returns>Environment type instance with properties set to theorem-satisfying values.</returns>
+    /// <returns>
+    /// A deferred maximization. Nothing reaches Z3 until <see cref="ISolveable{T}.Solve"/> or
+    /// <see cref="ISolveable{T}.TrySolve(out T)"/> is called on the result.
+    /// </returns>
     public ISolveable<T> OrderByDescending<TResult>(Expression<Func<T, TResult>> lambda)
         => new DeferredSolvable(() =>
             TryOptimize(Optimization.Maximize, lambda, out T? solution) ? (true, solution) : (false, default));


### PR DESCRIPTION
Fixes #57.
Fixes #58.

Answers #28, the original report.

## The defect

`Solve()` reports an unsatisfiable theorem by returning `default(T)` (`Theorem.cs:85-87`). For a
reference environment that is `null` and reads correctly. For a value type it is a fully populated
instance with every symbol zero - which is also the answer to plenty of satisfiable theorems:

```csharp
using var ctx = new Z3Context();

(from t in ctx.NewTheorem<(int a, int b)>()
 where t.a == t.b && t.a > 4 && t.b < 2      // no solution
 select t).Solve();                          // (0, 0)

(from t in ctx.NewTheorem<(int a, int b)>()
 where t.a == 0 && t.b == 0                  // exactly one solution
 select t).Solve();                          // (0, 0)
```

Measured, not inferred: those two calls return values that compare equal. And the caller cannot even
ask, because `result is null` on a non-nullable value type is `error CS0037: Cannot convert null to
'(int a, int b)' because it is a non-nullable value type`.

It is not tuple-specific. A `struct` and a `record struct` environment both come back as populated
all-zero instances from an unsatisfiable theorem, so a fix that special-cased `ValueTuple` would
have looked complete and not been.

**The workaround the original report offered does not work.** #28 noted that declaring the
environment as `(int a, int b)?` returns `null` when unsatisfiable, and suggested it as the way
round. Measured: it returns `null` for the unsatisfiable case, and throws
`ArgumentException: Property set method not found.` for a satisfiable one. `Nullable<T>` exposes
`HasValue` and `Value`, both get-only, so the moment there is a solution to write the marshalling
layer fails - and the unsatisfiable case never reaches that code, which is why it looked like it
worked. Before this PR there was no way to distinguish, not even the documented one. Pinned as a
test.

## The change

Additive. `Solve()` behaves exactly as before, so the README samples, the Demo and every existing
test still compile.

| Added | For |
|---|---|
| `bool TrySolve(out T)` on `Theorem<T>` and `ISolveable<T>` | every environment type, including the deferred form an `orderby` query returns |
| `bool TryOptimize<TResult>(Optimization, Expression<Func<T, TResult>>, out T)` | the optimiser's own path, which has its own solve |
| `T? SolveOrNull<T>()` where `T : struct` | lifts a value-type environment to `Nullable<T>`, so `result is null` compiles and means what it says |
| `T? OptimizeOrNull<T, TResult>(...)` where `T : struct` | the same, for optimisation |

`SolveOrNull` and `OptimizeOrNull` are extension methods rather than members because the `struct`
constraint that makes `T?` mean `Nullable<T>` cannot be applied to a member of `Theorem<T>`, whose
`T` is unconstrained. `SolveOrNull` hangs off `ISolveable<T>`, so it reaches the deferred `orderby`
form too.

`Solve<T>` and `Optimize<T, TResult>` are now thin wrappers over the two `Try` forms, so there is
one solve path rather than two copies of it.

### #58, in the same change

`Optimize` was declared to return a non-nullable `T` while returning `default!` when the status was
not `SATISFIABLE`. It now returns `T?`, matching `Solve()`. That is warning-level for consumers, not
an error - but under this repository's `TreatWarningsAsErrors` it **turned ten unchecked
dereferences across six tests in `OptimizationTests.cs` into compiler errors**, each of them a real
unguarded read of a value the library could return null for. Those tests now assert satisfiability
before reading, as they should always have. That is the clearest evidence the signature was wrong:
the compiler found the callers the moment it was allowed to.

Measured, not counted by eye: deleting the ten guards the fix added and rebuilding produces ten
`CS8602`s, one per guard.

One part of #58's diagnosis does not survive checking. It says `OrderBy`/`OrderByDescending`
inherit the defect "since both wrap `Optimize`". They do wrap it, but they hand back
`ISolveable<T>`, whose `Solve()` has been declared `T?` since the interface was introduced in
`217dc16` - and still is on `main`. The query-syntax route was always well-typed; only the direct
`Optimize` call was not. `OrderBy_OnAnUnsatisfiableTheorem_ReturnsNull` says so in a comment, so
the distinction is pinned rather than lost.

Both issues are fixed together because #57 says they are best designed together, and because any
shape that answers #57 has to cover `Optimize` and `OrderBy` anyway - they share `GetSolution` and
the same `default!` return.

## What is deliberately not changed

**`Status.UNKNOWN` is still reported as "no solution".** #57 raises this as a third wrinkle, and it
stays open, for a measured reason: `Z3Context` builds its context from a fixed `{ "MODEL", "true" }`
and exposes no `timeout` or `rlimit`, so a caller cannot ask Z3 to give up. I tried to produce an
`UNKNOWN` through the public API with a nonlinear integer problem - the sum of three cubes - and it
had not returned after 120 seconds; the process had to be killed. Z3 searched rather than
abandoning. A three-state result would model a state that cannot currently be observed, so
`TrySolve` returns a `bool`, and the missing timeout is raised as **#85**, which gates a proper
answer to the wrinkle.

**`Solve()` keeps its ambiguity** rather than being made unambiguous by a breaking change. That was
a deliberate choice of the additive shape; the ambiguity is now documented on `Solve` itself, in
`ISolveable<T>`, in a README section, and pinned by a characterisation test that shows the two
theorems returning the same value.

## Note for reviewers

`ISolveable<T>` gains a member. That is source-breaking for anyone who implemented the interface
themselves - unlikely, since it exists to let `OrderBy` defer, and both implementations are in this
repository - but it is a real break and `next-version` is already `2.0`.

## Tests

187 -> 202, in a new `UnsatisfiabilityTests.cs`, plus the two #58 pins in `OptimizationTests.cs`
rewritten now that the signature tells the truth.

Every negative is paired with a positive over **the same value**, because the whole difficulty is
that the two look identical. A test that only checked the unsatisfiable case would pass against an
implementation that always answered "no solution".

| Test | What it covers |
|---|---|
| `Solve_UnsatisfiableValueTupleTheorem_ReturnsWhatASatisfiableAllZeroTheoremReturns` | the ambiguity itself, as a characterisation - two different theorems, one result |
| `TrySolve_UnsatisfiableValueTupleTheorem_ReturnsFalse` / `TrySolve_SatisfiableAllZeroValueTupleTheorem_ReturnsTrue` | the pair. Both values are `(0, 0)`; only the `bool` differs |
| `TrySolve_SatisfiableTheorem_ReturnsTheSolutionSolveWouldHaveReturned` | the two forms must disagree only about how they report absence |
| `TrySolve_UnsatisfiableReferenceTypeTheorem_ReturnsFalse` | keeps both paths answering the same way |
| `TrySolve_UnsatisfiableStructTheorems_ReturnFalse` | a `struct` and a `record struct` - the problem is the value type, not the tuple |
| `SolveOrNull_UnsatisfiableValueTupleTheorem_ReturnsNull` / `..._SatisfiableAllZeroValueTupleTheorem_ReturnsTheAllZeroSolution` | the same pair through the `Nullable<T>` form |
| `TryOptimize_UnsatisfiableTheorem_ReturnsFalse` / `TryOptimize_SatisfiableTheoremWhoseOptimumIsZero_ReturnsTrue` | the same trap on the optimiser's path, where the optimum genuinely is zero |
| `OptimizeOrNull_UnsatisfiableTheorem_ReturnsNull` / `OptimizeOrNull_SatisfiableTheorem_ReturnsTheOptimum` | the optimisation half of the `Nullable<T>` form |
| `TrySolve_OnADeferredOrderBy_ReportsSatisfiabilityEitherWay` | the deferred solvable's own implementation of the interface |
| `SolveOrNull_OnADeferredOrderByDescending_ReturnsTheOptimum` | the extension reaching the deferred form |
| `Solve_NullableValueTupleEnvironment_ThrowsWhenTheTheoremIsSatisfiable` | the #28 workaround, pinned as the non-answer it is |

## Mutation results

| Mutation | Failures | Which |
|---|---|---|
| `TrySolve` reports satisfiable whatever the status | **4** | every unsatisfiable case, across value tuple, struct, record struct and reference environments |
| `TrySolve` infers satisfiability from the solution instead of the status | **2** | both all-zero satisfiable cases - and nothing else. This is the mutation those pairs exist for: it passes every other test in the suite |
| `TryOptimize` infers satisfiability the same way | **2** | the optimiser case and the deferred `orderby` case, confirming the two solve paths are covered independently |
| The deferred solvable always reports satisfiable | **1** | the deferred test alone |
| `SolveOrNull` / `OptimizeOrNull` ignore the status they were given | **2** | both null cases |
| Revert #58 - `Optimize` declared non-nullable again | **build fails**, `error CS8603` | the signature is load-bearing at compile time, not just documentation |

## Verification

- `dotnet build solutions/Z3.Linq.slnx -c Release` - clean, `TreatWarningsAsErrors` on
- 202/202 locally
- `./build.ps1 -Configuration Release` - 46 tasks, 0 errors, 0 warnings
- Coverage 77.5% -> 78.2% line (670 of 856), 70.3% -> 70.9% branch (460 of 648).
  `SolveableExtensions` and `DeferredSolvable` are both at 100%

## Documentation

A `When there is no solution` section in the README, after the examples: what `Solve()` returns,
why that is ambiguous for a value type, and the three forms that are not. The remarks on `Solve`,
`Optimize` and `ISolveable<T>` say the same thing at the call site.

## New issue

**#85** - no way to bound a solve. `Z3Context`'s configuration is fixed, no `timeout` or `rlimit`
can be set, and there is no `CancellationToken`, so an undecidable theorem runs until the process is
killed. Found while testing whether `Status.UNKNOWN` is reachable; it also explains why it is not.

## Release note

Releases remain on hold under #60 until Microsoft.Z3 5.x reaches nuget.org, so this reaches `main`
but not consumers. Nothing about the hold changes.

