### PR TITLE
Give collections the same sorts as scalars

### DIFF
--- a/solutions/Z3.Linq.Tests/CollectionSymbolTests.cs
+++ b/solutions/Z3.Linq.Tests/CollectionSymbolTests.cs
@@ -6,19 +6,26 @@ namespace Z3.Linq.Tests;
 /// </summary>
 /// <remarks>
 /// <para>
-/// A collection symbol is declared as a Z3 array with a domain (index) sort and a range
-/// (element) sort chosen per element type (Theorem.cs:205-235). Elements are always read with
-/// an integer index (Theorem.cs:448), and the number read is the <c>Count</c> of the collection
-/// already on the instance - so an environment must pre-size its collections, and a solution
-/// never changes their length.
+/// A collection symbol is declared as a Z3 array from <c>Int</c> to the element type's sort -
+/// the same sort a scalar of that type gets, from the one mapping the two share. Elements are
+/// always read back with an integer index, and the number read is the <c>Count</c> of the
+/// collection already on the instance - so an environment must pre-size its collections, and a
+/// solution never changes their length.
 /// </para>
 /// <para>
-/// Only <c>int</c> elements work. Every other element type declares a domain or range that
-/// contradicts how the elements are constrained or read; those cases are pinned below against
-/// #64. Where they fail depends on the constraint - one naming a constant of the element type
-/// fails during translation, while elements left free solve cleanly and fail in the marshalling
-/// loop instead. The Sudoku examples are all <c>int</c>, which is why the limitation has gone
-/// unnoticed.
+/// Every element type a scalar supports now round-trips through a collection too. Until #64
+/// only <c>int</c> did: collections carried a sort mapping of their own, and every row but the
+/// <c>int</c> one declared a domain or range that contradicted how the elements were constrained
+/// or read. Where a case failed depended on the constraint - one naming a constant of the
+/// element type failed during translation, while elements left free solved cleanly and failed
+/// in the marshalling loop instead - which is why the tests below cover both shapes. The Sudoku
+/// examples are all <c>int</c>, which is why the limitation went unnoticed.
+/// </para>
+/// <para>
+/// None of this reaches a collection whose elements are objects. The library builds one array
+/// per property of the element type for those, but neither the visitor nor the marshaller can
+/// use what it built, so a <c>Holder[]</c> symbol fails in every shape - #89. Nothing here
+/// covers that path.
 /// </para>
 /// <para>
 /// A collection symbol can be a property or a public field, and since #53 the two behave
@@ -130,146 +137,451 @@ public class CollectionSymbolTests
     }
 
     /// <summary>
-    /// KNOWN DEFECT (#64): no collection element type other than <c>int</c> can be translated.
-    /// </summary>
-    /// <remarks>
-    /// Each case declares a domain or range sort that contradicts either the constrained values
-    /// or the integer index used to read elements back, so Z3 rejects the term outright. The
-    /// message differs per type, so the assertion is on the exception rather than its text.
-    /// These pin current behaviour and must be updated when the defect is fixed.
-    /// </remarks>
-    [TestMethod]
-    public void Solve_LongArraySymbol_ThrowsZ3Exception()
-    {
-        // Arrange: range is BitVec 64 while the constrained value is an integer term.
-        using var context = new Z3Context();
-        var theorem = context.NewTheorem<LongArrayEnvironment>()
-            .Where(t => t.Values[0] == 1L)
-            .Where(t => t.Length == 2);
-
-        // Act & Assert
-        Should.Throw<Microsoft.Z3.Z3Exception>(() => theorem.Solve());
-    }
-
-    /// <summary>KNOWN DEFECT (#64). See <see cref="Solve_LongArraySymbol_ThrowsZ3Exception"/>.</summary>
-    [TestMethod]
-    public void Solve_BoolArraySymbol_ThrowsZ3Exception()
-    {
-        // Arrange: the domain - the index sort - is declared Bool, but elements are read with an
-        // integer index.
-        using var context = new Z3Context();
-        var theorem = context.NewTheorem<BoolArrayEnvironment>()
-            .Where(t => t.Values[0])
-            .Where(t => t.Length == 2);
-
-        // Act & Assert
-        Should.Throw<Microsoft.Z3.Z3Exception>(() => theorem.Solve());
-    }
-
-    /// <summary>KNOWN DEFECT (#64). See <see cref="Solve_LongArraySymbol_ThrowsZ3Exception"/>.</summary>
-    [TestMethod]
-    public void Solve_DoubleArraySymbol_ThrowsZ3Exception()
-    {
-        // Arrange: range is a floating-point sort while the constrained value is a real.
-        using var context = new Z3Context();
-        var theorem = context.NewTheorem<DoubleArrayEnvironment>()
-            .Where(t => t.Values[0] == 1.5)
-            .Where(t => t.Length == 2);
-
-        // Act & Assert
-        Should.Throw<Microsoft.Z3.Z3Exception>(() => theorem.Solve());
-    }
-
-    /// <summary>
-    /// KNOWN DEFECT (#64), and the reason the array half of #54 cannot be observed.
-    /// </summary>
-    /// <remarks>
-    /// The element loop has its own <c>TypeCode.Single</c> arm with the same defect #54 fixed on
-    /// the scalar path, and it was corrected in the same commit. Nothing reaches the parse it
-    /// contains. The shape below fails during translation, because a float array declares a
-    /// floating-point range against a real-valued constraint, exactly as a double array does;
-    /// leaving the elements free instead gets past translation but no further than the cast on
-    /// the line before the parse, as
-    /// <see cref="Solve_DecimalArrayWithFreeElements_CastsTheElementNotTheArray"/> shows for the
-    /// neighbouring arm.
-    /// This test pins current behaviour and must be updated when the defect is fixed.
-    /// </remarks>
-    [TestMethod]
-    public void Solve_FloatArraySymbol_ThrowsZ3Exception()
-    {
-        // Arrange
-        using var context = new Z3Context();
-        var theorem = context.NewTheorem<FloatArrayEnvironment>()
-            .Where(t => t.Values[0] == 1.5f)
-            .Where(t => t.Length == 2);
-
-        // Act & Assert
-        Should.Throw<Microsoft.Z3.Z3Exception>(() => theorem.Solve());
-    }
-
-    /// <summary>
-    /// KNOWN DEFECT (#64): a decimal array constrained against a decimal constant does not survive
-    /// translation.
-    /// </summary>
-    /// <remarks>
-    /// This is the shape #64 lists, and the reason it concluded the element loop was unreachable
-    /// for a decimal. It is not the only shape: leaving the elements free reaches the loop, which
-    /// is where the three tests below observe the #55 fix.
-    /// This test pins current behaviour and must be updated when the defect is fixed.
-    /// </remarks>
-    [TestMethod]
-    public void Solve_DecimalArraySymbol_ThrowsZ3Exception()
-    {
-        // Arrange
-        using var context = new Z3Context();
-        var theorem = context.NewTheorem<DecimalArrayEnvironment>()
-            .Where(t => t.Values[0] == 1.5m)
-            .Where(t => t.Length == 2);
-
-        // Act & Assert
-        Should.Throw<Microsoft.Z3.Z3Exception>(() => theorem.Solve());
-    }
-
-    /// <summary>
-    /// The defect in #55: the decimal arm of the element loop evaluated the whole array constant
-    /// instead of the element the loop had just selected.
+    /// A <c>long</c> collection round-trips values no <c>int</c> could hold.
     /// </summary>
     /// <remarks>
     /// <para>
