### PR TITLE
Generate and validate the XML documentation

### DIFF
--- a/solutions/Directory.Build.props
+++ b/solutions/Directory.Build.props
@@ -9,6 +9,13 @@
          and arm64 on all three platforms, so AnyCPU lets each machine resolve the one it
          needs; pinning x64 here would shut arm64 out. -->
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <!-- Generate the XML documentation file for every project. Two reasons. It makes the
+         compiler parse the doc comments, so malformed XML and unresolvable crefs are build
+         errors under TreatWarningsAsErrors rather than something a reviewer has to spot; and
+         it gives the packable projects a documentation file to ship, without which consumers
+         get no IntelliSense. CS1591 - a public member with no comment - is enforced only for
+         Z3.Linq; the other projects suppress it, each saying why. See #82. -->
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <!-- Package metadata common to the packable projects. Per-package values stay in the

--- a/solutions/Z3.Linq.Demo/Z3.Linq.Demo.csproj
+++ b/solutions/Z3.Linq.Demo/Z3.Linq.Demo.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
+    <!-- A console program with no API to document. See #82. -->
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/solutions/Z3.Linq.Examples/Z3.Linq.Examples.csproj
+++ b/solutions/Z3.Linq.Examples/Z3.Linq.Examples.csproj
@@ -3,6 +3,10 @@
   <PropertyGroup>
     <PackageDescription>Sample Theorems for Sudoku and River Crossing problems.</PackageDescription>
     <PackageTags>Z3; LINQ; Solver; SMT; Examples; Sudoku; Bart De Smet</PackageTags>
+    <!-- Sample code: its types are illustrations rather than an API, so a public member without
+         a doc comment is not an error here. The comments it does carry are still validated, and
+         the package ships what there is. See #82. -->
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/solutions/Z3.Linq.Tests/Z3.Linq.Tests.csproj
+++ b/solutions/Z3.Linq.Tests/Z3.Linq.Tests.csproj
@@ -3,6 +3,10 @@
   <PropertyGroup>
     <IsPackable>false</IsPackable>
     <RootNamespace>Z3.Linq.Tests</RootNamespace>
+    <!-- The doc comments here are validated like everyone else's (Directory.Build.props), but
+         a test's name is its documentation and CS1591 would demand a comment on every test
+         class and method. See #82. -->
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/solutions/Z3.Linq/Environment.cs
+++ b/solutions/Z3.Linq/Environment.cs
@@ -1,14 +1,40 @@
-﻿namespace Z3.Linq;
+namespace Z3.Linq;
 
 using Microsoft.Z3;
 using System.Collections.Generic;
 using System.Reflection;
 
+/// <summary>
+/// The Z3 handles standing in for the members of an environment type while a theorem is solved.
+/// </summary>
+/// <remarks>
+/// Built once per solve by walking the environment type. A scalar member gets a constant of its
+/// type's sort in <see cref="Expr"/>, a collection gets an array from <c>Int</c> to that sort,
+/// and a nested object gets an <see cref="Environment"/> of its own under
+/// <see cref="Properties"/>, with no <see cref="Expr"/>. Public because
+/// <see cref="ExpressionVisitor.Visit"/> takes one; there is no reason to build one directly.
+/// </remarks>
 public class Environment
 {
+    /// <summary>
+    /// Gets or sets the Z3 handle for a scalar or collection symbol, or <see langword="null"/>
+    /// for a nested object, which has <see cref="Properties"/> instead.
+    /// </summary>
     public Expr? Expr { get; set; }
 
+    /// <summary>
+    /// Gets or sets whether this environment describes a collection of objects, in which case
+    /// each entry in <see cref="Properties"/> is an array indexed by position rather than a
+    /// single handle.
+    /// </summary>
+    /// <remarks>
+    /// Set by the environment builder and read by nothing: neither the translator nor the
+    /// marshaller supports a collection of objects. See #89.
+    /// </remarks>
     public bool IsArray { get; set; }
-        
+
+    /// <summary>
+    /// Gets the environments of the members of a nested object, keyed by member.
+    /// </summary>
     public Dictionary<MemberInfo, Environment> Properties { get; private set; } = new Dictionary<MemberInfo, Environment>();
 }

--- a/solutions/Z3.Linq/ExpressionVisitor.cs
+++ b/solutions/Z3.Linq/ExpressionVisitor.cs
@@ -10,6 +10,14 @@ using MiaPlaza.ExpressionUtils.Evaluating;
 
 using Microsoft.Z3;
 
