### PR TITLE
Let a solve be bounded, and say when Z3 could not decide

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,45 @@ var solveable = from t in ctx.NewTheorem<(int a, int b)>()
 if (solveable.TrySolve(out var cheapest)) { /* ... */ }
 ```
 
+### When Z3 cannot decide
+
+Some theorems cannot be decided. Nonlinear integer arithmetic is undecidable in general, and a
+theorem such as *three integers whose cubes sum to 42* leaves Z3 searching until the process is
+killed - the constraints look no more exotic than the ones above. Bound the solve with a
+`Timeout`, or with a `ResourceLimit`, which counts Z3's own units of work and so is reached at the
+same point on every machine:
+
+```csharp
+using (var ctx = new Z3Context { Timeout = TimeSpan.FromSeconds(5) })
+{
+    var theorem = from t in ctx.NewTheorem<Symbols<int, int, int>>()
+                  where (t.X1 * t.X1 * t.X1) + (t.X2 * t.X2 * t.X2) + (t.X3 * t.X3 * t.X3) == 42
+                  select t;
+
+    try
+    {
+        var result = theorem.Solve();
+    }
+    catch (TheoremUndecidedException e)
+    {
+        Console.WriteLine($"Z3 stopped: {e.Reason}");   // Z3 stopped: timeout
+    }
+}
+```
+
+Every solve and optimisation also takes a `CancellationToken`, which interrupts Z3 and throws
+`OperationCanceledException` as usual:
+
+```csharp
+using var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+var result = theorem.Solve(cancellation.Token);
+```
+
+A theorem Z3 decides within the limit is unaffected, and `TrySolve` returning `false` still means
+exactly one thing: the theorem was proved to have no solution. A solve that stops without deciding
+throws, so it can never be mistaken for one.
+
 ## Getting Started
 
 You can install the [Z3.Linq NuGet Package](https://www.nuget.org/packages/Z3.Linq/).

--- a/solutions/Z3.Linq.Tests/SolveLimitTests.cs
+++ b/solutions/Z3.Linq.Tests/SolveLimitTests.cs
@@ -1,0 +1,303 @@
+namespace Z3.Linq.Tests;
+
+/// <summary>
+/// Bounding a solve: <see cref="Z3Context.Timeout"/>, <see cref="Z3Context.ResourceLimit"/> and
+/// the <see cref="CancellationToken"/> every solve and optimisation accepts.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Nonlinear integer arithmetic is undecidable in general, and the theorem these tests use -
+/// three integers whose cubes sum to 42 - is the one #85 measured as still searching after two
+/// minutes. Before #85 nothing in the API could stop it. Every test that runs it carries a
+/// <see cref="TimeoutAttribute"/>, so a regression fails the test rather than hanging the suite.
+/// </para>
+/// <para>
+/// How Z3 stops is reported by exception, never by <see langword="false"/>: a cancelled token is
+/// <see cref="OperationCanceledException"/>, and everything else - a limit reached, or Z3 giving
+/// up - is <see cref="TheoremUndecidedException"/>. That settles the wrinkle #57 deferred: the
+/// <see langword="false"/> from <c>TrySolve</c> means "proved to have no solution" and nothing
+/// else. Z3 describes why it stopped as a string, and the strings differ between the solver and
+/// the optimizer for the same limit, so no test asserts on them beyond their presence.
+/// </para>
+/// <para>
+/// The limits are small - half a second, a modest resource budget - because the point is that
+/// they are reached, not how long that takes. Nothing here asserts on elapsed time.
+/// </para>
+/// </remarks>
+[TestClass]
+public class SolveLimitTests
+{
+    private const int HangGuardMilliseconds = 60_000;
+
+    [TestMethod]
+    [Timeout(HangGuardMilliseconds)]
+    public void Solve_UndecidableTheoremWithATimeout_ThrowsTheoremUndecidedException()
+    {
+        // Arrange
+        using var context = new Z3Context { Timeout = TimeSpan.FromMilliseconds(500) };
+        var theorem = SumOfThreeCubes(context);
+
+        // Act
+        TheoremUndecidedException exception = Should.Throw<TheoremUndecidedException>(() => theorem.Solve());
+
+        // Assert
+        exception.Reason.ShouldNotBeNullOrEmpty();
+        exception.Message.ShouldContain(exception.Reason);
+    }
+
+    /// <summary>
+    /// A solve that stopped without deciding throws rather than returning <see langword="false"/>.
+    /// </summary>
+    /// <remarks>
+    /// The wrinkle #57 raised and #85 deferred: <c>TrySolve</c> used to return
+    /// <see langword="false"/> for <c>Status.UNKNOWN</c> as well as for unsatisfiable, which was
+    /// defensible only while nothing could produce an unknown. Now something can, and
+    /// <see langword="false"/> has to mean what it says.
+    /// </remarks>
+    [TestMethod]
+    [Timeout(HangGuardMilliseconds)]
+    public void TrySolve_UndecidableTheoremWithATimeout_ThrowsRatherThanReturningFalse()
+    {
+        // Arrange
+        using var context = new Z3Context { Timeout = TimeSpan.FromMilliseconds(500) };
+        var theorem = SumOfThreeCubes(context);
+
+        // Act & Assert
+        Should.Throw<TheoremUndecidedException>(() => theorem.TrySolve(out _));
+    }
+
+    /// <summary>
+    /// A resource limit stops the same theorem, deterministically.
+    /// </summary>
+    /// <remarks>
+    /// Z3's <c>rlimit</c> counts work rather than time, so the same theorem does the same amount
+    /// of it on every machine. Measured, this budget is exhausted in tens of milliseconds.
+    /// </remarks>
+    [TestMethod]
+    [Timeout(HangGuardMilliseconds)]
+    public void Solve_UndecidableTheoremWithAResourceLimit_ThrowsTheoremUndecidedException()
+    {
+        // Arrange
+        using var context = new Z3Context { ResourceLimit = 200_000 };
+        var theorem = SumOfThreeCubes(context);
+
+        // Act & Assert
+        Should.Throw<TheoremUndecidedException>(() => theorem.Solve());
+    }
+
+    [TestMethod]
+    public void Solve_SatisfiableTheoremWithATimeout_StillSolves()
+    {
+        // Arrange: a limit changes nothing for a theorem Z3 decides within it.
+        using var context = new Z3Context { Timeout = TimeSpan.FromMilliseconds(500) };
+
+        // Act
+        var result = context.NewTheorem<Symbols<int, int>>()
+            .Where(t => t.X1 == 3)
+            .Where(t => t.X2 == t.X1 + 1)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.X1.ShouldBe(3);
+        result.X2.ShouldBe(4);
+    }
+
+    [TestMethod]
+    public void TrySolve_UnsatisfiableTheoremWithATimeout_StillReturnsFalse()
+    {
+        // Arrange: false still means proved unsatisfiable, limit or no limit.
+        using var context = new Z3Context { Timeout = TimeSpan.FromMilliseconds(500) };
+        var theorem = context.NewTheorem<Symbols<int, int>>()
+            .Where(t => t.X1 == 3)
+            .Where(t => t.X1 == 4);
+
+        // Act
+        bool satisfiable = theorem.TrySolve(out _);
+
+        // Assert
+        satisfiable.ShouldBeFalse();
+    }
+
+    /// <summary>
+    /// The context stays usable after a solve is cut short.
+    /// </summary>
+    /// <remarks>
+    /// The limit is applied to each solve, not baked into the native context, so an undecided
+    /// solve leaves nothing behind - the next theorem on the same context solves normally.
+    /// </remarks>
+    [TestMethod]
+    [Timeout(HangGuardMilliseconds)]
+    public void Solve_AfterAnUndecidedSolveOnTheSameContext_StillSolves()
+    {
+        // Arrange
+        using var context = new Z3Context { Timeout = TimeSpan.FromMilliseconds(500) };
+        Should.Throw<TheoremUndecidedException>(() => SumOfThreeCubes(context).Solve());
+
+        // Act
+        var result = context.NewTheorem<Symbols<int, int>>()
+            .Where(t => t.X1 == 7)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.X1.ShouldBe(7);
+    }
+
+    /// <summary>
+    /// An already-cancelled token throws before any work is done.
+    /// </summary>
+    /// <remarks>
+    /// Measured on the raw API: an interrupt issued before the check starts is lost, so a token
+    /// that is cancelled on the way in has to be inspected rather than relied on to fire. The
+    /// theorem here is trivially satisfiable and would solve in milliseconds; it must not.
+    /// </remarks>
+    [TestMethod]
+    public void Solve_WithAnAlreadyCancelledToken_ThrowsOperationCanceledException()
+    {
+        // Arrange
+        using var context = new Z3Context();
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+        var theorem = context.NewTheorem<Symbols<int, int>>().Where(t => t.X1 == 3);
+
+        // Act
+        OperationCanceledException exception =
+            Should.Throw<OperationCanceledException>(() => theorem.Solve(cancellation.Token));
+
+        // Assert
+        exception.CancellationToken.ShouldBe(cancellation.Token);
+    }
+
+    [TestMethod]
+    [Timeout(HangGuardMilliseconds)]
+    public void Solve_CancelledDuringTheSolve_ThrowsOperationCanceledException()
+    {
+        // Arrange: no limit on the context, so only the token can end this.
+        using var context = new Z3Context();
+        using var cancellation = new CancellationTokenSource(TimeSpan.FromMilliseconds(300));
+        var theorem = SumOfThreeCubes(context);
+
+        // Act
+        OperationCanceledException exception =
+            Should.Throw<OperationCanceledException>(() => theorem.Solve(cancellation.Token));
+
+        // Assert
+        exception.CancellationToken.ShouldBe(cancellation.Token);
+    }
+
+    [TestMethod]
+    [Timeout(HangGuardMilliseconds)]
+    public void Optimize_UndecidableTheoremWithATimeout_ThrowsTheoremUndecidedException()
+    {
+        // Arrange: the optimizer has its own check, and reports the limit with a different
+        // string from the solver - which is why the library decides by what it asked for.
+        using var context = new Z3Context { Timeout = TimeSpan.FromMilliseconds(500) };
+        var theorem = SumOfThreeCubes(context);
+
+        // Act
+        TheoremUndecidedException exception =
+            Should.Throw<TheoremUndecidedException>(() => theorem.Optimize(Optimization.Minimize, t => t.X1));
+
+        // Assert
+        exception.Reason.ShouldNotBeNullOrEmpty();
+    }
+
+    [TestMethod]
+    [Timeout(HangGuardMilliseconds)]
+    public void Optimize_CancelledDuringTheSolve_ThrowsOperationCanceledException()
+    {
+        // Arrange
+        using var context = new Z3Context();
+        using var cancellation = new CancellationTokenSource(TimeSpan.FromMilliseconds(300));
+        var theorem = SumOfThreeCubes(context);
+
+        // Act
+        OperationCanceledException exception = Should.Throw<OperationCanceledException>(
+            () => theorem.TryOptimize(Optimization.Minimize, t => t.X1, out _, cancellation.Token));
+
+        // Assert
+        exception.CancellationToken.ShouldBe(cancellation.Token);
+    }
+
+    /// <summary>
+    /// The deferred form an <c>orderby</c> query returns takes the token when it is finally
+    /// solved.
+    /// </summary>
+    [TestMethod]
+    [Timeout(HangGuardMilliseconds)]
+    public void OrderBy_CancelledDuringTheDeferredSolve_ThrowsOperationCanceledException()
+    {
+        // Arrange
+        using var context = new Z3Context();
+        using var cancellation = new CancellationTokenSource(TimeSpan.FromMilliseconds(300));
+        ISolveable<Symbols<int, int, int>> deferred = SumOfThreeCubes(context).OrderBy(t => t.X1);
+
+        // Act
+        OperationCanceledException exception =
+            Should.Throw<OperationCanceledException>(() => deferred.TrySolve(out _, cancellation.Token));
+
+        // Assert
+        exception.CancellationToken.ShouldBe(cancellation.Token);
+    }
+
+    /// <summary>
+    /// The <c>Nullable</c>-lifting extension passes the token through.
+    /// </summary>
+    [TestMethod]
+    [Timeout(HangGuardMilliseconds)]
+    public void SolveOrNull_CancelledDuringTheSolve_ThrowsOperationCanceledException()
+    {
+        // Arrange
+        using var context = new Z3Context();
+        using var cancellation = new CancellationTokenSource(TimeSpan.FromMilliseconds(300));
+        var theorem = context.NewTheorem<(int a, int b, int c)>()
+            .Where(t => (t.a * t.a * t.a) + (t.b * t.b * t.b) + (t.c * t.c * t.c) == 42);
+
+        // Act & Assert
+        Should.Throw<OperationCanceledException>(() => theorem.SolveOrNull(cancellation.Token));
+    }
+
+    [TestMethod]
+    [DataRow(0L, DisplayName = "Zero")]
+    [DataRow(-1L, DisplayName = "Negative")]
+    public void Timeout_SetToANonPositiveValue_ThrowsArgumentOutOfRangeException(long ticks)
+    {
+        // Arrange
+        using var context = new Z3Context();
+
+        // Act & Assert
+        Should.Throw<ArgumentOutOfRangeException>(() => context.Timeout = TimeSpan.FromTicks(ticks));
+    }
+
+    [TestMethod]
+    public void ResourceLimit_SetToZero_ThrowsArgumentOutOfRangeException()
+    {
+        // Arrange
+        using var context = new Z3Context();
+
+        // Act & Assert
+        Should.Throw<ArgumentOutOfRangeException>(() => context.ResourceLimit = 0);
+    }
+
+    [TestMethod]
+    public void Timeout_SetToNull_ClearsTheLimit()
+    {
+        // Arrange
+        using var context = new Z3Context { Timeout = TimeSpan.FromSeconds(1) };
+
+        // Act
+        context.Timeout = null;
+
+        // Assert
+        context.Timeout.ShouldBeNull();
+    }
+
+    private static Theorem<Symbols<int, int, int>> SumOfThreeCubes(Z3Context context)
+    {
+        // x^3 + y^3 + z^3 == 42 over the integers. A solution exists - it was found in 2019 and
+        // has eighteen digits - but Z3 has no way to reach it, and no way to prove there is none.
+        return context.NewTheorem<Symbols<int, int, int>>()
+            .Where(t => (t.X1 * t.X1 * t.X1) + (t.X2 * t.X2 * t.X2) + (t.X3 * t.X3 * t.X3) == 42);
+    }
+}

--- a/solutions/Z3.Linq.Tests/TheoremSolveTests.cs
+++ b/solutions/Z3.Linq.Tests/TheoremSolveTests.cs
@@ -13,10 +13,11 @@ namespace Z3.Linq.Tests;
 /// packages daily on this repository.
 /// </para>
 /// <para>
-/// Unsatisfiable cases are deliberately kept trivial. <c>Solve</c> returns <c>default</c> for
-/// both <c>Status.UNSATISFIABLE</c> and <c>Status.UNKNOWN</c> (Theorem.cs:85-87), so a theorem
-/// that was merely slow would pass an "is unsatisfiable" assertion. Keeping these obviously
-/// contradictory removes that risk.
+/// Unsatisfiable cases are deliberately kept trivial. Since #85 a solve that stops without
+/// deciding throws <c>TheoremUndecidedException</c> rather than reporting the theorem
+/// unsatisfiable, so a merely slow theorem can no longer pass an "is unsatisfiable" assertion by
+/// accident - but only once a limit is set, and none is set here. Keeping these obviously
+/// contradictory keeps them fast as well as right.
 /// </para>
 /// <para>
 /// A symbol the returned model does not interpret takes an arbitrary value supplied by Z3's

--- a/solutions/Z3.Linq/ISolveable{T}.cs
+++ b/solutions/Z3.Linq/ISolveable{T}.cs
@@ -1,6 +1,8 @@
 namespace Z3.Linq
 {
+    using System;
     using System.Diagnostics.CodeAnalysis;
+    using System.Threading;
 
     /// <summary>
     /// Enables optimization constraints as expressed by OrderBy to be deferred, just like
@@ -12,24 +14,39 @@ namespace Z3.Linq
         /// <summary>
         /// Solves the theorem.
         /// </summary>
+        /// <param name="cancellationToken">A token that interrupts the solve.</param>
         /// <returns>
         /// Environment type instance with properties set to theorem-satisfying values, or
         /// <c>default(T)</c> if the theorem cannot be satisfied.
         /// </returns>
+        /// <exception cref="TheoremUndecidedException">
+        /// Z3 stopped without deciding: a limit on the <see cref="Z3Context"/> was reached, or it
+        /// gave up. See #85.
+        /// </exception>
+        /// <exception cref="OperationCanceledException"><paramref name="cancellationToken"/> was cancelled.</exception>
         /// <remarks>
         /// For a value-type environment <c>default(T)</c> is a populated all-zero instance and
         /// cannot be told apart from a solution in which every symbol is zero. Use
-        /// <see cref="TrySolve(out T)"/>, or <c>SolveOrNull</c>, where that matters. See #57.
+        /// <see cref="TrySolve(out T, CancellationToken)"/>, or <c>SolveOrNull</c>, where that
+        /// matters. See #57.
         /// </remarks>
-        T? Solve();
+        T? Solve(CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Solves the theorem, reporting satisfiability separately from the solution.
         /// </summary>
         /// <param name="result">The solution, when the theorem could be satisfied.</param>
+        /// <param name="cancellationToken">A token that interrupts the solve.</param>
         /// <returns>
         /// <see langword="true"/> if the theorem was satisfiable; otherwise <see langword="false"/>.
+        /// A solve that stopped without deciding throws rather than returning
+        /// <see langword="false"/>.
         /// </returns>
-        bool TrySolve([MaybeNullWhen(false)] out T result);
+        /// <exception cref="TheoremUndecidedException">
+        /// Z3 stopped without deciding: a limit on the <see cref="Z3Context"/> was reached, or it
+        /// gave up. See #85.
+        /// </exception>
+        /// <exception cref="OperationCanceledException"><paramref name="cancellationToken"/> was cancelled.</exception>
+        bool TrySolve([MaybeNullWhen(false)] out T result, CancellationToken cancellationToken = default);
     }
 }

--- a/solutions/Z3.Linq/SolveableExtensions.cs
+++ b/solutions/Z3.Linq/SolveableExtensions.cs
@@ -27,14 +27,17 @@ public static class SolveableExtensions
     /// </summary>
     /// <typeparam name="TEnvironment">Value-type environment over which the theorem is defined.</typeparam>
     /// <param name="solveable">The theorem, or a deferred optimisation over one.</param>
+    /// <param name="cancellationToken">A token that interrupts the solve.</param>
     /// <returns>The solution, or <see langword="null"/> if the theorem cannot be satisfied.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="solveable"/> is null.</exception>
-    public static TEnvironment? SolveOrNull<TEnvironment>(this ISolveable<TEnvironment> solveable)
+    /// <exception cref="TheoremUndecidedException">Z3 stopped without deciding. See #85.</exception>
+    /// <exception cref="OperationCanceledException"><paramref name="cancellationToken"/> was cancelled.</exception>
+    public static TEnvironment? SolveOrNull<TEnvironment>(this ISolveable<TEnvironment> solveable, CancellationToken cancellationToken = default)
         where TEnvironment : struct
     {
         ArgumentNullException.ThrowIfNull(solveable);
 
-        return solveable.TrySolve(out TEnvironment solution) ? solution : null;
+        return solveable.TrySolve(out TEnvironment solution, cancellationToken) ? solution : null;
     }
 
     /// <summary>
@@ -46,16 +49,20 @@ public static class SolveableExtensions
     /// <param name="theorem">The theorem to optimize over.</param>
     /// <param name="direction">The optimization goal, i.e. whether to minimize or maximize the solution.</param>
     /// <param name="lambda">Expression representing the value to minimize or maximize.</param>
+    /// <param name="cancellationToken">A token that interrupts the optimisation.</param>
     /// <returns>The optimal solution, or <see langword="null"/> if the theorem cannot be satisfied.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="theorem"/> is null.</exception>
+    /// <exception cref="TheoremUndecidedException">Z3 stopped without deciding. See #85.</exception>
+    /// <exception cref="OperationCanceledException"><paramref name="cancellationToken"/> was cancelled.</exception>
     public static TEnvironment? OptimizeOrNull<TEnvironment, TResult>(
         this Theorem<TEnvironment> theorem,
         Optimization direction,
-        Expression<Func<TEnvironment, TResult>> lambda)
+        Expression<Func<TEnvironment, TResult>> lambda,
+        CancellationToken cancellationToken = default)
         where TEnvironment : struct
     {
         ArgumentNullException.ThrowIfNull(theorem);
 
-        return theorem.TryOptimize(direction, lambda, out TEnvironment solution) ? solution : null;
+        return theorem.TryOptimize(direction, lambda, out TEnvironment solution, cancellationToken) ? solution : null;
     }
 }

--- a/solutions/Z3.Linq/Theorem.cs
+++ b/solutions/Z3.Linq/Theorem.cs
@@ -96,14 +96,15 @@ public class Theorem
     /// </summary>
     /// <typeparam name="T">Theorem environment type.</typeparam>
     /// <returns>Result of solving the theorem; <c>default(T)</c> if the theorem cannot be satisfied.</returns>
+    /// <param name="cancellationToken">A token that interrupts the solve.</param>
     /// <remarks>
     /// For a value-type environment <c>default(T)</c> is a real, populated instance - all zeroes -
     /// and so cannot be told apart from a solution in which every symbol happens to be zero. Use
-    /// <see cref="TrySolve{T}(out T)"/> where that matters. See #57.
+    /// <see cref="TrySolve{T}(out T, CancellationToken)"/> where that matters. See #57.
     /// </remarks>
-    protected T? Solve<T>()
+    protected T? Solve<T>(CancellationToken cancellationToken)
     {
-        return this.TrySolve<T>(out T? result) ? result : default;
+        return this.TrySolve<T>(out T? result, cancellationToken) ? result : default;
     }
 
     /// <summary>
@@ -111,8 +112,11 @@ public class Theorem
     /// </summary>
     /// <typeparam name="T">Theorem environment type.</typeparam>
     /// <param name="result">The solution, when the theorem could be satisfied.</param>
+    /// <param name="cancellationToken">A token that interrupts the solve.</param>
     /// <returns><see langword="true"/> if the theorem was satisfiable; otherwise <see langword="false"/>.</returns>
-    protected bool TrySolve<T>([MaybeNullWhen(false)] out T result)
+    /// <exception cref="TheoremUndecidedException">Z3 stopped without deciding - a limit on the <see cref="Z3Context"/> was reached, or it gave up.</exception>
+    /// <exception cref="OperationCanceledException"><paramref name="cancellationToken"/> was cancelled.</exception>
+    protected bool TrySolve<T>([MaybeNullWhen(false)] out T result, CancellationToken cancellationToken)
     {
         using Context ctx = this.context.CreateContext();
         var environment = GetEnvironment(ctx, typeof(T));
@@ -122,7 +126,7 @@ public class Theorem
 
         AssertConstraints<T>(ctx, solver, environment);
 
-        Status status = solver.Check();
+        Status status = this.Check(ctx, solver, cancellationToken);
 
         if (status != Status.SATISFIABLE)
         {
@@ -142,14 +146,16 @@ public class Theorem
     /// <param name="direction">The optimization goal, i.e. whether to minimize or maximize the solution.</param>
     /// <param name="lambda">Expression representing the value to minimize or maximize.</param>
     /// <returns>Result of solving the theorem; <c>default(T)</c> if the theorem cannot be satisfied.</returns>
+    /// <param name="cancellationToken">A token that interrupts the optimisation.</param>
     /// <remarks>
-    /// Carries the same ambiguity as <see cref="Solve{T}"/> for a value-type environment. Use
-    /// <see cref="TryOptimize{T, TResult}(Optimization, Expression{Func{T, TResult}}, out T)"/>
+    /// Carries the same ambiguity as <see cref="Solve{T}(CancellationToken)"/> for a value-type
+    /// environment. Use
+    /// <see cref="TryOptimize{T, TResult}(Optimization, Expression{Func{T, TResult}}, out T, CancellationToken)"/>
     /// where that matters. See #57.
     /// </remarks>
-    protected T? Optimize<T, TResult>(Optimization direction, Expression<Func<T, TResult>> lambda)
+    protected T? Optimize<T, TResult>(Optimization direction, Expression<Func<T, TResult>> lambda, CancellationToken cancellationToken)
     {
-        return this.TryOptimize<T, TResult>(direction, lambda, out T? result) ? result : default;
+        return this.TryOptimize<T, TResult>(direction, lambda, out T? result, cancellationToken) ? result : default;
     }
 
     /// <summary>
@@ -160,11 +166,15 @@ public class Theorem
     /// <param name="direction">The optimization goal, i.e. whether to minimize or maximize the solution.</param>
     /// <param name="lambda">Expression representing the value to minimize or maximize.</param>
     /// <param name="result">The optimal solution, when the theorem could be satisfied.</param>
+    /// <param name="cancellationToken">A token that interrupts the optimisation.</param>
     /// <returns><see langword="true"/> if the theorem was satisfiable; otherwise <see langword="false"/>.</returns>
+    /// <exception cref="TheoremUndecidedException">Z3 stopped without deciding - a limit on the <see cref="Z3Context"/> was reached, or it gave up.</exception>
+    /// <exception cref="OperationCanceledException"><paramref name="cancellationToken"/> was cancelled.</exception>
     protected bool TryOptimize<T, TResult>(
         Optimization direction,
         Expression<Func<T, TResult>> lambda,
-        [MaybeNullWhen(false)] out T result)
+        [MaybeNullWhen(false)] out T result,
+        CancellationToken cancellationToken)
     {
         using Context ctx = this.context.CreateContext();
         var environment = GetEnvironment(ctx, typeof(T));
@@ -187,7 +197,7 @@ public class Theorem
                 throw new ArgumentOutOfRangeException(nameof(direction), direction, null);
         }
 
-        Status status = optimizer.Check();
+        Status status = this.Check(ctx, optimizer, cancellationToken);
 
         if (status != Status.SATISFIABLE)
         {
@@ -197,6 +207,76 @@ public class Theorem
 
         result = GetSolution<T>(ctx, optimizer.Model, environment, this.template);
         return true;
+    }
+
+    /// <summary>
+    /// Runs the check on a solver or optimizer under the limits set on the <see cref="Z3Context"/>
+    /// and the caller's token, and turns an undecided outcome into an exception.
+    /// </summary>
+    /// <param name="ctx">The native context the check runs in.</param>
+    /// <param name="approach">The <see cref="Solver"/> or <see cref="Optimize"/> to check.</param>
+    /// <param name="cancellationToken">A token that interrupts the check.</param>
+    /// <returns><see cref="Status.SATISFIABLE"/> or <see cref="Status.UNSATISFIABLE"/> - never <see cref="Status.UNKNOWN"/>.</returns>
+    /// <remarks>
+    /// <para>
+    /// A cancelled token interrupts Z3 through <see cref="Context.Interrupt"/>. An interrupt that
+    /// arrives before the check has started is lost - measured, not assumed - so the token is
+    /// also inspected before the check, which leaves only the moment between that inspection and
+    /// Z3 starting work.
+    /// </para>
+    /// <para>
+    /// Z3 says why it stopped as a string, and the strings are not consistent: the solver says
+    /// <c>timeout</c> or <c>interrupted</c>, the optimizer says <c>canceled</c> for either, and an
+    /// exhausted resource limit is <c>canceled</c> on both. So cancellation is recognised from the
+    /// token rather than the string, and every other <see cref="Status.UNKNOWN"/> is a
+    /// <see cref="TheoremUndecidedException"/> carrying the string. Before #85 an
+    /// <see cref="Status.UNKNOWN"/> was reported as unsatisfiable, which was defensible only
+    /// because nothing could cause one.
+    /// </para>
+    /// </remarks>
+    private Status Check(Context ctx, Z3Object approach, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        Params? limits = this.context.CreateLimits(ctx);
+
+        switch (approach)
+        {
+            case Solver solver when limits is not null:
+                solver.Parameters = limits;
+                break;
+            case Optimize optimizer when limits is not null:
+                optimizer.Parameters = limits;
+                break;
+        }
+
+        Status status;
+
+        using (cancellationToken.Register(ctx.Interrupt))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            status = approach switch
+            {
+                Solver solver => solver.Check(),
+                Optimize optimizer => optimizer.Check(),
+                _ => throw new ArgumentException("Expected a Solver or an Optimize.", nameof(approach)),
+            };
+        }
+
+        if (status == Status.UNKNOWN)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            throw new TheoremUndecidedException(approach switch
+            {
+                Solver solver => solver.ReasonUnknown,
+                Optimize optimizer => optimizer.ReasonUnknown,
+                _ => "unknown",
+            });
+        }
+
+        return status;
     }
 
     /// <summary>

--- a/solutions/Z3.Linq/TheoremUndecidedException.cs
+++ b/solutions/Z3.Linq/TheoremUndecidedException.cs
@@ -1,0 +1,40 @@
+namespace Z3.Linq;
+
+using System;
+
+/// <summary>
+/// Z3 stopped without deciding whether the theorem is satisfiable.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Thrown when a solve or optimisation ends with Z3 reporting <c>unknown</c>: the
+/// <see cref="Z3Context.Timeout"/> or <see cref="Z3Context.ResourceLimit"/> was reached, or Z3
+/// gave up on a problem it cannot decide. The theorem has been proved neither satisfiable nor
+/// unsatisfiable, which is why this is an exception rather than a <see langword="false"/> from
+/// <c>TrySolve</c> - <see langword="false"/> means the theorem has no solution, and this means
+/// nobody knows. See #57 and #85.
+/// </para>
+/// <para>
+/// A solve cut short by a <see cref="System.Threading.CancellationToken"/> throws
+/// <see cref="OperationCanceledException"/> instead, as everywhere else in .NET.
+/// </para>
+/// </remarks>
+public class TheoremUndecidedException : Exception
+{
+    /// <summary>
+    /// Creates the exception.
+    /// </summary>
+    /// <param name="reason">Z3's own account of why it stopped.</param>
+    public TheoremUndecidedException(string reason)
+        : base($"Z3 could not decide whether the theorem is satisfiable ({reason}). A timeout or resource limit set on the Z3Context was reached, or Z3 gave up; the theorem has been proved neither satisfiable nor unsatisfiable.")
+    {
+        this.Reason = reason;
+    }
+
+    /// <summary>
+    /// Gets Z3's own account of why it stopped - <c>timeout</c>, <c>canceled</c> and
+    /// <c>interrupted</c> are the usual ones, and which of them a given limit produces differs
+    /// between the solver and the optimiser.
+    /// </summary>
+    public string Reason { get; }
+}

--- a/solutions/Z3.Linq/Theorem{T}.cs
+++ b/solutions/Z3.Linq/Theorem{T}.cs
@@ -48,18 +48,26 @@ public class Theorem<T> : Theorem, ISolveable<T>
     /// <summary>
     /// Solves the theorem.
     /// </summary>
+    /// <param name="cancellationToken">A token that interrupts the solve.</param>
     /// <returns>
     /// Environment type instance with properties set to theorem-satisfying values, or
     /// <c>default(T)</c> if the theorem cannot be satisfied.
     /// </returns>
+    /// <exception cref="TheoremUndecidedException">
+    /// Z3 stopped without deciding: the <see cref="Z3Context.Timeout"/> or
+    /// <see cref="Z3Context.ResourceLimit"/> was reached, or Z3 gave up. Without a limit, a theorem
+    /// Z3 cannot decide runs until the process is killed. See #85.
+    /// </exception>
+    /// <exception cref="OperationCanceledException"><paramref name="cancellationToken"/> was cancelled.</exception>
     /// <remarks>
     /// <para>
     /// Where <typeparamref name="T"/> is a value type - a value tuple, a struct, a record struct -
     /// <c>default(T)</c> is a populated instance with every symbol zero, which is also a perfectly
     /// good solution to some theorems. The two cannot be told apart here, and the result cannot
-    /// even be compared against <see langword="null"/>. Use <see cref="TrySolve(out T)"/>, or
-    /// <see cref="SolveableExtensions.SolveOrNull{TEnvironment}(ISolveable{TEnvironment})"/>, when
-    /// the difference matters. See #57.
+    /// even be compared against <see langword="null"/>. Use
+    /// <see cref="TrySolve(out T, CancellationToken)"/>, or
+    /// <see cref="SolveableExtensions.SolveOrNull{TEnvironment}(ISolveable{TEnvironment}, CancellationToken)"/>,
+    /// when the difference matters. See #57.
     /// </para>
     /// <para>
     /// A symbol that no constraint mentions is free: the theorem is still satisfiable, and Z3
@@ -74,26 +82,33 @@ public class Theorem<T> : Theorem, ISolveable<T>
     /// working in local time needs <see cref="DateTime.ToLocalTime"/> on the way out.
     /// </para>
     /// </remarks>
-    public T? Solve()
+    public T? Solve(CancellationToken cancellationToken = default)
     {
-        return base.Solve<T>();
+        return base.Solve<T>(cancellationToken);
     }
 
     /// <summary>
     /// Solves the theorem, reporting satisfiability separately from the solution.
     /// </summary>
     /// <param name="result">The solution, when the theorem could be satisfied.</param>
+    /// <param name="cancellationToken">A token that interrupts the solve.</param>
     /// <returns>
     /// <see langword="true"/> if the theorem was satisfiable; otherwise <see langword="false"/>.
     /// </returns>
+    /// <exception cref="TheoremUndecidedException">
+    /// Z3 stopped without deciding: the <see cref="Z3Context.Timeout"/> or
+    /// <see cref="Z3Context.ResourceLimit"/> was reached, or Z3 gave up. See #85.
+    /// </exception>
+    /// <exception cref="OperationCanceledException"><paramref name="cancellationToken"/> was cancelled.</exception>
     /// <remarks>
     /// The only form that answers "is there a solution?" for every environment type. What is
     /// written into <paramref name="result"/> when this returns <see langword="true"/> is exactly
-    /// what <see cref="Solve"/> would have returned.
+    /// what <see cref="Solve"/> would have returned. <see langword="false"/> means the theorem was
+    /// proved to have no solution - a solve that stopped without deciding throws instead.
     /// </remarks>
-    public bool TrySolve([MaybeNullWhen(false)] out T result)
+    public bool TrySolve([MaybeNullWhen(false)] out T result, CancellationToken cancellationToken = default)
     {
-        return base.TrySolve(out result);
+        return base.TrySolve(out result, cancellationToken);
     }
 
     /// <summary>
@@ -102,19 +117,25 @@ public class Theorem<T> : Theorem, ISolveable<T>
     /// <typeparam name="TResult">Type of the value being optimized.</typeparam>
     /// <param name="direction">The optimization goal, i.e. whether to minimize or maximize the solution.</param>
     /// <param name="lambda">Expression representing the value to minimize or maximize.</param>
+    /// <param name="cancellationToken">A token that interrupts the optimisation.</param>
     /// <returns>
     /// Environment type instance with properties set to theorem-satisfying values, or
     /// <c>default(T)</c> if the theorem cannot be satisfied.
     /// </returns>
+    /// <exception cref="TheoremUndecidedException">
+    /// Z3 stopped without deciding: the <see cref="Z3Context.Timeout"/> or
+    /// <see cref="Z3Context.ResourceLimit"/> was reached, or Z3 gave up. See #85.
+    /// </exception>
+    /// <exception cref="OperationCanceledException"><paramref name="cancellationToken"/> was cancelled.</exception>
     /// <remarks>
     /// Carries the same ambiguity as <see cref="Solve"/>, and answers it the same way - through
-    /// <see cref="TryOptimize{TResult}(Optimization, Expression{Func{T, TResult}}, out T)"/>. As
-    /// with <see cref="Solve"/>, a symbol that no constraint mentions is free and takes an
+    /// <see cref="TryOptimize{TResult}(Optimization, Expression{Func{T, TResult}}, out T, CancellationToken)"/>.
+    /// As with <see cref="Solve"/>, a symbol that no constraint mentions is free and takes an
     /// arbitrary value; the objective determines only what it is written in terms of.
     /// </remarks>
-    public T? Optimize<TResult>(Optimization direction, Expression<Func<T, TResult>> lambda)
+    public T? Optimize<TResult>(Optimization direction, Expression<Func<T, TResult>> lambda, CancellationToken cancellationToken = default)
     {
-        return base.Optimize<T, TResult>(direction, lambda);
+        return base.Optimize<T, TResult>(direction, lambda, cancellationToken);
     }
 
     /// <summary>
@@ -124,15 +145,22 @@ public class Theorem<T> : Theorem, ISolveable<T>
     /// <param name="direction">The optimization goal, i.e. whether to minimize or maximize the solution.</param>
     /// <param name="lambda">Expression representing the value to minimize or maximize.</param>
     /// <param name="result">The optimal solution, when the theorem could be satisfied.</param>
+    /// <param name="cancellationToken">A token that interrupts the optimisation.</param>
     /// <returns>
     /// <see langword="true"/> if the theorem was satisfiable; otherwise <see langword="false"/>.
     /// </returns>
+    /// <exception cref="TheoremUndecidedException">
+    /// Z3 stopped without deciding: the <see cref="Z3Context.Timeout"/> or
+    /// <see cref="Z3Context.ResourceLimit"/> was reached, or Z3 gave up. See #85.
+    /// </exception>
+    /// <exception cref="OperationCanceledException"><paramref name="cancellationToken"/> was cancelled.</exception>
     public bool TryOptimize<TResult>(
         Optimization direction,
         Expression<Func<T, TResult>> lambda,
-        [MaybeNullWhen(false)] out T result)
+        [MaybeNullWhen(false)] out T result,
+        CancellationToken cancellationToken = default)
     {
-        return base.TryOptimize(direction, lambda, out result);
+        return base.TryOptimize(direction, lambda, out result, cancellationToken);
     }
 
     /// <summary>
@@ -152,11 +180,11 @@ public class Theorem<T> : Theorem, ISolveable<T>
     /// <param name="lambda">Expression representing the value to minimize.</param>
     /// <returns>
     /// A deferred minimization. Nothing reaches Z3 until <see cref="ISolveable{T}.Solve"/> or
-    /// <see cref="ISolveable{T}.TrySolve(out T)"/> is called on the result.
+    /// <see cref="ISolveable{T}.TrySolve(out T, CancellationToken)"/> is called on the result.
     /// </returns>
     public ISolveable<T> OrderBy<TResult>(Expression<Func<T, TResult>> lambda)
-        => new DeferredSolvable(() =>
-            TryOptimize(Optimization.Minimize, lambda, out T? solution) ? (true, solution) : (false, default));
+        => new DeferredSolvable(cancellationToken =>
+            TryOptimize(Optimization.Minimize, lambda, out T? solution, cancellationToken) ? (true, solution) : (false, default));
 
     /// <summary>
     /// OrderByDescending query operator, used to optimize a solution using query expression syntax.
@@ -165,11 +193,11 @@ public class Theorem<T> : Theorem, ISolveable<T>
     /// <param name="lambda">Expression representing the value to maximize.</param>
     /// <returns>
     /// A deferred maximization. Nothing reaches Z3 until <see cref="ISolveable{T}.Solve"/> or
-    /// <see cref="ISolveable{T}.TrySolve(out T)"/> is called on the result.
+    /// <see cref="ISolveable{T}.TrySolve(out T, CancellationToken)"/> is called on the result.
     /// </returns>
     public ISolveable<T> OrderByDescending<TResult>(Expression<Func<T, TResult>> lambda)
-        => new DeferredSolvable(() =>
-            TryOptimize(Optimization.Maximize, lambda, out T? solution) ? (true, solution) : (false, default));
+        => new DeferredSolvable(cancellationToken =>
+            TryOptimize(Optimization.Maximize, lambda, out T? solution, cancellationToken) ? (true, solution) : (false, default));
 
     /// <summary>
     /// An optimisation that has not run yet.
@@ -177,22 +205,23 @@ public class Theorem<T> : Theorem, ISolveable<T>
     /// <remarks>
     /// The deferred call carries satisfiability alongside the solution rather than returning the
     /// solution alone, because for a value-type environment the solution on its own cannot say
-    /// whether there was one. See #57.
+    /// whether there was one. See #57. The token is the caller's, supplied when the deferred
+    /// solve is finally asked for, so it reaches the optimizer like any other. See #85.
     /// </remarks>
     private sealed class DeferredSolvable : ISolveable<T>
     {
-        private readonly Func<(bool Satisfiable, T? Solution)> optimize;
+        private readonly Func<CancellationToken, (bool Satisfiable, T? Solution)> optimize;
 
-        public DeferredSolvable(Func<(bool Satisfiable, T? Solution)> optimize)
+        public DeferredSolvable(Func<CancellationToken, (bool Satisfiable, T? Solution)> optimize)
         {
             this.optimize = optimize;
         }
 
-        public T? Solve() => this.optimize().Solution;
+        public T? Solve(CancellationToken cancellationToken = default) => this.optimize(cancellationToken).Solution;
 
-        public bool TrySolve([MaybeNullWhen(false)] out T result)
+        public bool TrySolve([MaybeNullWhen(false)] out T result, CancellationToken cancellationToken = default)
         {
-            (bool satisfiable, T? solution) = this.optimize();
+            (bool satisfiable, T? solution) = this.optimize(cancellationToken);
             result = solution!;
             return satisfiable;
         }

--- a/solutions/Z3.Linq/Z3Context.cs
+++ b/solutions/Z3.Linq/Z3Context.cs
@@ -34,6 +34,69 @@ public sealed class Z3Context : IDisposable
     public TextWriter? Log { get; set; }
 
     /// <summary>
+    /// Gets or sets how long a single solve or optimisation may run before Z3 gives up, or
+    /// <see langword="null"/> for no limit.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Some theorems cannot be decided - nonlinear integer arithmetic is undecidable in general -
+    /// and without a limit Z3 searches until the process is killed. When the limit is reached the
+    /// solve throws <see cref="TheoremUndecidedException"/>: the theorem has been proved neither
+    /// satisfiable nor unsatisfiable. A theorem Z3 can decide within the limit is unaffected.
+    /// See #85.
+    /// </para>
+    /// <para>
+    /// Wall-clock time, so the same theorem may or may not hit the limit on a different machine.
+    /// <see cref="ResourceLimit"/> is the deterministic alternative.
+    /// </para>
+    /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// The value is not positive, or exceeds what Z3 can represent in milliseconds.
+    /// </exception>
+    public TimeSpan? Timeout
+    {
+        get => this.timeout;
+        set
+        {
+            if (value is { } t && (t <= TimeSpan.Zero || t.TotalMilliseconds > uint.MaxValue))
+            {
+                throw new ArgumentOutOfRangeException(nameof(value), value, "The timeout must be positive and no more than uint.MaxValue milliseconds.");
+            }
+
+            this.timeout = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets how much work Z3 may do on a single solve or optimisation before giving up,
+    /// in Z3's own resource units, or <see langword="null"/> for no limit.
+    /// </summary>
+    /// <remarks>
+    /// The deterministic sibling of <see cref="Timeout"/>: the same theorem does the same amount
+    /// of work everywhere, so a limit that is reached on one machine is reached on all of them.
+    /// The unit is Z3's <c>rlimit</c>, which has no fixed relationship to time. When the limit is
+    /// reached the solve throws <see cref="TheoremUndecidedException"/>. See #85.
+    /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">The value is zero.</exception>
+    public uint? ResourceLimit
+    {
+        get => this.resourceLimit;
+        set
+        {
+            if (value is 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(value), value, "The resource limit must be positive.");
+            }
+
+            this.resourceLimit = value;
+        }
+    }
+
+    private TimeSpan? timeout;
+
+    private uint? resourceLimit;
+
+    /// <summary>
     /// Closes the native resources held by the Z3 theorem prover.
     /// </summary>
     public void Dispose()
@@ -94,6 +157,37 @@ public sealed class Z3Context : IDisposable
     internal Context CreateContext()
     {
         return new Context(config);
+    }
+
+    /// <summary>
+    /// The solver parameters carrying <see cref="Timeout"/> and <see cref="ResourceLimit"/>, or
+    /// <see langword="null"/> when neither is set.
+    /// </summary>
+    /// <param name="context">The native context the parameters are created in.</param>
+    /// <remarks>
+    /// Applied per solver rather than through the context configuration, so that a limit is a
+    /// property of the <see cref="Z3Context"/> that can be changed between solves.
+    /// </remarks>
+    internal Params? CreateLimits(Context context)
+    {
+        if (this.timeout is null && this.resourceLimit is null)
+        {
+            return null;
+        }
+
+        Params limits = context.MkParams();
+
+        if (this.timeout is { } t)
+        {
+            limits.Add("timeout", (uint)t.TotalMilliseconds);
+        }
+
+        if (this.resourceLimit is { } r)
+        {
+            limits.Add("rlimit", r);
+        }
+
+        return limits;
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes #85.

Settles the third wrinkle of #57.

## The defect

`Z3Context` built its native context from a fixed configuration and offered no way to add to it.
No timeout, no resource limit, no `CancellationToken` - and `Check()` ran synchronously on the
calling thread. A theorem Z3 cannot decide therefore ran until the process was killed:

```csharp
using var ctx = new Z3Context();

