### PR TITLE
Marshal anonymous environments like every other shape

### DIFF
--- a/solutions/Z3.Linq.Tests/EnvironmentTypeTests.cs
+++ b/solutions/Z3.Linq.Tests/EnvironmentTypeTests.cs
@@ -7,15 +7,19 @@ namespace Z3.Linq.Tests;
 /// <remarks>
 /// <para>
 /// Two code paths sit behind these. A compiler-generated type - an anonymous type - is created
-/// uninitialised and populated by writing to the compiler's backing fields, matched by name
-/// (Theorem.cs:610-651). Everything else is created with <c>Activator.CreateInstance</c> and
-/// populated through its properties and fields (Theorem.cs:653-699).
+/// uninitialised and populated by writing to the compiler's backing fields, matched by name.
+/// Everything else is created with <c>Activator.CreateInstance</c> and populated through its
+/// properties and fields.
 /// </para>
 /// <para>
-/// The split matters because the two support different types. The anonymous path handles only
-/// <c>bool</c> and <c>int</c> and throws on anything else, while the ordinary path handles the
-/// full set. A value tuple looks like an anonymous type in source but is an ordinary framework
-/// type, so it takes the second path and is not restricted.
+/// Since #75 the two share one marshaller, so an anonymous environment supports every type a
+/// named one does, nested objects included. Until then the anonymous path carried a marshaller
+/// of its own that handled <c>bool</c> and <c>int</c> only, and evaluated a property's handle
+/// before checking its type - so a nested object, whose handle is null, reached Z3 and came back
+/// as a bare <c>NullReferenceException</c>. The one shape still refused is a collection: the
+/// instance passed to <c>NewTheorem</c> is discarded, so nothing can pre-size it, and it is
+/// rejected by name. A value tuple looks like an anonymous type in source but is an ordinary
+/// framework type, so it takes the second path.
 /// </para>
 /// <para>
 /// Note that <c>Symbols&lt;T1, T2, T3, T4&gt;</c> does not exist - the family provides arities
@@ -104,32 +108,187 @@ public class EnvironmentTypeTests
     }
 
     /// <summary>
-    /// The anonymous-type path supports only <c>bool</c> and <c>int</c>.
+    /// An anonymous environment supports the types a named one does.
     /// </summary>
     /// <remarks>
-    /// Theorem.cs:647 throws for any other property type, so a double that is perfectly usable
-    /// in a named environment cannot be used in an anonymous one. This is a real restriction
-    /// rather than a defect - the branch never grew the other cases - but it is undocumented,
-    /// and the failure names the property rather than explaining the restriction.
+    /// This pinned a <see cref="NotSupportedException"/> until #75: the anonymous path had a
+    /// marshaller of its own that handled <c>bool</c> and <c>int</c> and refused everything
+    /// else, so a double that was perfectly usable in a named environment could not be used in
+    /// an anonymous one. It now goes through the same <c>ConvertZ3Expression</c> as every other
+    /// shape, and the restriction is gone with the code that imposed it.
     /// </remarks>
     [TestMethod]