+/// <summary>
+/// Translates the LINQ expression trees of the constraints of a theorem into Z3 expressions.
+/// </summary>
+/// <remarks>
+/// Driven by <c>Theorem</c> during <c>Solve</c> and <c>Optimize</c>, which build the
+/// <see cref="Environment"/> it translates against. It is public for historical reasons; there
+/// is no supported reason to call it directly.
+/// </remarks>
 public static class ExpressionVisitor
 {
     /// <summary>

--- a/solutions/Z3.Linq/ITheoremGlobalRewriter.cs
+++ b/solutions/Z3.Linq/ITheoremGlobalRewriter.cs
@@ -1,9 +1,23 @@
-﻿namespace Z3.Linq;
- 
+namespace Z3.Linq;
+
 using System.Collections.Generic;
 using System.Linq.Expressions;
 
+/// <summary>
+/// Rewrites the whole set of a theorem's constraints before they are translated to Z3.
+/// </summary>
+/// <remarks>
+/// Named on an environment type by <see cref="TheoremGlobalRewriterAttribute"/>. The rewriter
+/// sees every constraint the theorem has accumulated and returns the constraints to assert in
+/// their place, so it can add to them, drop them or replace them outright. Implementations need
+/// a public parameterless constructor, since the library creates one when the theorem is solved.
+/// </remarks>
 public interface ITheoremGlobalRewriter
 {
+    /// <summary>
+    /// Rewrites the constraints of a theorem.
+    /// </summary>
+    /// <param name="constraints">The constraints as written, in the order they were added.</param>
+    /// <returns>The constraints to assert instead.</returns>
     IEnumerable<LambdaExpression> Rewrite(IEnumerable<LambdaExpression> constraints);
 }

--- a/solutions/Z3.Linq/ITheoremPredicateRewriter.cs
+++ b/solutions/Z3.Linq/ITheoremPredicateRewriter.cs
@@ -1,8 +1,24 @@
-﻿namespace Z3.Linq;
- 
+namespace Z3.Linq;
+
 using System.Linq.Expressions;
 
+/// <summary>
+/// Rewrites a method call inside a constraint into an expression the translator understands.
+/// </summary>
+/// <remarks>
+/// Named on a method by <see cref="TheoremPredicateRewriterAttribute"/>. When the translator
+/// meets a call to that method it hands the call to the rewriter and translates the result in
+/// its place. The result has to differ from the input: a rewriter that returns the call it was
+/// given is rejected, because translating that call would only invoke the rewriter again.
+/// Implementations need a public parameterless constructor, since the library creates one when
+/// the call is met.
+/// </remarks>
 public interface ITheoremPredicateRewriter
 {
+    /// <summary>
+    /// Rewrites a call to the method the rewriter is registered on.
+    /// </summary>
+    /// <param name="call">The call as it appears in the constraint.</param>
+    /// <returns>The expression to translate in its place, which must not be <paramref name="call"/> itself.</returns>
     MethodCallExpression Rewrite(MethodCallExpression call);
 }

--- a/solutions/Z3.Linq/Optimization.cs
+++ b/solutions/Z3.Linq/Optimization.cs
@@ -1,7 +1,17 @@
-﻿namespace Z3.Linq;
+namespace Z3.Linq;
 
+/// <summary>
+/// The direction of an optimisation: which way <c>Optimize</c> moves its objective.
+/// </summary>
 public enum Optimization
 {
+    /// <summary>
+    /// Find a solution in which the objective is as large as the constraints allow.
+    /// </summary>
     Maximize,
+
+    /// <summary>
+    /// Find a solution in which the objective is as small as the constraints allow.
+    /// </summary>
     Minimize
 }

--- a/solutions/Z3.Linq/Theorem.cs
+++ b/solutions/Z3.Linq/Theorem.cs
@@ -619,14 +619,6 @@ public class Theorem
     }
 
     /// <summary>
-    /// Gets the solution object for the solved theorem.
-    /// </summary>
-    /// <typeparam name="T">Environment type to create an instance of.</typeparam>
-    /// <param name="context">Z3 context.</param>
-    /// <param name="model">Z3 model to evaluate theorem parameters under.</param>
-    /// <param name="environment">Environment with bindings of theorem variables to Z3 handles.</param>
-    /// <returns>Instance of the environment type with theorem-satisfying values.</returns>
-    /// <summary>
     /// Reads <paramref name="member"/> off <paramref name="instance"/>, or returns
     /// <see langword="null"/> if there is no instance to read it from.
     /// </summary>
@@ -649,6 +641,15 @@ public class Theorem
         return type.IsArray || (type.IsGenericType && typeof(IEnumerable).IsAssignableFrom(type.GetGenericTypeDefinition()));
     }
 