ctx.NewTheorem<Symbols<int, int, int>>()
   .Where(t => (t.X1 * t.X1 * t.X1) + (t.X2 * t.X2 * t.X2) + (t.X3 * t.X3 * t.X3) == 42)
   .Solve();
// still running after 120 seconds when #85 was raised; killed
```

And because nothing could bound a solve, `Status.UNKNOWN` was unreachable, so `Theorem.cs`
reported it as unsatisfiable - the wrinkle #57 raised and #86 had to leave open.

## Measured first, on the raw Microsoft.Z3 API

Before any library change, against the theorem above:

| Mechanism | Result | Time |
|---|---|---|
| solver parameter `timeout = 500` | `UNKNOWN`, reason `timeout` | 592 ms |
| solver parameter `rlimit = 200000` | `UNKNOWN`, reason **`canceled`** | 58 ms |
| context configuration `timeout = 500` | `UNKNOWN`, reason `timeout` | 532 ms |
| `Context.Interrupt()` from another thread after 300 ms | `UNKNOWN`, reason `interrupted` | 320 ms |
| optimizer parameter `timeout = 500` | `UNKNOWN`, reason **`canceled`** | 512 ms |
| optimizer interrupted after 300 ms | `UNKNOWN`, reason **`canceled`** | 311 ms |
| an easy theorem with the timeout set | `SATISFIABLE` / `UNSATISFIABLE` as before | 9 ms |
| `Interrupt()` issued **before** `Check()` | `SATISFIABLE` - the interrupt is lost | 6 ms |

Two of those rows shaped the design. The reason strings are not consistent - the optimizer says
`canceled` for a timeout and an interrupt alike, and an exhausted `rlimit` is `canceled` on both
- so the library cannot tell cancellation from a limit by reading them. And an interrupt that
arrives before the check starts does nothing, so an already-cancelled token has to be inspected
rather than relied on to fire.

## The change

**`Z3Context.Timeout` and `Z3Context.ResourceLimit`**, both nullable, both validated in the
setter, applied as parameters on each solver and optimizer rather than baked into the native
context - so they are properties of the `Z3Context` that can change between solves, and an
undecided solve leaves nothing behind. `ResourceLimit` is Z3's `rlimit`: deterministic, reached
at the same point on every machine, in units with no fixed relationship to time.

**A `CancellationToken` on every entry point** - `Solve`, `TrySolve`, `Optimize`, `TryOptimize`,
`ISolveable<T>`, the deferred `orderby` form, `SolveOrNull` and `OptimizeOrNull` - as an optional
parameter, `CancellationToken cancellationToken = default`. A cancelled token calls
`Context.Interrupt()`; the token is also inspected before the check, because of the lost-interrupt
row above. What remains is the moment between that inspection and Z3 starting work, which the
remarks say plainly.

**How `UNKNOWN` is reported, the question #85 deferred to.** Put to the maintainer with the
measurements above and chosen over a three-state result:

- a cancelled token throws `OperationCanceledException`, carrying the token, as everywhere in .NET;
- every other `UNKNOWN` - a timeout, an exhausted resource limit, or Z3 giving up on its own -
  throws a new **`TheoremUndecidedException`**, carrying Z3's reason string;
- **`TrySolve` returning `false` now means one thing: the theorem was proved to have no solution.**

Cancellation is recognised from the token rather than the string, because the strings cannot be
trusted to say which it was.

### Public surface

Optional parameters on existing methods: source-compatible for every caller, binary-breaking for
the changed signatures. `ISolveable<T>` changes shape for the second time in this stack, which
2.0 allows and #86 already did. `Z3Context` gains two properties; the library gains one exception
type.

The README gets a *When Z3 cannot decide* section after *When there is no solution*, with the
theorem above as its example.

## Tests

254 → 270, in a new `SolveLimitTests.cs`. Every test that runs the undecidable theorem carries a
`[Timeout]`, so a regression fails the test rather than hanging the suite - and the whole suite
still finishes in under a second and a half, because the parallel runner overlaps the waits.

| Test | What it covers |
|---|---|
| `Solve_UndecidableTheoremWithATimeout_ThrowsTheoremUndecidedException` | the issue's theorem, stopped by a timeout; the reason is carried and appears in the message |
| `TrySolve_UndecidableTheoremWithATimeout_ThrowsRatherThanReturningFalse` | #57's wrinkle, closed |
| `Solve_UndecidableTheoremWithAResourceLimit_ThrowsTheoremUndecidedException` | `rlimit`, with no timeout set - so it passing proves the limit reaches the solver |
| `Solve_SatisfiableTheoremWithATimeout_StillSolves` / `TrySolve_UnsatisfiableTheoremWithATimeout_StillReturnsFalse` | a limit changes nothing for a theorem Z3 decides within it |
| `Solve_AfterAnUndecidedSolveOnTheSameContext_StillSolves` | the limit is per solve; the context stays usable |
| `Solve_WithAnAlreadyCancelledToken_ThrowsOperationCanceledException` | the lost-interrupt row; a trivially satisfiable theorem must not solve |
| `Solve_CancelledDuringTheSolve_ThrowsOperationCanceledException` | the interrupt, with no limit on the context so only the token can end it; the exception carries the token |
| `Optimize_..WithATimeout..` / `Optimize_CancelledDuringTheSolve..` | the optimizer's own check, which reports both with a different string |
| `OrderBy_CancelledDuringTheDeferredSolve..` | the token reaches the deferred form when it is finally solved |
| `SolveOrNull_CancelledDuringTheSolve..` | the extension passes it through |
| `Timeout_SetToANonPositiveValue..` / `ResourceLimit_SetToZero..` / `Timeout_SetToNull_ClearsTheLimit` | the setters |

No test asserts on the reason string beyond its presence, for the reason in the table above, and
none asserts on elapsed time.

## Mutation results

Chosen so that no mutation can hang the run: the limits themselves are proved by construction
(each limit test sets only the limit it is about), and the mutations target how an `UNKNOWN` is
reported.

| Mutation | Failures | Which |
|---|---|---|
| `UNKNOWN` reported as unsatisfiable again - the pre-#85 code | **9** | every test that expects an exception, plus the one that solves again afterwards - an interrupted solve came back as "no solution" too |
| No inspection of the token before the check | **1** | the already-cancelled-token test alone: the trivially satisfiable theorem solved, because the interrupt fired before the check and was lost |
| An `UNKNOWN` is always `TheoremUndecidedException`; the token never consulted | **4** | the four cancelled-during tests, which get a TheoremUndecidedException instead of OperationCanceledException |

## Verification

- `dotnet build solutions/Z3.Linq.slnx -c Release` - clean, `TreatWarningsAsErrors` and
  documentation generation on; every new cref resolves
- 270/270 locally, 1.4 s
- `./build.ps1 -Configuration Release` - 46 tasks, 0 errors, 0 warnings
- Coverage 88.3% -> 88.7% line (770 of 868), 77.9% -> 78.8% branch (517 of 656)

## Release note

Releases remain on hold under #60 until Microsoft.Z3 5.x reaches nuget.org, so this reaches `main`
but not consumers. Nothing about the hold changes.