-    /// Every other arm of that loop reads <c>numValExpr</c>, the result of
-    /// <c>MkSelect(arrVal, MkInt(i))</c>. The decimal arm called <c>Eval</c> a second time on
-    /// <c>subEnv.Expr</c> - the array itself - and cast the result to
-    /// <see cref="Microsoft.Z3.RatNum"/>, which an array expression can never satisfy. The issue
-    /// describes the symptom as every element taking the same value or the cast failing; measured,
-    /// it is always the cast, in every shape a decimal collection can take.
+    /// The first of the element types #64 fixed. Its range was declared as a 64-bit bit-vector
+    /// while a constrained value translated to an integer term, so Z3 rejected the comparison
+    /// outright - <c>Sorts (_ BitVec 64) and Int are incompatible</c>. The range is now the same
+    /// <c>Int</c> a scalar <c>long</c> has always used.
     /// </para>
     /// <para>
-    /// A decimal collection still cannot be solved, because #64 declares its range as a
-    /// floating-point sort, so the assertion here is about which expression the cast rejects
-    /// rather than about a value. The load-bearing half is that the message no longer names an
-    /// array: that is #55, and reverting the fix fails on it. The element type it does name is
-    /// #64's sort mapping, and that half must be updated when #64 is fixed.
-    /// </para>
-    /// <para>
-    /// #64 records this code as unreachable. That holds only for a constraint naming a decimal
-    /// constant, which fails during translation; with the elements left free the theorem solves
-    /// and the element loop runs.
+    /// The values are beyond <c>Int32</c> range on purpose: a round-trip that silently narrowed
+    /// the element read would only pass by accident.
     /// </para>
     /// </remarks>
     [TestMethod]
