### PR TITLE
Encode a DateTime as ticks rather than a file time

### DIFF
--- a/solutions/Z3.Linq.Tests/CollectionSymbolTests.cs
+++ b/solutions/Z3.Linq.Tests/CollectionSymbolTests.cs
@@ -423,7 +423,7 @@ public class CollectionSymbolTests
     /// </summary>
     /// <remarks>
     /// <c>DateTime</c> shared the <c>long</c> row of the old mapping and failed the same two ways.
-    /// #56 had already corrected the element read to <c>FromFileTimeUtc</c>, so once the range
+    /// #56 had already corrected the element read to UTC, so once the range
     /// is <c>Int</c> nothing else on this path needs to change - the comment on #64 that
     /// measured exactly that is what this test pins.
     /// </remarks>
@@ -468,13 +468,33 @@ public class CollectionSymbolTests
         result.Values.ShouldBe([instant, instant]);
     }
 
+    [TestMethod]
+    public void Solve_DateTimeArrayElementBefore1601_RoundTripsTheValue()
+    {
+        // Arrange: the element read has its own DateTime arm, so the #83 encoding change has to
+        // hold here as well as for a scalar.
+        using var context = new Z3Context();
+        DateTime instant = new(1500, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        // Act
+        var result = context.NewTheorem<DateTimeArrayEnvironment>()
+            .Where(t => t.Values[0] == instant)
+            .Where(t => t.Length == 2)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.Values[0].ShouldBe(instant);
+        result.Values[0].Kind.ShouldBe(DateTimeKind.Utc);
+    }
+
     /// <summary>
     /// A <c>DateTime</c> collection with free elements reads back as UTC.
     /// </summary>
     /// <remarks>
     /// The instants are completion's to choose and are not asserted - measured, they are
-    /// <c>1601-01-01T00:00:00Z</c>, file time zero, which is the earliest instant the encoding
-    /// can express (#83). The kind is fixed by the read path and can be asserted where the value
+    /// <c>DateTime.MinValue</c> - tick zero, since #83 made the encoding ticks rather than a
+    /// file time counted from 1601. The kind is fixed by the read path and can be asserted where the value
     /// cannot, as the scalar family in <c>SymbolTypeMarshallingTests</c> does.
     /// </remarks>
     [TestMethod]

--- a/solutions/Z3.Linq.Tests/OptimizationTests.cs
+++ b/solutions/Z3.Linq.Tests/OptimizationTests.cs
@@ -389,7 +389,7 @@ public class OptimizationTests
     /// </summary>
     /// <remarks>
     /// <para>
-    /// A DateTime is encoded as an integer file time, so ordering it is ordering that integer -
+    /// A DateTime is encoded as an integer - its ticks - so ordering it is ordering that integer -
     /// which is only the same thing as ordering the instants because every constant on the way in
     /// is converted the same way, whatever kind it carried. This test puts one bound in local time
     /// and one in UTC to say so: they are half an hour apart on the timeline, not the seven-and-a-

--- a/solutions/Z3.Linq.Tests/SymbolTypeMarshallingTests.cs
+++ b/solutions/Z3.Linq.Tests/SymbolTypeMarshallingTests.cs
@@ -481,10 +481,10 @@ public class SymbolTypeMarshallingTests
     /// </summary>
     /// <remarks>
     /// <para>
-    /// A DateTime is carried through Z3 as a Windows file time - a position on the UTC timeline -
-    /// so the kind cannot survive the trip and the read path has to choose one. It chooses UTC, to
-    /// match the <c>ToFileTimeUtc</c> the write path already used. Before #56 it chose local time,
-    /// and the same theorem answered differently on every machine that ran it.
+    /// A DateTime is carried through Z3 as an integer - a position on the UTC timeline - so the
+    /// kind cannot survive the trip and the read path has to choose one. It chooses UTC, to match
+    /// the UTC the write path already converted to. Before #56 it chose local time, and the same
+    /// theorem answered differently on every machine that ran it.
     /// </para>
     /// <para>
     /// The kind assertion is the load-bearing one. Comparing ticks alone would have passed on UTC
@@ -516,11 +516,11 @@ public class SymbolTypeMarshallingTests
     /// </summary>
     /// <remarks>
     /// <c>new DateTime(2026, 6, 1, 12, 0, 0)</c> - the ordinary way to write a date into a
-    /// constraint - carries <see cref="DateTimeKind.Unspecified"/>, and the two file-time
-    /// conversions disagree about what that means: <c>ToFileTime</c> reads it as local time,
-    /// <c>ToFileTimeUtc</c> as UTC. The write path uses the second, which is why #56 was fixed on
-    /// the read path: switching the write to <c>ToFileTime</c> instead would have made this shape
-    /// agree while leaving an explicitly-UTC constant, the issue's own repro, still shifted.
+    /// constraint - carries <see cref="DateTimeKind.Unspecified"/>, and a conversion to UTC has
+    /// to decide what that means. The write path takes it as UTC already, the convention the
+    /// file-time encoding it replaced (<c>ToFileTimeUtc</c>) had; the other reading, as local
+    /// time, is what would have made this shape agree before #56 while leaving an explicitly-UTC
+    /// constant, the issue's own repro, still shifted.
     /// </remarks>
     [TestMethod]
     public void Solve_DateTimeSymbolWithNoKind_RoundTripsTheValueAsUtc()
@@ -577,7 +577,7 @@ public class SymbolTypeMarshallingTests
     /// The top of the range, and a case the old read path got right only by luck: converting the
     /// maximum to local time overflows, and <c>ToLocalTime</c> clamps instead of throwing, so east
     /// of Greenwich the ticks happened to match. West of it they did not. Reading as UTC removes
-    /// the conversion, so there is nothing left to clamp. The bottom of the range is #83.
+    /// the conversion, so there is nothing left to clamp. The bottom of the range was #83, below.
     /// </remarks>
     [TestMethod]
     public void Solve_DateTimeSymbolAtMaxValue_RoundTripsTheValue()
@@ -598,57 +598,138 @@ public class SymbolTypeMarshallingTests
     }
 
     /// <summary>