+    /// <summary>
+    /// Gets the solution object for the solved theorem.
+    /// </summary>
+    /// <typeparam name="T">Environment type to create an instance of.</typeparam>
+    /// <param name="context">Z3 context.</param>
+    /// <param name="model">Z3 model to evaluate theorem parameters under.</param>
+    /// <param name="environment">Environment with bindings of theorem variables to Z3 handles.</param>
+    /// <param name="template">An instance of <typeparamref name="T"/> whose collections give the solution's their length, or null.</param>
+    /// <returns>Instance of the environment type with theorem-satisfying values.</returns>
     private static T GetSolution<T>(Context context, Model model, Environment environment, object? template)
     {
         Type t = typeof(T);

--- a/solutions/Z3.Linq/TheoremGlobalRewriterAttribute.cs
+++ b/solutions/Z3.Linq/TheoremGlobalRewriterAttribute.cs
@@ -1,13 +1,28 @@
-﻿namespace Z3.Linq;
+namespace Z3.Linq;
 
 using System;
 
+/// <summary>
+/// Names the <see cref="ITheoremGlobalRewriter"/> that rewrites a theorem's constraints before
+/// they are translated. Applied to the environment type.
+/// </summary>
 public class TheoremGlobalRewriterAttribute : Attribute
 {
+    /// <summary>
+    /// Creates the attribute.
+    /// </summary>
+    /// <param name="rewriterType">
+    /// A type implementing <see cref="ITheoremGlobalRewriter"/> with a public parameterless
+    /// constructor. A type that does not implement the interface is rejected when the theorem
+    /// is solved, not when the attribute is applied.
+    /// </param>
     public TheoremGlobalRewriterAttribute(Type rewriterType)
     {
         this.RewriterType = rewriterType;
     }
 
+    /// <summary>
+    /// Gets the type of the rewriter to apply.
+    /// </summary>
     public Type RewriterType { get; }
 }

--- a/solutions/Z3.Linq/TheoremPredicateRewriterAttribute.cs
+++ b/solutions/Z3.Linq/TheoremPredicateRewriterAttribute.cs
@@ -1,13 +1,28 @@
-﻿namespace Z3.Linq;
+namespace Z3.Linq;
 
 using System;
 
+/// <summary>
+/// Names the <see cref="ITheoremPredicateRewriter"/> that rewrites calls to the method it is
+/// applied to. Applied to a method that is called inside a constraint.
+/// </summary>
 public class TheoremPredicateRewriterAttribute : Attribute
 {
+    /// <summary>
+    /// Creates the attribute.
+    /// </summary>
+    /// <param name="rewriterType">
+    /// A type implementing <see cref="ITheoremPredicateRewriter"/> with a public parameterless
+    /// constructor. A type that does not implement the interface is rejected when a call to the
+    /// method is translated, not when the attribute is applied.
+    /// </param>
     public TheoremPredicateRewriterAttribute(Type rewriterType)
     {
         this.RewriterType = rewriterType;
     }
 
+    /// <summary>
+    /// Gets the type of the rewriter to apply.
+    /// </summary>
     public Type RewriterType { get; }
 }

--- a/solutions/Z3.Linq/TheoremVariableTypeMappingAttribute.cs
+++ b/solutions/Z3.Linq/TheoremVariableTypeMappingAttribute.cs
@@ -1,13 +1,31 @@
-﻿namespace Z3.Linq;
+namespace Z3.Linq;
 
 using System;
 
+/// <summary>
+/// Declares that a type used for a symbol stands for one of the supported types, and is
+/// converted back from it when the solution is read.
+/// </summary>
+/// <remarks>
+/// Applied to the type of a symbol. The symbol is declared and solved as
+/// <see cref="RegularType"/>, and when the solution is built the solved value is passed to a
+/// public constructor of the declaring type that takes a single <see cref="RegularType"/>
+/// argument. A type without such a constructor fails when the solution is read, not when the
+/// theorem is created.
+/// </remarks>
 public class TheoremVariableTypeMappingAttribute : Attribute
 {
+    /// <summary>
+    /// Creates the attribute.
+    /// </summary>
+    /// <param name="regularType">The supported type the declaring type stands for in the theorem.</param>
     public TheoremVariableTypeMappingAttribute(Type regularType)
     {
         this.RegularType = regularType;
     }
 
+    /// <summary>
+    /// Gets the supported type the declaring type stands for in the theorem.
+    /// </summary>
     public Type RegularType { get; }
 }


### PR DESCRIPTION
Fixes #82.

## The defect

No project set `GenerateDocumentationFile`, so the compiler never parsed a doc comment. Two
consequences: the test suite's documentation - which carries most of the reasoning behind this
stack - was unvalidated, and a malformed comment reached #81 and was caught by a reviewer rather
than the build, despite `TreatWarningsAsErrors`; and the package shipped no documentation file,
so consumers got no IntelliSense for anything.

## What turning it on found first

Measured before any other change, with `-p:GenerateDocumentationFile=true` on the command line:

| Code | Count | What |
|---|---|---|
| CS1591 | 21 unique in `Z3.Linq` | public members with no comment. The issue said 44 - the build log lists each warning twice, so that was 22 unique, and one has been documented since |
| CS1572 | 3 | `<param>` tags for `context`, `model` and `environment` on a method with no such parameters |
| CS1573 | 2 | `member` and `instance` with no tag on the same method |
| CS1711 | 1 | a `<typeparam name="T">` on a method with no `T` |

The last three rows are **one defect this stack introduced**: the documentation for
`GetSolution<T>` came loose from its method when #75 inserted `IsCollection` between them, and
#78 then inserted `GetMemberValue` before that - so the block attached to `GetMemberValue`,
describing a `T`, a `context`, a `model` and an `environment` it does not have. Neither PR could
have noticed, because nothing parsed the comment. It is back on `GetSolution<T>`, with the
`template` parameter it gained in #78. That is the guard proving its worth before it exists.

## The change

**`GenerateDocumentationFile=true` in `Directory.Build.props`, for every project.** Malformed XML
and unresolvable crefs are build errors from here, and the packable projects ship their
documentation. **CS1591 is enforced for `Z3.Linq` only**; the test, examples and demo projects
suppress it, each with a comment in its own project file saying why - a test's name is its
documentation, sample types are illustrations rather than an API, and the demo is a console
program. That answers the issue's open question about where the settings belong: the setting is
global, the suppression is per project, next to the reason.

**The 21 public members are documented.** `Environment` and its three members,
`ExpressionVisitor`, `ITheoremGlobalRewriter` and `ITheoremPredicateRewriter` and their methods,
the three attributes with their constructors and properties, and `Optimization` with both values.
Each comment says what the thing is for and, where it matters, when a wrong use fails - a
rewriter type that does not implement the interface is rejected at solve time, not when the
attribute is applied; a predicate rewriter that returns its input is refused; a mapped type
without the right constructor fails when the solution is read. `Environment.IsArray` says plainly
that nothing reads it, and points at #89.

## Verification

- `dotnet build solutions/Z3.Linq.slnx -c Release` - clean: 0 warnings, 0 errors, with
  `TreatWarningsAsErrors` on and documentation generation on for all four projects
- 247/247 tests, unchanged - this PR touches no behaviour
- `./build.ps1 -Configuration Release` - 46 tasks, 0 errors, 0 warnings
- **The package now ships the documentation.** Before, `lib/net10.0` held only the assembly;
  after, `lib/net10.0` holds `Z3.Linq.dll` and a 47,833-byte `Z3.Linq.xml`. Straight from the ZeroFailed pipeline: every earlier package in `_packages` lists the dll alone, and `Z3.Linq.2.0.2-xml-docs.47.nupkg` lists both. `Z3.Linq.Examples` ships its 4 KB file too
- `Z3.Linq.xml` documents 93 members

### Negative controls

Both run against the final code and restored byte-identical afterwards, because a clean build
proves nothing until the check has been seen to fail:

| Break | Result |
|---|---|
| A cref in `Environment` changed to `ExpressionVisitor.NoSuchMember` | `error CS1574: XML comment has cref attribute 'NoSuchMember' that could not be resolved` |
| A duplicated `</remarks>` in a test class - the exact defect from #81 | `error CS1570: XML comment has badly formed XML -- 'End tag was not expected at this location.'` |

## What this does not catch

Recorded on the issue and worth repeating here: the defect Copilot found on #86 was an inaccurate
`<returns>` - well-formed XML, resolving crefs, wrong sentence. This setting would not have caught
it and nothing mechanical will. It catches the malformed-XML and broken-reference classes, which
is what it found on #81 and what it found in this stack.

Coverage unchanged at 88.1% line (693 of 786) and 77.5% branch (459 of 592), as it should be for a change that touches no behaviour.

## Release note

Releases remain on hold under #60 until Microsoft.Z3 5.x reaches nuget.org. This is the change
the issue asked to have in place before that hold lifts, so the first published 2.x carries its
documentation.