-    public void Solve_DecimalArrayWithFreeElements_CastsTheElementNotTheArray()
+    public void Solve_LongArraySymbol_RoundTripsEveryElement()
     {
         // Arrange
         using var context = new Z3Context();
-        var theorem = context.NewTheorem<DecimalArrayEnvironment>()
-            .Where(t => t.Length == 2);
 
         // Act
-        InvalidCastException exception = Should.Throw<InvalidCastException>(() => theorem.Solve());
+        var result = context.NewTheorem<LongArrayEnvironment>()
+            .Where(t => t.Values[0] == 9_000_000_000L)
+            .Where(t => t.Values[1] == -9_000_000_000L)
+            .Where(t => t.Length == 2)
+            .Solve();
 
         // Assert
-        exception.Message.ShouldNotContain("ArrayExpr");
-        exception.Message.ShouldContain("FPNum");
+        result.ShouldNotBeNull();
+        result.Values.ShouldBe([9_000_000_000L, -9_000_000_000L]);
+    }
+
+    [TestMethod]
+    public void Solve_LongListSymbol_RoundTripsEveryElement()
+    {
+        // Arrange: the generic-collection branch, reconstructed through the constructor rather
+        // than ToArray.
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<LongListEnvironment>()
+            .Where(t => t.Values[0] == 9_000_000_000L)
+            .Where(t => t.Values[1] == 1L)
+            .Where(t => t.Length == 2)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.Values.ShouldBe([9_000_000_000L, 1L]);
+    }
+
+    /// <summary>
+    /// A <c>bool</c> collection round-trips each element.
+    /// </summary>
+    /// <remarks>
+    /// The case where the <em>domain</em> was wrong rather than the range: a <c>bool</c>
+    /// collection was declared as an array indexed <em>by</em> <c>Bool</c>, and every element is
+    /// read with an integer index - <c>domain sort Int and parameter Bool do not match</c>. It
+    /// failed the same way whether or not the constraint named a constant, because the index is
+    /// supplied by the library rather than by the constraint. The domain is now <c>Int</c> for
+    /// every element type.
+    /// </remarks>
+    [TestMethod]
+    public void Solve_BoolArraySymbol_RoundTripsEveryElement()
+    {
+        // Arrange
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<BoolArrayEnvironment>()
+            .Where(t => t.Values[0])
+            .Where(t => !t.Values[1])
+            .Where(t => t.Length == 2)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.Values.ShouldBe([true, false]);
+    }
+
+    [TestMethod]
+    public void Solve_BoolListSymbol_RoundTripsEveryElement()
+    {
+        // Arrange
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<BoolListEnvironment>()
+            .Where(t => !t.Values[0])
+            .Where(t => t.Values[1])
+            .Where(t => t.Length == 2)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.Values.ShouldBe([false, true]);
+    }
+
+    /// <summary>
+    /// A <c>double</c> collection round-trips each element.
+    /// </summary>
+    /// <remarks>
+    /// The range was a floating-point sort while a constrained value translated to a real -
+    /// <c>Sorts (_ FloatingPoint 11 53) and Real are incompatible</c>. A scalar <c>double</c> has
+    /// always been a <c>Real</c>, and its collection now is too. The values are chosen to be
+    /// exactly representable, so the assertion is about the sort and not about rounding.
+    /// </remarks>
+    [TestMethod]
+    public void Solve_DoubleArraySymbol_RoundTripsEveryElement()
+    {
+        // Arrange
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<DoubleArrayEnvironment>()
+            .Where(t => t.Values[0] == 1.5)
+            .Where(t => t.Values[1] == -2.25)
+            .Where(t => t.Length == 2)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.Values.ShouldBe([1.5, -2.25]);
+    }
+
+    [TestMethod]
+    public void Solve_DoubleArrayWithRelationalConstraints_SatisfiesThemAll()
+    {
+        // Arrange: elements related to each other rather than pinned, over a real-sorted
+        // collection - the shape the int tests above use, now available to every element type.
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<DoubleArrayEnvironment>()
+            .Where(t => t.Values[0] > 2.5)
+            .Where(t => t.Values[1] == t.Values[0] * 2)
+            .Where(t => t.Length == 2)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.Values[0].ShouldBeGreaterThan(2.5);
+        result.Values[1].ShouldBe(result.Values[0] * 2);
+    }
+
+    /// <summary>
+    /// A <c>float</c> collection round-trips each element - the array half of #54, observable for
+    /// the first time.
+    /// </summary>
+    /// <remarks>
+    /// The element loop has had its own <c>TypeCode.Single</c> arm, corrected alongside the
+    /// scalar one when #54 was fixed, and until #64 nothing could reach it: a constrained
+    /// <c>float</c> collection failed during translation exactly as a <c>double</c> one did, and
+    /// a free one got no further than the cast on the line before the parse. This is the first
+    /// test that exercises that arm, and <c>0.1f</c> is here because it is not exactly
+    /// representable - the parse has to produce the same <c>float</c> the constraint named.
+    /// </remarks>
+    [TestMethod]
+    public void Solve_FloatArraySymbol_RoundTripsEveryElement()
+    {
+        // Arrange
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<FloatArrayEnvironment>()
+            .Where(t => t.Values[0] == 1.5f)
+            .Where(t => t.Values[1] == 0.1f)
+            .Where(t => t.Length == 2)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.Values.ShouldBe([1.5f, 0.1f]);
+    }
+
+    /// <summary>
+    /// A <c>decimal</c> collection round-trips each element.
+    /// </summary>
+    /// <remarks>
+    /// This is the shape #64 listed for <c>decimal</c> - a constraint naming a decimal constant -
+    /// and the reason it concluded the element loop was unreachable. The range it declared was a
+    /// 32-bit floating-point sort, which would not have held a <c>decimal</c> even if the sorts
+    /// had agreed; see <see cref="Solve_DecimalArraySymbol_RoundTripsAtFullPrecision"/> for the
+    /// case that proves the range is now a <c>Real</c>.
+    /// </remarks>
+    [TestMethod]
+    public void Solve_DecimalArraySymbol_RoundTripsEveryElement()
+    {
+        // Arrange
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<DecimalArrayEnvironment>()
+            .Where(t => t.Values[0] == 1.5m)
+            .Where(t => t.Values[1] == 0.1m)
+            .Where(t => t.Length == 2)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.Values.ShouldBe([1.5m, 0.1m]);
+    }
+
+    /// <summary>
+    /// A <c>decimal</c> element survives at full precision.
+    /// </summary>
+    /// <remarks>
+    /// <c>decimal.MaxValue</c> has 29 significant digits. No floating-point sort Z3 offers could
+    /// return it exactly, so this passing is direct evidence that the element range is the same
+    /// unbounded <c>Real</c> a scalar <c>decimal</c> uses, rather than a wider float that would
+    /// pass the test above and lose precision quietly on larger values.
+    /// </remarks>
+    [TestMethod]
+    public void Solve_DecimalArraySymbol_RoundTripsAtFullPrecision()
+    {
+        // Arrange
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<DecimalArrayEnvironment>()
+            .Where(t => t.Values[0] == decimal.MaxValue)
+            .Where(t => t.Values[1] == 0.0000000000000000000000000001m)
+            .Where(t => t.Length == 2)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.Values.ShouldBe([decimal.MaxValue, 0.0000000000000000000000000001m]);
+    }
+
+    [TestMethod]
+    public void Solve_DecimalListSymbol_RoundTripsEveryElement()
+    {
+        // Arrange
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<DecimalListEnvironment>()
+            .Where(t => t.Values[0] == 2.5m)
+            .Where(t => t.Values[1] == 1.5m)
+            .Where(t => t.Length == 2)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.Values.ShouldBe([2.5m, 1.5m]);
+    }
+
+    /// <summary>
+    /// A <c>string</c> collection round-trips each element.
+    /// </summary>
+    /// <remarks>
+    /// The other domain case, alongside <c>bool</c>: a <c>string</c> collection was declared as
+    /// indexed by <c>String</c>, with a 16-bit bit-vector range that could not have held a
+    /// string either. Both halves were wrong, and both now come from the shared mapping - an
+    /// <c>Int</c> domain and the <c>String</c> sort a scalar uses. The empty string is included
+    /// because it is what completion supplies for a free element, so a test that pinned only
+    /// non-empty values could not tell a constrained element from an unconstrained one.
+    /// </remarks>
+    [TestMethod]
+    public void Solve_StringArraySymbol_RoundTripsEveryElement()
+    {
+        // Arrange
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<StringArrayEnvironment>()
+            .Where(t => t.Values[0] == "abc")
+            .Where(t => t.Values[1] == "")
+            .Where(t => t.Length == 2)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.Values.ShouldBe(["abc", ""]);
+    }
+
+    /// <summary>
+    /// A <c>DateTime</c> collection round-trips each instant exactly, as UTC.
+    /// </summary>
+    /// <remarks>
+    /// <c>DateTime</c> shared the <c>long</c> row of the old mapping and failed the same two ways.
+    /// #56 had already corrected the element read to <c>FromFileTimeUtc</c>, so once the range
+    /// is <c>Int</c> nothing else on this path needs to change - the comment on #64 that
+    /// measured exactly that is what this test pins.
+    /// </remarks>
+    [TestMethod]
+    public void Solve_DateTimeArraySymbol_RoundTripsEveryElement()
+    {
+        // Arrange
+        using var context = new Z3Context();
+        DateTime first = new(2026, 6, 1, 12, 0, 0, DateTimeKind.Utc);
+        DateTime second = new(2026, 6, 2, 9, 30, 0, DateTimeKind.Utc);
+
+        // Act
+        var result = context.NewTheorem<DateTimeArrayEnvironment>()
+            .Where(t => t.Values[0] == first)
+            .Where(t => t.Values[1] == second)
+            .Where(t => t.Length == 2)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.Values.ShouldBe([first, second]);
+        result.Values[0].Kind.ShouldBe(DateTimeKind.Utc);
+        result.Values[1].Kind.ShouldBe(DateTimeKind.Utc);
+    }
+
+    [TestMethod]
+    public void Solve_DateTimeListSymbol_RoundTripsEveryElement()
+    {
+        // Arrange
+        using var context = new Z3Context();
+        DateTime instant = new(2026, 6, 1, 12, 0, 0, DateTimeKind.Utc);
+
+        // Act
+        var result = context.NewTheorem<DateTimeListEnvironment>()
+            .Where(t => t.Values[0] == instant)
+            .Where(t => t.Values[1] == instant)
+            .Where(t => t.Length == 2)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.Values.ShouldBe([instant, instant]);
+    }
+
+    /// <summary>
+    /// A <c>DateTime</c> collection with free elements reads back as UTC.
+    /// </summary>
+    /// <remarks>
+    /// The instants are completion's to choose and are not asserted - measured, they are
+    /// <c>1601-01-01T00:00:00Z</c>, file time zero, which is the earliest instant the encoding
+    /// can express (#83). The kind is fixed by the read path and can be asserted where the value
+    /// cannot, as the scalar family in <c>SymbolTypeMarshallingTests</c> does.
+    /// </remarks>
+    [TestMethod]
+    public void Solve_DateTimeArrayWithFreeElements_ReadsBackAsUtc()
+    {
+        // Arrange
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<DateTimeArrayEnvironment>()
+            .Where(t => t.Length == 2)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.Values.Length.ShouldBe(2);
+        result.Values[0].Kind.ShouldBe(DateTimeKind.Utc);
+        result.Values[1].Kind.ShouldBe(DateTimeKind.Utc);
+    }
+
+    /// <summary>
+    /// A <c>short</c> collection round-trips each element.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A <c>short</c> collection had three defects stacked, and this test is the first to reach
+    /// the third. The range was a 16-bit bit-vector, so the widened comparison failed in the
+    /// visitor (#64); behind that sat the <c>Convert</c> node #63 fixed for scalars, which the
+    /// guard there handles for a select just as well; and behind <em>that</em> the element loop
+    /// still shared its <c>Int16</c> arm with <c>Int32</c> and handed reflection an <c>int</c>.
+    /// The last was recorded on #64 when #63 was fixed, because it could not be tested until this
+    /// change made it reachable.
+    /// </para>
+    /// <para>
+    /// The arithmetic form is here rather than in a separate test because it is the one that
+    /// reaches the #63 guard: a bare equality against a constant is folded to a comparison of
+    /// the select with a literal, while an addition is where C# inserts the widening.
+    /// </para>
+    /// </remarks>
+    [TestMethod]
+    public void Solve_ShortArraySymbol_RoundTripsEveryElement()
+    {
+        // Arrange
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<ShortArrayEnvironment>()
+            .Where(t => t.Values[0] + t.Values[1] == 10)
+            .Where(t => t.Values[0] == 4)
+            .Where(t => t.Length == 2)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.Values.ShouldBe([(short)4, (short)6]);
+    }
+
+    /// <summary>
+    /// A <c>short</c> element whose model value no <c>short</c> can hold fails loudly.
+    /// </summary>
+    /// <remarks>
+    /// The element read is a checked cast, as the scalar arm has been since #63 and for the same
+    /// reason: the array's range is an unbounded <c>Int</c>, so a constraint written against the
+    /// widened <c>int</c> can be satisfied by a value the element cannot hold, and an unchecked
+    /// cast would wrap it into a plausible wrong answer. #87 - bounding the symbol so Z3 cannot
+    /// pick such a value - applies to elements exactly as it does to scalars.
+    /// </remarks>
+    [TestMethod]
+    public void Solve_ShortArrayElementConstrainedOutsideShortRange_ThrowsOverflowException()
+    {
+        // Arrange
+        using var context = new Z3Context();
+        int beyondShortRange = 40000;
+        var theorem = context.NewTheorem<ShortArrayEnvironment>()
+            .Where(t => t.Values[0] == beyondShortRange)
+            .Where(t => t.Length == 2);
+
+        // Act & Assert
+        Should.Throw<OverflowException>(() => theorem.Solve());
+    }
+
+    /// <summary>
+    /// A <c>decimal</c> collection with free elements is materialised at its initialised length.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The shape that reaches the element loop without naming a decimal constant, and the one
+    /// that observed #55 while #64 still stood: the decimal arm evaluated the whole array
+    /// constant instead of the element the loop had just selected, and cast the result to
+    /// <see cref="Microsoft.Z3.RatNum"/>, which an array expression can never satisfy. Before
+    /// #64 the fix could only be seen in which type the failing cast named; now the loop
+    /// completes, and reverting #55 fails this test outright.
+    /// </para>
+    /// <para>
+    /// The element values come from model completion and are not asserted.
+    /// </para>
+    /// </remarks>
+    [TestMethod]
+    public void Solve_DecimalArrayWithFreeElements_ReturnsTheInitialisedLength()
+    {
+        // Arrange
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<DecimalArrayEnvironment>()
+            .Where(t => t.Length == 2)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.Values.Length.ShouldBe(2);
     }
 
     /// <summary>