-    public void Solve_AnonymousTypeWithDoubleProperty_ThrowsNotSupportedException()
+    public void Solve_AnonymousTypeWithDoubleProperty_PopulatesIt()
     {
         // Arrange
         using var context = new Z3Context();
-        var theorem = context.NewTheorem(new { d = default(double) })
-            .Where(t => t.d == 1.5);
 
-        // Act & Assert
-        Should.Throw<NotSupportedException>(() => theorem.Solve());
+        // Act
+        var result = context.NewTheorem(new { d = default(double) })
+            .Where(t => t.d == 1.5)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.d.ShouldBe(1.5);
+    }
+
+    [TestMethod]
+    public void Solve_AnonymousTypeWithEveryScalarType_PopulatesEachOne()
+    {
+        // Arrange: one property of each type the sort mapping supports, in a single anonymous
+        // environment, so a regression to a marshaller that knows some of them would show up as
+        // a named failure rather than pass on the two it did handle.
+        using var context = new Z3Context();
+        DateTime instant = new(2026, 6, 1, 12, 0, 0, DateTimeKind.Utc);
+
+        // Act
+        var result = context.NewTheorem(new
+            {
+                flag = default(bool),
+                n = default(int),
+                s = default(short),
+                l = default(long),
+                f = default(float),
+                d = default(double),
+                m = default(decimal),
+                text = default(string),
+                when = default(DateTime),
+            })
+            .Where(t => t.flag)
+            .Where(t => t.n == 1)
+            .Where(t => t.s == 2)
+            .Where(t => t.l == 9_000_000_000L)
+            .Where(t => t.f == 1.5f)
+            .Where(t => t.d == -2.25)
+            .Where(t => t.m == 0.1m)
+            .Where(t => t.text == "abc")
+            .Where(t => t.when == instant)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.flag.ShouldBeTrue();
+        result.n.ShouldBe(1);
+        result.s.ShouldBe((short)2);
+        result.l.ShouldBe(9_000_000_000L);
+        result.f.ShouldBe(1.5f);
+        result.d.ShouldBe(-2.25);
+        result.m.ShouldBe(0.1m);
+        result.text.ShouldBe("abc");
+        result.when.ShouldBe(instant);
+        result.when.Kind.ShouldBe(DateTimeKind.Utc);
+    }
+
+    /// <summary>
+    /// The case in #75: an anonymous environment holding a nested object.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is the issue's repro verbatim - the nested object is not even constrained - and it
+    /// threw a bare <see cref="NullReferenceException"/> from inside the native interop. A nested
+    /// environment has no handle of its own, only children, and the anonymous branch evaluated
+    /// the handle before looking at the type, so the null went straight to <c>Model.Eval</c>.
+    /// The three evaluation sites in <c>ConvertZ3Expression</c> guarded against exactly that;
+    /// this fourth one did not, and now no longer exists.
+    /// </para>
+    /// <para>
+    /// The inner values come from completion and are not asserted; that the inner object is
+    /// constructed at all is the point.
+    /// </para>
+    /// </remarks>
+    [TestMethod]
+    public void Solve_AnonymousTypeWithAnUnconstrainedNestedObject_ConstructsIt()
+    {
+        // Arrange
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem(new { inner = new InnerEnvironment(), n = default(int) })
+            .Where(t => t.n == 1)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.inner.ShouldNotBeNull();
+        result.n.ShouldBe(1);
+    }
+
+    [TestMethod]
+    public void Solve_AnonymousTypeWithANestedObject_PopulatesTheNestedProperties()
+    {
+        // Arrange: the same shape with the inner symbols constrained through the anonymous root,
+        // which is what a caller would actually write. Translation already handled this - the
+        // solve completed before the marshalling failure - so the assertion is on the values.
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem(new { inner = new InnerEnvironment(), n = default(int) })
+            .Where(t => t.inner.A == 5)
+            .Where(t => t.inner.B == t.n * 2)
+            .Where(t => t.n == 4)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.inner.A.ShouldBe(5);
+        result.inner.B.ShouldBe(8);
+        result.n.ShouldBe(4);
+    }
+
+    [TestMethod]
+    public void Solve_AnonymousTypeWithANestedAnonymousType_PopulatesIt()
+    {
+        // Arrange: an anonymous type inside an anonymous type. The recursion re-enters the same
+        // branch for the inner one, so both levels are written through backing fields.
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem(new { inner = new { a = default(int) }, n = default(int) })
+            .Where(t => t.inner.a == 4)
+            .Where(t => t.n == 1)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.inner.a.ShouldBe(4);
+        result.n.ShouldBe(1);
+    }
+
+    /// <summary>
+    /// A collection in an anonymous environment is rejected by name.
+    /// </summary>
+    /// <remarks>
+    /// The one shape the shared marshaller cannot serve here. It reads the element count from
+    /// the collection already on the instance, and an anonymous instance is created uninitialised
+    /// - the one passed to <c>NewTheorem</c> is discarded - so there is nothing to read. Without
+    /// the guard this would be #78's <see cref="NullReferenceException"/> on the count; with it,
+    /// the message says which member and why. Pinned because dropping the guard passes every
+    /// other test in this file.
+    /// </remarks>
+    [TestMethod]
+    public void Solve_AnonymousTypeWithACollectionProperty_ThrowsNotSupportedException()
+    {
+        // Arrange
+        using var context = new Z3Context();
+        var theorem = context.NewTheorem(new { v = new int[2], n = default(int) })
+            .Where(t => t.v[0] == 3)
+            .Where(t => t.n == 1);
+
+        // Act
+        NotSupportedException exception = Should.Throw<NotSupportedException>(() => theorem.Solve());
+
+        // Assert
+        exception.Message.ShouldContain("v");
+        exception.Message.ShouldContain("pre-sized");
     }
 
     [TestMethod]
     public void Solve_ValueTupleWithDouble_PopulatesEveryField()
     {
-        // Arrange: the counterpart to the test above. A value tuple is written the same way in
-        // source but is an ordinary framework type exposing public fields, so it takes the
-        // non-anonymous path and the bool/int restriction does not apply.
+        // Arrange: a value tuple is written the same way in source as an anonymous type but is
+        // an ordinary framework type exposing public fields, so it takes the non-anonymous path.
+        // Kept beside the anonymous double case because until #75 the two behaved differently.
         using var context = new Z3Context();
 
         // Act
@@ -266,11 +425,12 @@ public class EnvironmentTypeTests
     /// An anonymous environment with an unconstrained property is still populated.
     /// </summary>
     /// <remarks>
-    /// The anonymous path writes to compiler-generated backing fields and evaluates the model
-    /// through its own call, separate from the one every other environment shape uses. So it
-    /// failed independently under #51 and it can regress independently: this is the only test
-    /// covering that call. Only <c>flag</c> is asserted - <c>n</c> is free and takes whatever
-    /// completion supplies.
+    /// The anonymous path writes to compiler-generated backing fields, and until #75 it also
+    /// evaluated the model through a call of its own, separate from the one every other shape
+    /// uses - so it failed independently under #51, and this was the only test covering that
+    /// call. It now marshals through <c>ConvertZ3Expression</c> like everything else; the test
+    /// stays because the backing-field write is still this branch's own. Only <c>flag</c> is
+    /// asserted - <c>n</c> is free and takes whatever completion supplies.
     /// </remarks>
     [TestMethod]
     public void Solve_AnonymousTypeWithAnUnconstrainedProperty_PopulatesTheConstrainedOne()

--- a/solutions/Z3.Linq/Theorem.cs
+++ b/solutions/Z3.Linq/Theorem.cs
@@ -256,7 +256,7 @@ public class Theorem
     {
         var toReturn = new Environment();
 
-        if (targetType.IsArray || (targetType.IsGenericType && typeof(IEnumerable).IsAssignableFrom(targetType.GetGenericTypeDefinition())))
+        if (IsCollection(targetType))
         {
             Type? elType;
 
@@ -404,7 +404,7 @@ public class Theorem
         TypeCode typeCode = Type.GetTypeCode(parameterType);
         if (typeCode == TypeCode.Object)
         {
-            if (parameterType.IsArray || (parameterType.IsGenericType && typeof(IEnumerable).IsAssignableFrom(parameterType.GetGenericTypeDefinition())))
+            if (IsCollection(parameterType))
             {
                 Type eltType = parameterType.IsArray ? parameterType.GetElementType()! : parameterType.GetGenericArguments()[0];
 
@@ -592,6 +592,15 @@ public class Theorem
     /// <param name="model">Z3 model to evaluate theorem parameters under.</param>
     /// <param name="environment">Environment with bindings of theorem variables to Z3 handles.</param>
     /// <returns>Instance of the environment type with theorem-satisfying values.</returns>
+    /// <summary>
+    /// Whether <paramref name="type"/> is one the library treats as a collection symbol: an
+    /// array, or a generic type implementing <see cref="IEnumerable"/>.
+    /// </summary>
+    private static bool IsCollection(Type type)
+    {
+        return type.IsArray || (type.IsGenericType && typeof(IEnumerable).IsAssignableFrom(type.GetGenericTypeDefinition()));
+    }
+
     private static T GetSolution<T>(Context context, Model model, Environment environment)
     {
         Type t = typeof(T);
@@ -633,22 +642,26 @@ public class Theorem
                     continue;
                 }
 
-                // Evaluation of the values though the handle in the environment bindings.
                 var subEnv = environment.Properties[parameter];
 
-                Expr val = EvaluateWithCompletion(model, subEnv.Expr);
-                if (parameter.PropertyType == typeof(bool))
+                // The same marshaller a named environment uses, so an anonymous one supports the
+                // same types - including a nested object, which is materialised by the recursion
+                // inside ConvertZ3Expression rather than evaluated here. This branch used to carry
+                // a marshaller of its own that handled bool and int, and evaluated the handle
+                // before checking the type - so a nested object, whose handle is null, reached Z3
+                // and surfaced as a NullReferenceException. See #75.
+                //
+                // A collection is the one thing the shared path cannot do for an anonymous type:
+                // the element count is read from the collection already on the instance, and the
+                // instance here is uninitialised - the one passed to NewTheorem is discarded - so
+                // there is nothing to read it from. Reject it by name rather than let that read
+                // fail on a null.
+                if (IsCollection(parameter.PropertyType))
                 {
-                    field.SetValue(result, val.IsTrue);
+                    throw new NotSupportedException("Unsupported parameter type for " + parameter.Name + ": a collection in an anonymous environment cannot be pre-sized.");
                 }
-                else if (parameter.PropertyType == typeof(int))
-                {
-                    field.SetValue(result, ((IntNum)val).Int);
-                }
-                else
-                { 
-                    throw new NotSupportedException("Unsupported parameter type for " + parameter.Name + "."); 
-                }
+
+                field.SetValue(result, ConvertZ3Expression(result, context, model, subEnv, parameter));
             }
 
             return result;
@@ -725,18 +738,7 @@ public class Theorem
     /// overrides a value the solver chose - so symbols the model does interpret are
     /// unaffected. See https://github.com/endjin/Z3.Linq/issues/51.
     /// </para>
-    /// <para>
-    /// <paramref name="expr"/> is nullable because <c>Environment.Expr</c> is, and the
-    /// anonymous-type branch of <c>GetSolution</c> passes it without the guard the three sites
-    /// in <c>ConvertZ3Expression</c> use. A null reaches Microsoft.Z3 and surfaces as a
-    /// <c>NullReferenceException</c> - reachable today with an anonymous environment holding a
-    /// nested object, and tracked by https://github.com/endjin/Z3.Linq/issues/75. Declaring the
-    /// parameter nullable states that honestly; a non-nullable one would need a suppression or
-    /// a new guard here, and either would change behaviour that this change deliberately leaves
-    /// alone. Issue 75 proposes the better fix - checking the property type before evaluating,
-    /// so the existing <c>NotSupportedException</c> fires and names the property.
-    /// </para>
     /// </remarks>
-    private static Expr EvaluateWithCompletion(Model model, Expr? expr)
+    private static Expr EvaluateWithCompletion(Model model, Expr expr)
         => model.Eval(expr, completion: true);
 }


### PR DESCRIPTION
Fixes #75.

## The defect

An anonymous environment holding a nested object threw a bare `NullReferenceException` from
inside the native interop:

```csharp
public sealed class Leaf { public int A { get; set; } }

using var ctx = new Z3Context();
ctx.NewTheorem(new { inner = new Leaf(), n = default(int) }).Where(t => t.n == 1).Solve();
// System.NullReferenceException: Object reference not set to an instance of an object.
```

A nested environment has no Z3 handle of its own, only children. The three evaluation sites in
`ConvertZ3Expression` guard against that null and throw an `ArgumentException` naming the member;
the fourth site - the anonymous-type branch of `GetSolution` - evaluated the handle before looking
at the type, so the null went straight to `Model.Eval`. The `NotSupportedException` two lines
later, which would at least have named the property, was never reached.

## Why the fix is bigger than the issue suggested

#75 proposed moving the type check above the evaluation, so the existing `NotSupportedException`
fires first. That would have improved the message and kept the branch as it was: a **third copy of
the marshaller**, handling `bool` and `int` only, so that a `double`, `long`, `string`,
`decimal`, `short`, `float` or `DateTime` that is perfectly usable in a named environment was
refused in an anonymous one - pinned in `EnvironmentTypeTests` as "a real restriction rather
than a defect".

Measured, the alternative costs less and delivers more. Replacing that branch's marshaller with a
call to `ConvertZ3Expression` - the one every other environment shape uses - makes all of the
following work, with nothing else changed:

| Shape | Before | After |
|---|---|---|
| `new { inner = new Leaf(), n = 0 }` - the issue's repro | `NullReferenceException` | `inner` constructed, `n = 1` |
| the same, constrained through it: `t.inner.A == 5` | `NullReferenceException` | `inner.A = 5` |
| `new { inner = new { a = 0 }, n = 0 }` - nested anonymous | `NullReferenceException` | `inner.a = 4` |
| `new { p = new Pair(), n = 0 }` where `Pair` has a `double` | `NullReferenceException` | `p.Y = 2.5` |
| `double`, `long`, `string`, `decimal`, `short`, `float`, `DateTime` properties | `NotSupportedException` | each round-trips exactly |
| `new { v = new int[2], n = 0 }` | `NotSupportedException: Unsupported parameter type for v.` | `NotSupportedException: ... a collection in an anonymous environment cannot be pre-sized.` |

So #75 stops being a bad diagnostic on an unsupported shape and becomes a supported shape. The
scope was put to the maintainer with these numbers and chosen over the diagnostic-only fix.

## The change

```csharp
field.SetValue(result, ConvertZ3Expression(result, context, model, subEnv, parameter));
```

replaces the inline `bool`/`int` chain. A nested object is materialised by the recursion inside
`ConvertZ3Expression` - the same recursion that handles it for a named environment - rather than
evaluated here, so the null never reaches Z3 because nothing evaluates it.

**Collections are the one exception, and are refused by name.** The shared path reads the element
count from the collection already on the instance, and an anonymous instance is created
uninitialised - `NewTheorem<T>(T dummy)` discards the argument, as its parameter name says - so
there is nothing to read. Without a guard that is #78's `NullReferenceException` on the count;
with it, the message says which member and why. The guard uses a new `IsCollection` helper, which
also replaces the two places in `GetEnvironment` that spelled the same test out inline.

**`EvaluateWithCompletion` takes a non-nullable `Expr` again.** #51 made it `Expr?` for exactly
one reason - this branch passed a nullable - and documented that in a paragraph of remarks. Both
the annotation and the paragraph are gone; the clean build under `TreatWarningsAsErrors` is the
compiler confirming no caller can hand it a null any more.

Net: 26 lines out, 28 in, in `Theorem.cs`.

## Tests

225 → 230, in `EnvironmentTypeTests.cs`.

| Test | What it covers |
|---|---|
| `Solve_AnonymousTypeWithAnUnconstrainedNestedObject_ConstructsIt` | #75's repro verbatim - the nested object is not even constrained |
| `Solve_AnonymousTypeWithANestedObject_PopulatesTheNestedProperties` | the same shape constrained through the anonymous root, including a constraint across the nesting boundary |
| `Solve_AnonymousTypeWithANestedAnonymousType_PopulatesIt` | the recursion re-entering the anonymous branch |
| `Solve_AnonymousTypeWithDoubleProperty_PopulatesIt` | the former `ThrowsNotSupportedException` pin, now a round-trip |
| `Solve_AnonymousTypeWithEveryScalarType_PopulatesEachOne` | nine properties, one of each supported type, in a single anonymous environment - a regression to a marshaller that knows some of them fails by name rather than passing on the two it handled |
| `Solve_AnonymousTypeWithACollectionProperty_ThrowsNotSupportedException` | the guard; asserts the member name and the reason are both in the message |

Three existing remarks that described the anonymous branch's separate evaluation call are
rewritten to say what is now true.

## Mutation results

| Mutation | Failures | Which |
|---|---|---|
| Drop the collection guard | **1** | the collection pin alone - it becomes #78's `NullReferenceException` |
| Restore the old `bool`/`int` marshaller | **5** | the double round-trip, the every-scalar test, and all three nested-object tests. `Solve_AnonymousTypeEnvironment_PopulatesEveryProperty` and the unconstrained-property test stay green, because they are `bool` and `int` - which is precisely why the restriction survived as long as it did |

## Verification

- `dotnet build solutions/Z3.Linq.slnx -c Release` - clean, `TreatWarningsAsErrors` on
- 230/230 locally
- `./build.ps1 -Configuration Release` - 46 tasks, 0 errors, 0 warnings
- Coverage: line unchanged at 88.1% (683 of 775, from 687 of 779); branch 77.0% -> 76.5% (444 of 580, from 456 of 592). Both totals fall because the removed bool/int chain was covered code with covered branches - twelve branches no longer exist - and the one-line call that replaces it has none

## Release note

Releases remain on hold under #60 until Microsoft.Z3 5.x reaches nuget.org, so this reaches `main`
but not consumers. Nothing about the hold changes.