-    /// KNOWN DEFECT (#83): a DateTime constant before 1601 fails during translation.
+    /// A <see cref="DateTime"/> constant before 1601 round-trips.
     /// </summary>
     /// <remarks>
-    /// A Windows file time counts from 1601-01-01 UTC and cannot express anything earlier, so the
-    /// constant throws out of <c>ToFileTimeUtc</c> before Z3 sees the theorem. Unchanged by #56 -
-    /// the range belongs to the encoding, not to the conversion that inverts it. The null
-    /// <c>ParamName</c> is what identifies this as the write path; the read path supplies one.
+    /// <para>
+    /// The write half of #83. A DateTime used to travel through Z3 as a Windows file time, which
+    /// counts from 1601-01-01 UTC and cannot express anything earlier, so a constant before that
+    /// threw out of <c>ToFileTimeUtc</c> - <c>Not a valid Win32 FileTime</c> - before Z3 saw the
+    /// theorem. Roughly two thirds of the type's range was unusable. It now travels as its ticks,
+    /// which count from 0001-01-01 and cover the whole range.
+    /// </para>
+    /// <para>
+    /// The years are chosen to span the range the old encoding could not express, with
+    /// <see cref="DateTime.MinValue"/> - tick zero - as the boundary case at the bottom.
+    /// </para>
     /// </remarks>
     [TestMethod]