@@ -282,44 +594,45 @@ public class CollectionSymbolTests
     /// <c>ToArray</c> - and only the element read is shared.
     /// </remarks>
     [TestMethod]
-    public void Solve_DecimalListWithFreeElements_CastsTheElementNotTheArray()
+    public void Solve_DecimalListWithFreeElements_ReturnsTheInitialisedLength()
     {
         // Arrange
         using var context = new Z3Context();
-        var theorem = context.NewTheorem<DecimalListEnvironment>()
-            .Where(t => t.Length == 2);
 
         // Act
-        InvalidCastException exception = Should.Throw<InvalidCastException>(() => theorem.Solve());
+        var result = context.NewTheorem<DecimalListEnvironment>()
+            .Where(t => t.Length == 2)
+            .Solve();
 
         // Assert
-        exception.Message.ShouldNotContain("ArrayExpr");
-        exception.Message.ShouldContain("FPNum");
+        result.ShouldNotBeNull();
+        result.Values.Count.ShouldBe(2);
     }
 
     /// <summary>
-    /// The element loop is reached by a theorem that genuinely constrains the elements, not only
-    /// by one that leaves them out of the constraints altogether.
+    /// Elements of a <c>decimal</c> collection can be related to each other.
     /// </summary>
     /// <remarks>
-    /// Relating two elements to each other puts both selects in the formula while naming no
-    /// decimal constant, so nothing forces the sort mismatch #64 describes and translation
-    /// succeeds. Without this the fix could be dismissed as only mattering to empty theorems.
+    /// Relating two elements puts both selects in the formula while naming no constant, which
+    /// is the shape that reached the element loop under #64 and now yields a value. The lower
+    /// bound is there so the equality cannot be satisfied trivially by the completion default.
     /// </remarks>
     [TestMethod]
-    public void Solve_DecimalArrayWithElementsConstrainedToEachOther_CastsTheElementNotTheArray()
+    public void Solve_DecimalArrayWithElementsConstrainedToEachOther_ReturnsEqualElements()
     {
         // Arrange
         using var context = new Z3Context();
-        var theorem = context.NewTheorem<DecimalArrayEnvironment>()
-            .Where(t => t.Values[0] == t.Values[1]);
 
         // Act
-        InvalidCastException exception = Should.Throw<InvalidCastException>(() => theorem.Solve());
+        var result = context.NewTheorem<DecimalArrayEnvironment>()
+            .Where(t => t.Values[0] == t.Values[1])
+            .Where(t => t.Values[0] > 1.25m)
+            .Solve();
 
         // Assert
-        exception.Message.ShouldNotContain("ArrayExpr");
-        exception.Message.ShouldContain("FPNum");
+        result.ShouldNotBeNull();
+        result.Values[0].ShouldBeGreaterThan(1.25m);
+        result.Values[1].ShouldBe(result.Values[0]);
     }
 
     /// <summary>
@@ -501,25 +814,29 @@ public class CollectionSymbolTests
     }
 
     /// <summary>
-    /// KNOWN DEFECT (#64): a field is no better off than a property for element types other than
-    /// <c>int</c>.
+    /// A field is no different from a property for element types other than <c>int</c>.
     /// </summary>
     /// <remarks>
-    /// Translation fails before any marshalling happens, so this failed identically before #53 was
-    /// fixed. It is here so the fix cannot be mistaken for having widened the element types a
-    /// field supports. See <see cref="Solve_LongArraySymbol_ThrowsZ3Exception"/>.
-    /// This test pins current behaviour and must be updated when the defect is fixed.
+    /// This was pinned as a failure while #64 stood, so that the #53 fix could not be mistaken
+    /// for having widened the element types a field supports. It is kept as the positive case
+    /// for the same reason in reverse: the sort mapping is chosen before the member kind matters,
+    /// so a field gets the corrected declaration exactly as a property does.
     /// </remarks>
     [TestMethod]
-    public void Solve_LongArrayInAPublicField_ThrowsZ3Exception()
+    public void Solve_LongArrayInAPublicField_RoundTripsEveryElement()
     {
         // Arrange
         using var context = new Z3Context();
-        var theorem = context.NewTheorem<LongFieldCollectionEnvironment>()
-            .Where(t => t.Values[0] == 1L);
 
-        // Act & Assert
-        Should.Throw<Microsoft.Z3.Z3Exception>(() => theorem.Solve());
+        // Act
+        var result = context.NewTheorem<LongFieldCollectionEnvironment>()
+            .Where(t => t.Values[0] == 9_000_000_000L)
+            .Where(t => t.Values[1] == 2L)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.Values.ShouldBe([9_000_000_000L, 2L]);
     }
 
     /// <summary>