-    public void Solve_DateTimeSymbolBeforeTheFileTimeEpoch_ThrowsArgumentOutOfRangeException()
+    [DataRow(1, DisplayName = "Year 1 - DateTime.MinValue")]
+    [DataRow(1066, DisplayName = "Year 1066")]
+    [DataRow(1500, DisplayName = "Year 1500")]
+    [DataRow(1600, DisplayName = "Year 1600 - the last the file time could not express")]
+    public void Solve_DateTimeSymbolBefore1601_RoundTripsTheValue(int year)
+    {
+        // Arrange
+        using var context = new Z3Context();
+        var instant = new DateTime(year, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        // Act
+        var result = context.NewTheorem<Symbols<DateTime, int>>()
+            .Where(t => t.X1 == instant)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.X1.Kind.ShouldBe(DateTimeKind.Utc);
+        result.X1.ShouldBe(instant);
+    }
+
+    [TestMethod]
+    public void Solve_DateTimeSymbolOneTickBefore1601_RoundTripsTheValue()
+    {
+        // Arrange: the exact boundary of the old encoding, from the wrong side of it.
+        using var context = new Z3Context();
+        var instant = new DateTime(1601, 1, 1, 0, 0, 0, DateTimeKind.Utc).AddTicks(-1);
+
+        // Act
+        var result = context.NewTheorem<Symbols<DateTime, int>>()
+            .Where(t => t.X1 == instant)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.X1.ShouldBe(instant);
+    }
+
+    /// <summary>
+    /// A satisfiable theorem whose only models lie before 1601 returns one of them.
+    /// </summary>
+    /// <remarks>
+    /// The read half of #83, and the worse one: nothing here was malformed. The constraints were
+    /// well-formed, Z3 found a model, and the read path then refused to express it - every model
+    /// was a negative file time, and the exception blamed a <c>fileTime</c> parameter no caller
+    /// had supplied. Which instant comes back is Z3's choice; that it lies before 1601 is not.
+    /// </remarks>
+    [TestMethod]
+    public void Solve_DateTimeSymbolConstrainedBefore1601_ReturnsAnInstantBefore1601()
+    {
+        // Arrange
+        using var context = new Z3Context();
+        var epoch = new DateTime(1601, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        // Act
+        var result = context.NewTheorem<Symbols<DateTime, int>>()
+            .Where(t => t.X1 < epoch && t.X2 == 0)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.X1.Kind.ShouldBe(DateTimeKind.Utc);
+        result.X1.ShouldBeLessThan(epoch);
+    }
+
+    /// <summary>
+    /// A <see cref="DateTime"/> symbol whose model value no <see cref="DateTime"/> can hold fails
+    /// loudly, naming the symbol.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The symbol is an unbounded integer, so <c>t.X1 &gt; DateTime.MaxValue</c> - which has no
+    /// solution in <see cref="DateTime"/> terms - is satisfiable in Z3's integers, and the model
+    /// is a tick count beyond the type. The read path used to hand that to
+    /// <c>FromFileTimeUtc</c> and let it throw about a <c>fileTime</c> parameter; it now checks
+    /// the range itself and says which symbol and what the range is. The same trade-off as the
+    /// checked read of a <c>short</c>: loud rather than wrong, until #87 bounds the symbol so
+    /// Z3 cannot choose such a value at all.
+    /// </para>
+    /// <para>
+    /// Both ends are pinned. The bottom is the case #83 reported as the read-side failure, and
+    /// with the encoding now starting at tick zero it is only reachable by constraining below
+    /// <see cref="DateTime.MinValue"/> itself.
+    /// </para>
+    /// </remarks>
+    [TestMethod]
+    public void Solve_DateTimeSymbolConstrainedBeyondMaxValue_ThrowsOverflowExceptionNamingIt()
+    {
+        // Arrange
+        using var context = new Z3Context();
+        DateTime max = DateTime.MaxValue;
+        var theorem = context.NewTheorem<Symbols<DateTime, int>>()
+            .Where(t => t.X1 > max && t.X2 == 0);
+
+        // Act
+        OverflowException exception = Should.Throw<OverflowException>(() => theorem.Solve());
+
+        // Assert
+        exception.Message.ShouldContain("X1");
+        exception.Message.ShouldContain("0001-01-01 to 9999-12-31");
+    }
+
+    [TestMethod]
+    public void Solve_DateTimeSymbolConstrainedBelowMinValue_ThrowsOverflowExceptionNamingIt()
     {
         // Arrange
         using var context = new Z3Context();
         DateTime min = DateTime.MinValue;
         var theorem = context.NewTheorem<Symbols<DateTime, int>>()
-            .Where(t => t.X1 == min);
+            .Where(t => t.X1 < min && t.X2 == 0);
 
         // Act
-        ArgumentOutOfRangeException exception =
-            Should.Throw<ArgumentOutOfRangeException>(() => theorem.Solve());
+        OverflowException exception = Should.Throw<OverflowException>(() => theorem.Solve());
 
         // Assert
-        exception.ParamName.ShouldBeNull();
-    }
-
-    /// <summary>
-    /// KNOWN DEFECT (#83): a satisfiable theorem whose only models lie before 1601 throws while
-    /// its solution is being marshalled.
-    /// </summary>
-    /// <remarks>
-    /// The other half of #83, and the worse one: nothing here is malformed. The constraints are
-    /// well-formed, Z3 finds a model, and the read path then refuses to express it. Every model
-    /// satisfying this theorem is a negative file time, so the throw does not depend on which one
-    /// Z3 picks. <c>ParamName</c> distinguishes this from the write-side case above, so a fix to
-    /// one half cannot pass as a fix to both.
-    /// </remarks>
-    [TestMethod]
-    public void Solve_DateTimeSymbolConstrainedBeforeTheFileTimeEpoch_ThrowsArgumentOutOfRangeException()
-    {
-        // Arrange
-        using var context = new Z3Context();
-        var epoch = new DateTime(1601, 1, 1, 0, 0, 0, DateTimeKind.Utc);
-        var theorem = context.NewTheorem<Symbols<DateTime, int>>()
-            .Where(t => t.X1 < epoch && t.X2 == 0);
-
-        // Act
-        ArgumentOutOfRangeException exception =
-            Should.Throw<ArgumentOutOfRangeException>(() => theorem.Solve());
-
-        // Assert
-        exception.ParamName.ShouldBe("fileTime");
+        exception.Message.ShouldContain("X1");
     }
 
     [TestMethod]
@@ -810,9 +891,10 @@ public class SymbolTypeMarshallingTests
     [TestMethod]
     public void Solve_UnconstrainedDateTimeSymbol_ReturnsAResult()
     {
-        // Arrange: DateTime shares the integer sort with long but has its own read-back through
-        // the file-time encoding, which can only express 1601 onwards - so completion has to
-        // supply a value that encoding can carry, not merely an integer.
+        // Arrange: DateTime shares the integer sort with long but has its own read-back, from
+        // ticks, so completion has to supply a value the type can carry, not merely an integer.
+        // Measured, it supplies zero - DateTime.MinValue; it was 1601-01-01 while the encoding
+        // was a file time (#83). Neither is asserted.
         using var context = new Z3Context();
 
         // Act

--- a/solutions/Z3.Linq/ExpressionVisitor.cs
+++ b/solutions/Z3.Linq/ExpressionVisitor.cs
@@ -326,9 +326,13 @@ public static class ExpressionVisitor
                 // and about half of all cultures render 1.5 as something else. See #52.
                 return context.MkReal(((IFormattable)val).ToString(null, CultureInfo.InvariantCulture));
             case TypeCode.DateTime:
-                // A DateTime is encoded as its position on the UTC timeline. ToFileTimeUtc reads a
-                // Kind of Unspecified as UTC, so that is the convention the read path inverts. See #56.
-                return context.MkInt(((DateTime)val).ToFileTimeUtc());
+                // A DateTime is encoded as its ticks - 100ns intervals from 0001-01-01 - on the UTC
+                // timeline, which covers the whole DateTime range. A Windows file time counted from
+                // 1601 instead, so nothing earlier could be written or read. See #83.
+                //
+                // A Kind of Local is converted to UTC first; Unspecified is taken to be UTC already,
+                // which is the convention ToFileTimeUtc had and the read path inverts. See #56.
+                return context.MkInt(ToUtcTicks((DateTime)val));
             case TypeCode.String:
                 return context.MkString(val.ToString());
             default:
@@ -461,5 +465,20 @@ public static class ExpressionVisitor
     private static Expr VisitUnary(Context context, Environment environment, UnaryExpression expression, ParameterExpression param, Func<Context, Expr, Expr> ctor)
     {
         return ctor(context, Visit(context, environment, expression.Operand, param));
+    }
+    /// <summary>
+    /// The ticks of <paramref name="value"/> on the UTC timeline, which is how a
+    /// <see cref="DateTime"/> is encoded for Z3.
+    /// </summary>
+    /// <remarks>
+    /// A <see cref="DateTimeKind.Local"/> value is converted to UTC; an
+    /// <see cref="DateTimeKind.Unspecified"/> one is taken to be UTC already, as
+    /// <see cref="DateTime.ToFileTimeUtc"/> - the previous encoding - did. The read path in
+    /// <c>Theorem</c> produces a <see cref="DateTimeKind.Utc"/> value from the same ticks.
+    /// See #56 and #83.
+    /// </remarks>
+    internal static long ToUtcTicks(DateTime value)
+    {
+        return value.Kind == DateTimeKind.Local ? value.ToUniversalTime().Ticks : value.Ticks;
     }
 }

--- a/solutions/Z3.Linq/Theorem.cs
+++ b/solutions/Z3.Linq/Theorem.cs
@@ -487,8 +487,8 @@ public class Theorem
                             numVal = ((IntNum)numValExpr).Int64;
                             break;
                         case TypeCode.DateTime:
-                            // FromFileTimeUtc, for the reason given on the scalar arm below. See #56.
-                            numVal = DateTime.FromFileTimeUtc(((IntNum)numValExpr).Int64);
+                            // Ticks on the UTC timeline, for the reason given on the scalar arm below.
+                            numVal = ToDateTime(((IntNum)numValExpr).Int64, parameter.Name);
                             break;
                         case TypeCode.Boolean:
                             numVal = numValExpr.IsTrue;
@@ -554,11 +554,11 @@ public class Theorem
                     value = ((IntNum)val).Int64;
                     break;
                 case TypeCode.DateTime:
-                    // The write path encodes the instant with ToFileTimeUtc (ExpressionVisitor.cs:311),
-                    // whose inverse is FromFileTimeUtc. FromFileTime converts to local time, which
-                    // shifts the value by the machine's UTC offset and makes the same theorem answer
-                    // differently on different machines. See #56.
-                    value = DateTime.FromFileTimeUtc(((IntNum)val).Int64);
+                    // The write path encodes the instant as its ticks on the UTC timeline
+                    // (ExpressionVisitor.ToUtcTicks), so the value is read back as UTC from the
+                    // same ticks. It used to be a Windows file time, read with FromFileTimeUtc, which
+                    // could express nothing before 1601. See #56 and #83.
+                    value = ToDateTime(((IntNum)val).Int64, parameter.Name);
                     break;
                 case TypeCode.Boolean:
                     value = val.IsTrue;
@@ -616,6 +616,28 @@ public class Theorem
         }
 
         return value!;
+    }
+
+    /// <summary>
+    /// Reads a <see cref="DateTime"/> symbol back from the ticks Z3 holds it as.
+    /// </summary>
+    /// <remarks>
+    /// The symbol is an unbounded integer, so Z3 can satisfy a constraint with a value no
+    /// <see cref="DateTime"/> can hold - <c>t.X1 &gt; DateTime.MaxValue</c> is satisfiable in
+    /// integers. The <see cref="DateTime"/> constructor would throw for that anyway; this throws
+    /// first, naming the symbol and the range, since the constructor names neither. The same
+    /// trade-off as the checked read of a <c>short</c>: loud rather than wrong. #87 - bounding
+    /// the symbol so Z3 cannot pick such a value - applies here too.
+    /// </remarks>
+    private static DateTime ToDateTime(long ticks, string name)
+    {
+        if (ticks < DateTime.MinValue.Ticks || ticks > DateTime.MaxValue.Ticks)
+        {
+            throw new OverflowException(
+                $"The value Z3 chose for the DateTime symbol {name} is outside the range a DateTime can hold, 0001-01-01 to 9999-12-31. See https://github.com/endjin/Z3.Linq/issues/87.");
+        }
+
+        return new DateTime(ticks, DateTimeKind.Utc);
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes #83.

## The defect

A `DateTime` travelled through Z3 as a Windows file time - 100ns intervals counted from
1601-01-01 UTC - so nothing earlier could be written or read:

```csharp
using var ctx = new Z3Context();
var y1500 = new DateTime(1500, 1, 1, 0, 0, 0, DateTimeKind.Utc);

ctx.NewTheorem<Symbols<DateTime, int>>().Where(t => t.X1 == y1500).Solve();
// System.ArgumentOutOfRangeException: Not a valid Win32 FileTime.
//   - during translation, before Z3 sees the theorem

ctx.NewTheorem<Symbols<DateTime, int>>().Where(t => t.X1 < y1601).Solve();
// System.ArgumentOutOfRangeException: Not a valid Win32 FileTime. (Parameter 'fileTime')
//   - after Z3 found a model, while reading it back
```

Roughly two thirds of the type's range was unusable, and the second shape is the worse one:
nothing about it is malformed, Z3 solves it, and the read path then refuses to express the answer
- blaming a `fileTime` parameter no caller supplied.

Measured before the change, fifteen shapes. Beyond the issue's rows: one tick before 1601 fails
on the write; a `DateTime[]` element before 1601 fails the same way; and
`t.X1 > DateTime.MaxValue` - which has **no solution in `DateTime` terms** - returns a model and
dies on the read with the `fileTime` message.

## The change

**Ticks instead of a file time.** `DateTime.Ticks` counts from 0001-01-01 and covers the whole
range, fits an `Int64` exactly as the file time did, and the encoding is internal, so nothing
outside the library depends on the choice. The write path becomes `ExpressionVisitor.ToUtcTicks`,
the two read paths become `Theorem.ToDateTime`.

**#56's kind convention is kept exactly.** `ToFileTimeUtc` converted a `Local` value to UTC and
took `Unspecified` to be UTC already; `ToUtcTicks` does the same, and the read path produces
`Utc` as before. Rows K and L of the probe - a Local constant coming back as the same instant in
UTC, an Unspecified constant coming back with identical ticks - are unchanged before and after,
and the #56 tests pass untouched.

**The read is guarded, and the guard names the symbol.** The symbol is an unbounded integer, so
`t.X1 > DateTime.MaxValue` still has a model in Z3; the guard turns that into

```
OverflowException: The value Z3 chose for the DateTime symbol X1 is outside the range a DateTime
can hold, 0001-01-01 to 9999-12-31. See https://github.com/endjin/Z3.Linq/issues/87.
```

rather than the constructor's complaint. The same trade-off as the checked read of a `short`
(#63): loud rather than wrong, until #87 bounds the symbol so Z3 cannot choose such a value. With
the encoding starting at tick zero, the bottom of the range is now reachable only by constraining
below `DateTime.MinValue` itself.

**One visible change beyond the fix.** An unconstrained `DateTime` symbol completes to
`DateTime.MinValue` rather than `1601-01-01`, because completion supplies zero and zero now means
something else. The issue flagged this; no test asserted the old value, and the remarks that
mentioned it are updated.

## Measured after the change

| Shape | Before | After |
|---|---|---|
| `== 1500-01-01`, `== DateTime.MinValue`, one tick before 1601 | `ArgumentOutOfRangeException` on the write | exact, `Utc` |
| `DateTime[]` element `== 1500-01-01` | `ArgumentOutOfRangeException` on the write | exact, `Utc` |
| `< 1601-01-01` | `ArgumentOutOfRangeException` on the read | `1600-12-31T23:59:59.9999999Z` |
| `> DateTime.MaxValue`, `< DateTime.MinValue` | `ArgumentOutOfRangeException (Parameter 'fileTime')` | `OverflowException` naming `X1` and the range |
| `== DateTime.MaxValue`, `== 1601-01-01`, Local kind, Unspecified kind | worked | unchanged |
| unconstrained | `1601-01-01Z` | `0001-01-01Z` |

## Tests

247 → 254. The two #83 pins in `SymbolTypeMarshallingTests` are replaced, and the remarks across
three files that described the encoding as a file time now describe it as ticks.

| Test | What it covers |
|---|---|
| `Solve_DateTimeSymbolBefore1601_RoundTripsTheValue` | years 1, 1066, 1500 and 1600 - the range the old encoding could not express, with `MinValue` as the bottom boundary |
| `Solve_DateTimeSymbolOneTickBefore1601_RoundTripsTheValue` | the exact boundary of the old encoding, from the wrong side |
| `Solve_DateTimeSymbolConstrainedBefore1601_ReturnsAnInstantBefore1601` | the read half of the issue - the theorem that solved and then threw |
| `Solve_DateTimeSymbolConstrainedBeyondMaxValue_ThrowsOverflowExceptionNamingIt` / `..BelowMinValue..` | the guard, both ends; asserts the symbol name and the range are in the message |
| `Solve_DateTimeArrayElementBefore1601_RoundTripsTheValue` (in `CollectionSymbolTests`) | the element read has its own `DateTime` arm |

## Mutation results

| Mutation | Failures | Which |
|---|---|---|
| Write path uses raw ticks, no Local → UTC conversion | **2** | the Local-kind test and the `OrderByDescending` DateTime test. **Only on a machine with a non-zero UTC offset** - this one is on BST - which is the same blind spot #56 recorded: UTC CI cannot see a Local/UTC confusion |
| Read path drops the range guard | **2** | the two overflow pins alone, which become `ArgumentOutOfRangeException` from the constructor |
| Read path produces `Unspecified` rather than `Utc` | **15** | every kind assertion across four files |
| Read path back on file time - the two ends disagree | **15** | every DateTime round-trip, including the #56 ones |

## Verification

- `dotnet build solutions/Z3.Linq.slnx -c Release` - clean, `TreatWarningsAsErrors` and
  documentation generation on
- 254/254 locally
- `./build.ps1 -Configuration Release` - 46 tasks, 0 errors, 0 warnings
- Coverage 88.1% -> 88.3% line (702 of 795), 77.5% -> 77.9% branch (469 of 602)

## Release note

Releases remain on hold under #60 until Microsoft.Z3 5.x reaches nuget.org, so this reaches `main`
but not consumers. Nothing about the hold changes.