@@ -689,6 +1006,48 @@ public class CollectionSymbolTests
     private sealed class DecimalListEnvironment
     {
         public List<decimal> Values { get; set; } = [0m, 0m];
+
+        public int Length { get; set; }
+    }
+
+    private sealed class LongListEnvironment
+    {
+        public List<long> Values { get; set; } = [0L, 0L];
+
+        public int Length { get; set; }
+    }
+
+    private sealed class BoolListEnvironment
+    {
+        public List<bool> Values { get; set; } = [false, false];
+
+        public int Length { get; set; }
+    }
+
+    private sealed class StringArrayEnvironment
+    {
+        public string[] Values { get; set; } = new string[2];
+
+        public int Length { get; set; }
+    }
+
+    private sealed class DateTimeArrayEnvironment
+    {
+        public DateTime[] Values { get; set; } = new DateTime[2];
+
+        public int Length { get; set; }
+    }
+
+    private sealed class DateTimeListEnvironment
+    {
+        public List<DateTime> Values { get; set; } = [default, default];
+
+        public int Length { get; set; }
+    }
+
+    private sealed class ShortArrayEnvironment
+    {
+        public short[] Values { get; set; } = new short[2];
 
         public int Length { get; set; }
     }

--- a/solutions/Z3.Linq/Theorem.cs
+++ b/solutions/Z3.Linq/Theorem.cs
@@ -224,6 +224,29 @@ public class Theorem
         }
     }
 
+    /// <summary>
+    /// Gets the Z3 sort a symbol of the given CLR type is declared with, or <see langword="null"/>
+    /// if the type is not one the library maps.
+    /// </summary>
+    /// <remarks>
+    /// This is the only mapping from CLR type to sort. A scalar symbol is a constant of this sort,
+    /// and a collection symbol is a Z3 array from <c>Int</c> to it, so the two cannot disagree -
+    /// there is nothing else to consult. Collections used to carry a mapping of their own, and
+    /// only its <c>int</c> row agreed with this one; every other element type declared a domain or
+    /// range that contradicted how its elements were constrained and read back. See #64.
+    /// </remarks>
+    private static Sort? TryGetSymbolSort(Context context, TypeCode typeCode)
+    {
+        return typeCode switch
+        {
+            TypeCode.String => context.StringSort,
+            TypeCode.Int16 or TypeCode.Int32 or TypeCode.Int64 or TypeCode.DateTime => context.IntSort,
+            TypeCode.Boolean => context.BoolSort,
+            TypeCode.Single or TypeCode.Decimal or TypeCode.Double => context.RealSort,
+            _ => null,
+        };
+    }
+
     private Environment GetEnvironment(Context context, Type targetType)
     {
         return GetEnvironment(context, targetType, targetType.Name);
@@ -246,65 +269,34 @@ public class Theorem
                 elType = targetType.GetGenericArguments()[0];
             }
 
-            Sort arrDomain;
-            Sort arrRange;
-                
-            switch (Type.GetTypeCode(elType))
-            {
-                case TypeCode.String:
-                    arrDomain = context.StringSort;
-                    arrRange = context.MkBitVecSort(16);
-                    break;
-                case TypeCode.Int16:
-                    arrDomain = context.IntSort;
-                    arrRange = context.MkBitVecSort(16);
-                    break;
-                case TypeCode.Int32:
-                    arrDomain = context.IntSort;
-                    arrRange = context.IntSort;
-                    break;
-                case TypeCode.Int64:
-                case TypeCode.DateTime:
-                    arrDomain = context.IntSort;
-                    arrRange = context.MkBitVecSort(64);
-                    break;
-                case TypeCode.Boolean:
-                    arrDomain = context.BoolSort;
-                    arrRange = context.BoolSort;
-                    break;
-                case TypeCode.Single:
-                    arrDomain = context.RealSort;
-                    arrRange = context.MkFPSortSingle();
-                    break;
-                case TypeCode.Decimal:
-                    arrDomain = context.RealSort;
-                    arrRange = context.MkFPSortSingle();
-                    break;
-                case TypeCode.Double:
-                    arrDomain = context.RealSort;
-                    arrRange = context.MkFPSortDouble();
-                    break;
-                case TypeCode.Object:
-                    toReturn.IsArray = true;
+            TypeCode elTypeCode = Type.GetTypeCode(elType);
 
-                    foreach (PropertyInfo parameter in elType!.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+            if (elTypeCode == TypeCode.Object)
+            {
+                toReturn.IsArray = true;
+
+                foreach (PropertyInfo parameter in elType!.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+                {
+                    var newPrefix = parameter.Name;
+
+                    if (!string.IsNullOrEmpty(prefix))
                     {
-                        var newPrefix = parameter.Name;
-                            
-                        if (!string.IsNullOrEmpty(prefix))
-                        {
-                            newPrefix = $"{prefix}_{newPrefix}";
-                        }
-                            
-                        toReturn.Properties[parameter] = GetEnvironment(context, parameter, newPrefix, true);
+                        newPrefix = $"{prefix}_{newPrefix}";
                     }
 
-                    return toReturn;
-                default:
-                    throw new NotSupportedException($"Unsupported member type {targetType.FullName}");
+                    toReturn.Properties[parameter] = GetEnvironment(context, parameter, newPrefix, true);
+                }
+
+                return toReturn;
             }
 
-            toReturn.Expr = context.MkArrayConst(prefix, arrDomain, arrRange);
+            // Elements are always read back with an integer index - ConvertZ3Expression selects
+            // with MkInt(i) - so the domain is Int whatever the element type. The range is the
+            // sort a scalar of that type would get, from the one mapping both share. See #64.
+            Sort elementSort = TryGetSymbolSort(context, elTypeCode)
+                ?? throw new NotSupportedException($"Unsupported member type {targetType.FullName}");
+
+            toReturn.Expr = context.MkArrayConst(prefix, context.IntSort, elementSort);
         }
         else
         {
@@ -362,75 +354,26 @@ public class Theorem
             // indistinguishable. Using the prefix means those become ValueTuple`8_Item1 and
             // ValueTuple`8_Rest_Item1.
             string name = prefix;
-            switch (Type.GetTypeCode(parameterType))
+            TypeCode typeCode = Type.GetTypeCode(parameterType);
+
+            if (typeCode == TypeCode.Object)
             {
-                case TypeCode.String:
-                    constrExp = context.MkConst(name, context.StringSort);
-                    break;
-                case TypeCode.Int16:
-                case TypeCode.Int32:
-                case TypeCode.Int64:
-                case TypeCode.DateTime:
-                    constrExp = context.MkIntConst(name);
-                    break;
-                case TypeCode.Boolean:
-                    constrExp = context.MkBoolConst(name);
-                    break;
-                case TypeCode.Single:
-                case TypeCode.Decimal:
-                case TypeCode.Double:
-                    constrExp = context.MkRealConst(name);
-                    break;
-                case TypeCode.Object:
-                    return GetEnvironment(context, parameterType, prefix);
-                default:
-                    throw new NotSupportedException("Unsupported parameter type for " + name + ".");
+                return GetEnvironment(context, parameterType, prefix);
             }
+
+            Sort sort = TryGetSymbolSort(context, typeCode)
+                ?? throw new NotSupportedException("Unsupported parameter type for " + name + ".");
+
+            constrExp = context.MkConst(name, sort);
         }
         else
         {
-            Sort arrDomain;
-            Sort arrRange;
-            switch (Type.GetTypeCode(parameterType))
-            {
-                case TypeCode.String:
-                    arrDomain = context.StringSort;
-                    arrRange = context.MkBitVecSort(16);
-                    break;
-                case TypeCode.Int16:
-                    arrDomain = context.IntSort;
-                    arrRange = context.MkBitVecSort(16);
-                    break;
-                case TypeCode.Int32:
-                    arrDomain = context.IntSort;
-                    arrRange = context.IntSort;
-                    break;
-                case TypeCode.Int64:
-                case TypeCode.DateTime:
-                    arrDomain = context.IntSort;
-                    arrRange = context.MkBitVecSort(64);
-                    break;
-                case TypeCode.Boolean:
-                    arrDomain = context.BoolSort;
-                    arrRange = context.BoolSort;
-                    break;
-                case TypeCode.Single:
-                    arrDomain = context.RealSort;
-                    arrRange = context.MkFPSortSingle();
-                    break;
-                case TypeCode.Decimal:
-                    arrDomain = context.RealSort;
-                    arrRange = context.MkFPSortSingle();
-                    break;
-                case TypeCode.Double:
-                    arrDomain = context.RealSort;
-                    arrRange = context.MkFPSortDouble();
-                    break;
-                default:
-                    throw new NotSupportedException($"Only one level of object collections is currently supported, 2 levels detected with prefix {prefix}");
+            // One Z3 array per property of the element type, indexed by position. Domain and
+            // range are chosen exactly as for a collection of the property type. See #64.
+            Sort elementSort = TryGetSymbolSort(context, Type.GetTypeCode(parameterType))
+                ?? throw new NotSupportedException($"Only one level of object collections is currently supported, 2 levels detected with prefix {prefix}");
 
-            }
-            constrExp = context.MkArrayConst(prefix, arrDomain, arrRange);
+            constrExp = context.MkArrayConst(prefix, context.IntSort, elementSort);
         }
 
         toReturn.Expr = constrExp;
@@ -500,6 +443,9 @@ public class Theorem
                             numVal = numValExpr.String;
                             break;
                         case TypeCode.Int16:
+                            // Checked, for the reason given on the scalar arm below. See #63.
+                            numVal = checked((short)((IntNum)numValExpr).Int);
+                            break;
                         case TypeCode.Int32:
                             numVal = ((IntNum)numValExpr).Int;
                             break;


### PR DESCRIPTION
Fixes #64.

## The defect

Collection symbols only worked with `int` elements. Every other element type built a Z3 array
whose domain or range contradicted how its elements were constrained and read back, and the
theorem threw a raw `Z3Exception` about sorts:

```csharp
public class Env { public long[] Values { get; set; } = new long[2]; public int Length { get; set; } }

using var context = new Z3Context();
context.NewTheorem<Env>().Where(t => t.Values[0] == 1L).Where(t => t.Length == 2).Solve();
// Microsoft.Z3.Z3Exception: Sorts (_ BitVec 64) and Int are incompatible
```

The array sort mapping - which existed in two identical copies - paired a domain and a range per
element type:

| Element | Domain (index) | Range (element) | What was wrong |
|---|---|---|---|
| `int` | `Int` | `Int` | nothing - the only self-consistent row |
| `short` | `Int` | `BitVec 16` | range: constraints translate to `Int` |
| `long`, `DateTime` | `Int` | `BitVec 64` | range |
| `bool` | **`Bool`** | `Bool` | domain: elements are read with an integer index |
| `string` | **`String`** | `BitVec 16` | both |
| `float`, `decimal` | **`Real`** | `FloatingPoint 8 24` | range - and a `decimal` could never have fitted |
| `double` | **`Real`** | `FloatingPoint 11 53` | range |

Measured before the change, every non-`int` type failed in one of two places depending on the
constraint - during translation when it named a constant of the element type, or in the
marshalling loop when the elements were left free - which is why the tests cover both shapes.
`bool` and `string` failed in the same place either way, because the index is supplied by the
library rather than by the constraint.

## The change

**The collection mapping is deleted. There is one function from CLR type to sort, and a
collection is an array from `Int` to whatever that function says a scalar of the element type
is.**

```csharp
private static Sort? TryGetSymbolSort(Context context, TypeCode typeCode) => typeCode switch
{
    TypeCode.String => context.StringSort,
    TypeCode.Int16 or TypeCode.Int32 or TypeCode.Int64 or TypeCode.DateTime => context.IntSort,
    TypeCode.Boolean => context.BoolSort,
    TypeCode.Single or TypeCode.Decimal or TypeCode.Double => context.RealSort,
    _ => null,
};
```

The scalar path calls it for its constant; both collection paths call it for their range and use
`Int` for their domain. That is the actual fix, not the corrected table: the defect was two
mappings that could drift, and now there is nothing to drift. The mutation matrix below is the
evidence - reverting one row of the shared mapping fails scalar and collection tests together.

The rest is 54 net lines removed, three `NotSupportedException` messages preserved exactly, and
one more thing:

**The array-element read for `short` gets the checked cast** the scalar arm has had since #63.
That arm was unreachable until this change - noted on #64 at the time, with the reason - and is
covered for the first time here, including the overflow pin.

## Measured after the change

Every element type, both shapes, arrays and `List<T>`:

| Element | Constrained | Free elements |
|---|---|---|
| `long` | `[9000000000, -9000000000]` exact | `[0, 0]` |
| `bool` | `[true, false]` | `[false, false]` |
| `double` | `[1.5, -2.25]`; relational `[3.5, 7]` | `[0, 0]` |
| `float` | `[1.5, 0.1]` - the array half of #54, observable for the first time | `[0, 0]` |
| `decimal` | `[1.5, 0.1]`; **`decimal.MaxValue` exact**, 29 significant digits | `[0, 0]` |
| `string` | `["abc", ""]` | `["", ""]` |
| `DateTime` | two instants exact, kind `Utc` | `1601-01-01Z`, file time zero, kind `Utc` |
| `short` | `[4, 6]` through arithmetic; out-of-range → `OverflowException` | `[0, 0]` |

`decimal.MaxValue` is the load-bearing one. No floating-point sort Z3 offers could return it
exactly, so it passing is direct evidence the range is an unbounded `Real` rather than a wider
float that would pass the ordinary values and lose precision quietly on large ones.

## What is deliberately not changed

**Object collections stay broken, and are now #89.** A `Holder[]` whose elements have scalar
properties fails in every shape - constraining `t.Items[0].Value` dies in the visitor
(`Unknown parameter encountered: Value`), and leaving the elements free dies in the marshaller
(`requires subEnv.Expr to be non-null`). Measured before and after this change; identical.
It is a different mechanism from #64: the library builds one per-property array for these and
then neither end of the pipeline can use it, and `Environment.IsArray` - the flag that would
route either end - is written and never read. The per-property arrays now go through the shared
mapping, so the sort side is settled for whoever finishes it. The library's own error message,
`Only one level of object collections is currently supported`, promises something that does not
work; #89 says so.

**#87 applies to elements too.** A `short` element is an unbounded `Int` exactly as a `short`
scalar is, so Z3 can still pick a value the element cannot hold. The checked read makes that loud
rather than wrong, which is the same trade-off #63 made and for the same reason.

## Tests

214 → 225, in `CollectionSymbolTests.cs`. The nine characterisation pins that asserted the old
failures are replaced by round-trips, and the three #55 tests - which until now could only
observe that fix in *which type the failing cast named* - become positive tests that reverting
#55 fails outright.

| Test | What it covers |
|---|---|
| `Solve_LongArraySymbol_RoundTripsEveryElement` / `..LongList..` / `..LongArrayInAPublicField..` | the range fix; values beyond `Int32` so a narrowing read cannot pass by accident |
| `Solve_BoolArraySymbol..` / `..BoolList..` | the domain fix |
| `Solve_StringArraySymbol_RoundTripsEveryElement` | both halves were wrong; includes `""` so a constrained element is distinguishable from a free one |
| `Solve_DoubleArraySymbol..` / `..WithRelationalConstraints..` | real range; the relational shape the `int` tests use, now available to every type |
| `Solve_FloatArraySymbol_RoundTripsEveryElement` | the first test ever to reach the element loop's `Single` arm |
| `Solve_DecimalArraySymbol_RoundTripsEveryElement` / `..AtFullPrecision` / `..DecimalList..` | real range; `decimal.MaxValue` proves it is not a float |
| `Solve_DateTimeArraySymbol..` / `..DateTimeList..` / `..WithFreeElements_ReadsBackAsUtc` | the row a comment on #64 had already measured; kind asserted where the value cannot be |
| `Solve_ShortArraySymbol_RoundTripsEveryElement` | three stacked defects - #64, the #63 guard over a select, and the element arm's `Int16` case |
| `Solve_ShortArrayElementConstrainedOutsideShortRange_ThrowsOverflowException` | the checked read; the only thing between current behaviour and a silent wrap |
| `Solve_DecimalArrayWithFreeElements_ReturnsTheInitialisedLength` and siblings | #55, now covered by a passing test instead of an exception message |

## Mutation results

| Mutation | Failures | Which |
|---|---|---|
| Domain back to the element sort | **3** | `bool` array, `bool` list, `string` array - exactly the domain cases. Real-domained arrays tolerate an integer index, which is why `double` did not fail on domain in the original table either |
| Shared mapping: real row → `FloatingPoint` | **43** | `double`/`float`/`decimal` **scalars and collections together**, across five test files |
| Shared mapping: `long`/`DateTime` row → `BitVec 64` | **18** | `long`/`DateTime` scalars and collections together |
| Revert #55 | **6** | every decimal collection test |
| Element `short` read `unchecked` | **1** | the overflow pin alone |
| Object-collection per-property arrays: domain back to the element sort | **0** | unreachable behind #89 - stated rather than implied |

The second and third rows are the point of the design. Before this change a wrong row in the
collection mapping failed only collections and the scalar suite stayed green; that is how #64
went unnoticed. Now there is no row that can be wrong for one and not the other.

## Verification

- `dotnet build solutions/Z3.Linq.slnx -c Release` - clean, `TreatWarningsAsErrors` on
- 225/225 locally
- `./build.ps1 -Configuration Release` - 46 tasks, 0 errors, 0 warnings
- Coverage 78.3% -> 88.1% line (687 of 779) and 70.9% -> 77.0% branch (456 of 592). Most of the line movement is 82 coverable lines that no longer exist - the two copies of the collection mapping - rather than new coverage; the twelve newly covered lines are the element arms this change made reachable

## New issue

**#89** - object collections cannot be constrained or read back. Found by probing whether the
second copy of the mapping was reachable; it is not, by any theorem.

## Release note

Releases remain on hold under #60 until Microsoft.Z3 5.x reaches nuget.org, so this reaches `main`
but not consumers. Nothing about the hold changes.
