### PR TITLE
Bound each integer symbol to the range of its type

### DIFF
--- a/solutions/Z3.Linq.Tests/CollectionSymbolTests.cs
+++ b/solutions/Z3.Linq.Tests/CollectionSymbolTests.cs
@@ -556,11 +556,19 @@ public class CollectionSymbolTests
     /// A <c>short</c> element whose model value no <c>short</c> can hold fails loudly.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// The element read is a checked cast, as the scalar arm has been since #63 and for the same
     /// reason: the array's range is an unbounded <c>Int</c>, so a constraint written against the
     /// widened <c>int</c> can be satisfied by a value the element cannot hold, and an unchecked
-    /// cast would wrap it into a plausible wrong answer. #87 - bounding the symbol so Z3 cannot
-    /// pick such a value - applies to elements exactly as it does to scalars.
+    /// cast would wrap it into a plausible wrong answer.
+    /// </para>
+    /// <para>
+    /// A scalar <c>short</c> is bounded to its range since #87, and the same constraint on one is
+    /// simply unsatisfiable. An element is not: the length of a collection is not known when the
+    /// constraints are asserted, and bounding every element would take a quantifier, which can
+    /// cost Z3 its completeness. So for an element the checked read is still what stands between
+    /// a loud answer and a wrong one, and this test is what holds it there.
+    /// </para>
     /// </remarks>
     [TestMethod]
     public void Solve_ShortArrayElementConstrainedOutsideShortRange_ThrowsOverflowException()
@@ -574,6 +582,32 @@ public class CollectionSymbolTests
 
         // Act & Assert
         Should.Throw<OverflowException>(() => theorem.Solve());
+    }
+
+    /// <summary>
+    /// A <see cref="DateTime"/> element constrained beyond the range of the type fails loudly,
+    /// naming the symbol.
+    /// </summary>
+    /// <remarks>
+    /// The element counterpart of the guard #83 added, and since #87 the only way to reach it: a
+    /// scalar <see cref="DateTime"/> is bounded and the same constraint on one is unsatisfiable.
+    /// </remarks>
+    [TestMethod]
+    public void Solve_DateTimeArrayElementConstrainedBeyondMaxValue_ThrowsOverflowExceptionNamingIt()
+    {
+        // Arrange
+        using var context = new Z3Context();
+        DateTime max = DateTime.MaxValue;
+        var theorem = context.NewTheorem<DateTimeArrayEnvironment>()
+            .Where(t => t.Values[0] > max)
+            .Where(t => t.Length == 2);
+
+        // Act
+        OverflowException exception = Should.Throw<OverflowException>(() => theorem.Solve());
+
+        // Assert
+        exception.Message.ShouldContain("Values");
+        exception.Message.ShouldContain("0001-01-01 to 9999-12-31");
     }
 
     /// <summary>

--- a/solutions/Z3.Linq.Tests/SymbolBoundsTests.cs
+++ b/solutions/Z3.Linq.Tests/SymbolBoundsTests.cs
@@ -1,0 +1,224 @@
+namespace Z3.Linq.Tests;
+
+/// <summary>
+/// The range of a symbol is the range of its type: a <c>short</c>, <c>int</c>, <c>long</c> or
+/// <see cref="DateTime"/> symbol is bounded to what the CLR type can hold.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Each of those travels through Z3 as an unbounded integer. Until #87 nothing told Z3 the
+/// range, so a constraint no value of the type could satisfy still had a model, and the failure
+/// came on the way out - an <see cref="OverflowException"/> from a checked read for
+/// <c>short</c> and <see cref="DateTime"/>, and for <c>int</c> a <c>Z3Exception</c> from the
+/// numeral accessor, <c>Numeral is not an int</c>. The bounds are asserted alongside the
+/// constraints now, and such a theorem is unsatisfiable, which is the true answer.
+/// </para>
+/// <para>
+/// The optimisation tests are the direct evidence, one per type: maximising or minimising a
+/// symbol with no other bound on it returns the extreme of the type. Before #87 it returned
+/// whatever Z3 supplied for an unbounded objective - zero, measured - so each of these fails by
+/// itself if its type's row of the bounds is dropped.
+/// </para>
+/// <para>
+/// Only scalars are bounded. A collection element is not, for the reasons given on the element
+/// tests in <c>CollectionSymbolTests</c>, and is read with a checked conversion instead.
+/// </para>
+/// </remarks>
+[TestClass]
+public class SymbolBoundsTests
+{
+    [TestMethod]
+    public void Optimize_ShortSymbolMaximised_ReturnsShortMaxValue()
+    {
+        // Arrange
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<Symbols<short, int>>()
+            .Where(t => t.X2 == 1)
+            .Optimize(Optimization.Maximize, t => t.X1);
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.X1.ShouldBe(short.MaxValue);
+    }
+
+    [TestMethod]
+    public void Optimize_ShortSymbolMinimised_ReturnsShortMinValue()
+    {
+        // Arrange
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<Symbols<short, int>>()
+            .Where(t => t.X2 == 1)
+            .Optimize(Optimization.Minimize, t => t.X1);
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.X1.ShouldBe(short.MinValue);
+    }
+
+    [TestMethod]
+    public void Optimize_IntSymbolMaximised_ReturnsIntMaxValue()
+    {
+        // Arrange
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<Symbols<int, int>>()
+            .Where(t => t.X2 == 1)
+            .Optimize(Optimization.Maximize, t => t.X1);
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.X1.ShouldBe(int.MaxValue);
+    }
+
+    [TestMethod]
+    public void Optimize_LongSymbolMinimised_ReturnsLongMinValue()
+    {
+        // Arrange
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<Symbols<long, int>>()
+            .Where(t => t.X2 == 1)
+            .Optimize(Optimization.Minimize, t => t.X1);
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.X1.ShouldBe(long.MinValue);
+    }
+
+    [TestMethod]
+    public void Optimize_DateTimeSymbolMaximised_ReturnsDateTimeMaxValue()
+    {
+        // Arrange
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<Symbols<DateTime, int>>()
+            .Where(t => t.X2 == 1)
+            .Optimize(Optimization.Maximize, t => t.X1);
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.X1.ShouldBe(DateTime.MaxValue);
+        result.X1.Kind.ShouldBe(DateTimeKind.Utc);
+    }
+
+    [TestMethod]
+    public void Optimize_DateTimeSymbolMinimised_ReturnsDateTimeMinValue()
+    {
+        // Arrange
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<Symbols<DateTime, int>>()
+            .Where(t => t.X2 == 1)
+            .Optimize(Optimization.Minimize, t => t.X1);
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.X1.ShouldBe(DateTime.MinValue);
+    }
+
+    /// <summary>
+    /// An <c>int</c> symbol constrained beyond the range of <c>int</c> has no solution.
+    /// </summary>
+    /// <remarks>
+    /// #87 recorded this route as unreachable for <c>int</c>, because a comparison against a
+    /// <c>long</c> variable fell into the conversion catch-all. #76 made the widening a no-op,
+    /// and the route opened: measured before this change, the theorem solved and the read threw
+    /// <c>Z3Exception: Numeral is not an int</c>. Now it is unsatisfiable.
+    /// </remarks>
+    [TestMethod]
+    public void Solve_IntSymbolConstrainedBeyondIntRange_IsUnsatisfiable()
+    {
+        // Arrange
+        using var context = new Z3Context();
+        long beyondIntRange = 3_000_000_000L;
+        var theorem = context.NewTheorem<Symbols<int, int>>()
+            .Where(t => t.X1 == beyondIntRange);
+
+        // Act
+        bool satisfiable = theorem.TrySolve(out _);
+
+        // Assert
+        satisfiable.ShouldBeFalse();
+    }
+
+    [TestMethod]
+    public void Solve_ShortSymbolAtBothEndsOfItsRange_IsSatisfiable()
+    {
+        // Arrange: the bounds are inclusive - the extremes themselves are still values.
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<Symbols<short, short>>()
+            .Where(t => t.X1 == short.MinValue)
+            .Where(t => t.X2 == short.MaxValue)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.X1.ShouldBe(short.MinValue);
+        result.X2.ShouldBe(short.MaxValue);
+    }
+
+    /// <summary>
+    /// A symbol in a nested object is bounded like one at the top level.
+    /// </summary>
+    /// <remarks>
+    /// The bounds are asserted by walking the environment, and a nested object is an environment
+    /// of its own under the outer one, so the walk has to descend.
+    /// </remarks>
+    [TestMethod]
+    public void Optimize_ShortSymbolInANestedObjectMaximised_ReturnsShortMaxValue()
+    {
+        // Arrange
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<OuterEnvironment>()
+            .Where(t => t.Top == 1)
+            .Optimize(Optimization.Maximize, t => t.Inner.Value);
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.Inner.Value.ShouldBe(short.MaxValue);
+    }
+
+    /// <summary>
+    /// A bounded symbol still reports itself unsatisfiable through <c>TryOptimize</c>, and a
+    /// contradiction within the range is still a contradiction.
+    /// </summary>
+    [TestMethod]
+    public void TryOptimize_ShortSymbolConstrainedOutsideItsRange_ReturnsFalse()
+    {
+        // Arrange
+        using var context = new Z3Context();
+        int beyondShortRange = 40000;
+        var theorem = context.NewTheorem<Symbols<short, int>>()
+            .Where(t => t.X1 > beyondShortRange);
+
+        // Act
+        bool satisfiable = theorem.TryOptimize(Optimization.Minimize, t => t.X1, out _);
+
+        // Assert
+        satisfiable.ShouldBeFalse();
+    }
+
+    private sealed class InnerEnvironment
+    {
+        public short Value { get; set; }
+    }
+
+    private sealed class OuterEnvironment
+    {
+        public InnerEnvironment Inner { get; set; } = new();
+
+        public int Top { get; set; }
+    }
+}

--- a/solutions/Z3.Linq.Tests/SymbolTypeMarshallingTests.cs
+++ b/solutions/Z3.Linq.Tests/SymbolTypeMarshallingTests.cs
@@ -192,25 +192,25 @@ public class SymbolTypeMarshallingTests
     }
 
     /// <summary>
-    /// A <c>short</c> symbol whose model value no <c>short</c> can hold fails loudly.
+    /// A <c>short</c> symbol constrained to a value no <c>short</c> can hold has no solution.
     /// </summary>
     /// <remarks>
     /// <para>
-    /// The symbol is an unbounded <c>MkIntConst</c> - nothing tells Z3 the value has to fit in
-    /// 16 bits - so a constraint written against the widened <c>int</c> can be satisfied by a
-    /// number the member cannot hold. The read is a checked cast, which throws; an unchecked one
-    /// would wrap 40000 to -25536 and hand back a wrong answer that looks like a right one.
+    /// C# blocks the direct spelling of this - <c>t.X1 == 40000</c> against a <c>short</c> is
+    /// <c>error CS0652</c> - so it takes an <c>int</c> variable to reach, and the constraint is
+    /// then written against the widened <c>int</c>, which 40000 satisfies. Until #87 the symbol
+    /// was an unbounded integer, so Z3 found that model and the checked read of the result threw
+    /// <see cref="OverflowException"/>: loud, but the wrong answer - there is no short equal to
+    /// 40000, and the theorem is unsatisfiable. The symbol is now bounded to the range of its
+    /// type when the constraints are asserted, and that is what comes back.
     /// </para>
     /// <para>
-    /// C# blocks the direct spelling of this - <c>t.X1 == 40000</c> against a <c>short</c> is
-    /// <c>error CS0652</c> - so it takes an <c>int</c> variable to reach. Pinned because the
-    /// choice between wrapping and throwing is the whole point of the arm, and a later
-    /// simplification to a plain cast would pass every other test in this file. See #63, and
-    /// #87 for bounding the symbol so Z3 cannot pick the value in the first place.
+    /// The checked read stays, as a defence and because a collection element still needs it -
+    /// see <c>CollectionSymbolTests</c>.
     /// </para>
     /// </remarks>
     [TestMethod]
-    public void Solve_ShortSymbolConstrainedOutsideShortRange_ThrowsOverflowException()
+    public void Solve_ShortSymbolConstrainedOutsideShortRange_IsUnsatisfiable()
     {
         // Arrange
         using var context = new Z3Context();
@@ -218,8 +218,11 @@ public class SymbolTypeMarshallingTests
         var theorem = context.NewTheorem<Symbols<short, int>>()
             .Where(t => t.X1 == beyondShortRange);
 
-        // Act & Assert
-        Should.Throw<OverflowException>(() => theorem.Solve());
+        // Act
+        bool satisfiable = theorem.TrySolve(out _);
+
+        // Assert
+        satisfiable.ShouldBeFalse();
     }
 
     /// <summary>
@@ -680,27 +683,24 @@ public class SymbolTypeMarshallingTests
     }
 
     /// <summary>
-    /// A <see cref="DateTime"/> symbol whose model value no <see cref="DateTime"/> can hold fails
-    /// loudly, naming the symbol.
+    /// A <see cref="DateTime"/> symbol constrained beyond the range of the type has no solution.
     /// </summary>
     /// <remarks>
     /// <para>
-    /// The symbol is an unbounded integer, so <c>t.X1 &gt; DateTime.MaxValue</c> - which has no
-    /// solution in <see cref="DateTime"/> terms - is satisfiable in Z3's integers, and the model
-    /// is a tick count beyond the type. The read path used to hand that to
-    /// <c>FromFileTimeUtc</c> and let it throw about a <c>fileTime</c> parameter; it now checks
-    /// the range itself and says which symbol and what the range is. The same trade-off as the
-    /// checked read of a <c>short</c>: loud rather than wrong, until #87 bounds the symbol so
-    /// Z3 cannot choose such a value at all.
+    /// <c>t.X1 &gt; DateTime.MaxValue</c> has no solution in <see cref="DateTime"/> terms. Until
+    /// #87 the symbol was an unbounded integer, so it had one in Z3's - a tick count beyond the
+    /// type - and the read threw. The symbol is now bounded to the range of the type when the
+    /// constraints are asserted, so the theorem is unsatisfiable, which is the true answer.
     /// </para>
     /// <para>
     /// Both ends are pinned. The bottom is the case #83 reported as the read-side failure, and
-    /// with the encoding now starting at tick zero it is only reachable by constraining below
-    /// <see cref="DateTime.MinValue"/> itself.
+    /// with the encoding starting at tick zero it is only reachable by constraining below
+    /// <see cref="DateTime.MinValue"/> itself. The read guard #83 added stays, for collection
+    /// elements - see <c>CollectionSymbolTests</c>.
     /// </para>
     /// </remarks>
     [TestMethod]
-    public void Solve_DateTimeSymbolConstrainedBeyondMaxValue_ThrowsOverflowExceptionNamingIt()
+    public void Solve_DateTimeSymbolConstrainedBeyondMaxValue_IsUnsatisfiable()
     {
         // Arrange
         using var context = new Z3Context();
@@ -709,15 +709,14 @@ public class SymbolTypeMarshallingTests
             .Where(t => t.X1 > max && t.X2 == 0);
 
         // Act
-        OverflowException exception = Should.Throw<OverflowException>(() => theorem.Solve());
+        bool satisfiable = theorem.TrySolve(out _);
 
         // Assert
-        exception.Message.ShouldContain("X1");
-        exception.Message.ShouldContain("0001-01-01 to 9999-12-31");
+        satisfiable.ShouldBeFalse();
     }
 
     [TestMethod]
-    public void Solve_DateTimeSymbolConstrainedBelowMinValue_ThrowsOverflowExceptionNamingIt()
+    public void Solve_DateTimeSymbolConstrainedBelowMinValue_IsUnsatisfiable()
     {
         // Arrange
         using var context = new Z3Context();
@@ -726,10 +725,10 @@ public class SymbolTypeMarshallingTests
             .Where(t => t.X1 < min && t.X2 == 0);
 
         // Act
-        OverflowException exception = Should.Throw<OverflowException>(() => theorem.Solve());
+        bool satisfiable = theorem.TrySolve(out _);
 
         // Assert
-        exception.Message.ShouldContain("X1");
+        satisfiable.ShouldBeFalse();
     }
 
     [TestMethod]

--- a/solutions/Z3.Linq/Theorem.cs
+++ b/solutions/Z3.Linq/Theorem.cs
@@ -327,6 +327,102 @@ public class Theorem
 
             this.context.LogWriteLine(expression.ToString());
         }
+
+        AssertBounds(context, approach, environment);
+    }
+
+    /// <summary>
+    /// Asserts, for every scalar symbol whose CLR type is a bounded integer, that the symbol lies
+    /// within the range of that type.
+    /// </summary>
+    /// <param name="context">Z3 context.</param>
+    /// <param name="approach">The <see cref="Solver"/> or <see cref="Optimize"/> to assert into.</param>
+    /// <param name="environment">Environment with bindings of theorem variables to Z3 handles.</param>
+    /// <remarks>
+    /// <para>
+    /// A <c>short</c>, <c>int</c>, <c>long</c> or <see cref="DateTime"/> symbol is an unbounded
+    /// Z3 integer, so without this a constraint no value of the type can satisfy - a
+    /// <c>short</c> equal to 40000, a <see cref="DateTime"/> after <see cref="DateTime.MaxValue"/>
+    /// - still had a model, and the read back then failed. With it the theorem is unsatisfiable,
+    /// which is the true answer, and an optimisation with no other bound on the symbol returns
+    /// the extreme of the type rather than whatever Z3 happened to pick. See #87.
+    /// </para>
+    /// <para>
+    /// Only scalars are bounded. A collection is an array from <c>Int</c> to the element sort,
+    /// its length is not known here - it comes from the instance when the solution is read - and
+    /// bounding every element would take a quantifier, which can cost Z3 its completeness. So an
+    /// element is read with a checked conversion instead, and a value outside its type is loud
+    /// rather than wrong.
+    /// </para>
+    /// <para>
+    /// The bounds are not logged: the log shows the constraints the caller wrote.
+    /// </para>
+    /// </remarks>
+    private static void AssertBounds(Context context, Z3Object approach, Environment environment)
+    {
+        foreach ((MemberInfo member, Environment child) in environment.Properties)
+        {
+            if (child.Expr is IntExpr symbol && GetBounds(Type.GetTypeCode(SymbolType(member))) is (long low, long high))
+            {
+                BoolExpr bounds = context.MkAnd(
+                    context.MkGe(symbol, context.MkInt(low)),
+                    context.MkLe(symbol, context.MkInt(high)));
+
+                switch (approach)
+                {
+                    case Solver solver:
+                        solver.Assert(bounds);
+                        break;
+                    case Optimize optimize:
+                        optimize.Assert(bounds);
+                        break;
+                }
+            }
+
+            AssertBounds(context, approach, child);
+        }
+    }
+
+    /// <summary>
+    /// The range of values a CLR type can hold, for the types that travel through Z3 as an
+    /// integer, or <see langword="null"/> for a type with no such range.
+    /// </summary>
+    /// <param name="typeCode">The type code of the CLR type.</param>
+    /// <returns>The inclusive range, or <see langword="null"/>.</returns>
+    /// <remarks>
+    /// A <see cref="DateTime"/> is its ticks (#83), so its range is
+    /// <see cref="DateTime.MinValue"/> to <see cref="DateTime.MaxValue"/> in ticks.
+    /// </remarks>
+    private static (long Low, long High)? GetBounds(TypeCode typeCode)
+    {
+        return typeCode switch
+        {
+            TypeCode.Int16 => (short.MinValue, short.MaxValue),
+            TypeCode.Int32 => (int.MinValue, int.MaxValue),
+            TypeCode.Int64 => (long.MinValue, long.MaxValue),
+            TypeCode.DateTime => (DateTime.MinValue.Ticks, DateTime.MaxValue.Ticks),
+            _ => null,
+        };
+    }
+
+    /// <summary>
+    /// The CLR type a member is solved as: its declared type, or the type a
+    /// <see cref="TheoremVariableTypeMappingAttribute"/> on that type maps it to.
+    /// </summary>
+    /// <param name="member">The property or field.</param>
+    /// <returns>The type the symbol is declared and read as.</returns>
+    private static Type SymbolType(MemberInfo member)
+    {
+        Type type = member switch
+        {
+            PropertyInfo property => property.PropertyType,
+            FieldInfo field => field.FieldType,
+            _ => throw new NotSupportedException(),
+        };
+
+        TheoremVariableTypeMappingAttribute? mapping = type.GetCustomAttributes<TheoremVariableTypeMappingAttribute>(false).SingleOrDefault();
+
+        return mapping?.RegularType ?? type;
     }
 
     /// <summary>
@@ -557,7 +653,9 @@ public class Theorem
                             numVal = numValExpr.String;
                             break;
                         case TypeCode.Int16:
-                            // Checked, for the reason given on the scalar arm below. See #63.
+                            // Checked: an element is not bounded to the range of its type - #87
+                            // bounds scalars only - so Z3 can pick a value no short can hold, and
+                            // an unchecked cast would wrap it into a plausible wrong answer. See #63.
                             numVal = checked((short)((IntNum)numValExpr).Int);
                             break;
                         case TypeCode.Int32:
@@ -621,10 +719,10 @@ public class Theorem
                     break;
                 case TypeCode.Int16:
                     // Int16 cannot share the Int32 arm: the model value is an int, and reflection
-                    // refuses to write an int to a short member. The cast is checked because the
-                    // symbol is an unbounded MkIntConst, so Z3 may return a value no short can
-                    // hold - an unchecked cast would wrap it into a plausible wrong answer.
-                    // See #63.
+                    // refuses to write an int to a short member. The cast is checked as a defence:
+                    // since #87 a scalar short is bounded to its range when the constraints are
+                    // asserted, so the check cannot fire here, but it costs nothing and the element
+                    // arm above still depends on it. See #63.
                     value = checked((short)((IntNum)val).Int);
                     break;
                 case TypeCode.Int32:
@@ -702,12 +800,13 @@ public class Theorem
     /// Reads a <see cref="DateTime"/> symbol back from the ticks Z3 holds it as.
     /// </summary>
     /// <remarks>
-    /// The symbol is an unbounded integer, so Z3 can satisfy a constraint with a value no
-    /// <see cref="DateTime"/> can hold - <c>t.X1 &gt; DateTime.MaxValue</c> is satisfiable in
-    /// integers. The <see cref="DateTime"/> constructor would throw for that anyway; this throws
-    /// first, naming the symbol and the range, since the constructor names neither. The same
-    /// trade-off as the checked read of a <c>short</c>: loud rather than wrong. #87 - bounding
-    /// the symbol so Z3 cannot pick such a value - applies here too.
+    /// A scalar <see cref="DateTime"/> symbol is bounded to the range of the type when the
+    /// constraints are asserted (#87), so for a scalar this guard cannot fire. A collection
+    /// element is not bounded - its length is not known when the constraints are asserted - so
+    /// an element constrained beyond the range still has a model and still reaches here, and this
+    /// throws naming the symbol and the range rather than letting the <see cref="DateTime"/>
+    /// constructor complain about a parameter. The same trade-off as the checked read of a
+    /// <c>short</c> element: loud rather than wrong.
     /// </remarks>
     private static DateTime ToDateTime(long ticks, string name)
     {

--- a/solutions/Z3.Linq/Theorem{T}.cs
+++ b/solutions/Z3.Linq/Theorem{T}.cs
@@ -81,6 +81,13 @@ public class Theorem<T> : Theorem, ISolveable<T>
     /// rather than as local time. The result is therefore the same on every machine; a caller
     /// working in local time needs <see cref="DateTime.ToLocalTime"/> on the way out.
     /// </para>
+    /// <para>
+    /// A <c>short</c>, <c>int</c>, <c>long</c> or <see cref="DateTime"/> symbol is bounded to the
+    /// range of its type, so a constraint no value of the type can satisfy makes the theorem
+    /// unsatisfiable, and an optimisation with no other bound on such a symbol returns the
+    /// extreme of the type. Elements of a collection are not bounded; one constrained beyond its
+    /// type is read with a checked conversion and throws. See #87.
+    /// </para>
     /// </remarks>
     public T? Solve(CancellationToken cancellationToken = default)
     {


### PR DESCRIPTION
Fixes #87.

## The defect

A `short`, `int`, `long` or `DateTime` symbol travels through Z3 as an unbounded integer, and
nothing told Z3 the range of the type. A constraint no value of the type could satisfy still had a
model, and the failure came on the way out:

```csharp
using var ctx = new Z3Context();
int beyondShortRange = 40000;

ctx.NewTheorem<Symbols<short, int>>().Where(t => t.X1 == beyondShortRange).Solve();
// System.OverflowException     - from the checked read #63 added; loud, but the wrong answer
```

There is no `short` equal to 40000. The theorem is unsatisfiable, and that is what should come back.

**#87's own table needs one correction.** It recorded the `int` route as unreachable, because a
comparison against a `long` variable fell into the conversion catch-all. #76 made that widening a
no-op and the route opened: measured before this change, `t.X1 == 3_000_000_000L` on an `int`
symbol solves and the read throws `Z3Exception: Numeral is not an int`. Recorded on the issue.

Measured before, twelve shapes. The other finding worth stating: **optimising a symbol with no
other bound returned an arbitrary value** - zero, every time - because Z3 reports an unbounded
objective and supplies whatever model it likes. Maximising a `short` gave 0.

## The change

**The bounds are asserted alongside the constraints.** `AssertConstraints` now walks the
environment and, for every scalar symbol whose type has a range - `short`, `int`, `long`,
`DateTime` in ticks - asserts `low <= symbol <= high`, descending into nested objects. An enum
is its underlying type and is bounded as one.

| Shape | Before | After |
|---|---|---|
| `short == 40000` (via an `int` variable) | `OverflowException` on the read | **unsatisfiable** |
| `int == 3_000_000_000L` | `Z3Exception: Numeral is not an int` | **unsatisfiable** |
| `DateTime > DateTime.MaxValue`, `< DateTime.MinValue` | `OverflowException` from the #83 guard | **unsatisfiable** |
| maximise a `short` with no other bound | `0` | `32767` |
| maximise an `int` / minimise a `long` | `0` | `2147483647` / `-9223372036854775808` |
| maximise / minimise a `DateTime` | `0001-01-01` | `9999-12-31T23:59:59.9999999Z` / `0001-01-01` |
| `short == short.MaxValue`, `== short.MinValue` | worked | unchanged - the bounds are inclusive |
| `DateTime[]` element `> DateTime.MaxValue` | `OverflowException` naming the symbol | unchanged - see below |

**Only scalars are bounded, deliberately.** A collection is an array from `Int` to the element
sort; its length is not known when the constraints are asserted - it comes from the instance when
the solution is read - and bounding every element would take a quantifier, which can cost Z3 its
completeness. So an element keeps the checked read from #63 and the guard from #83, and a value
outside its type is loud rather than wrong. The last row of the table, and the two element tests,
hold that in place; the comments on both reads now say which case each is for.

**The bounds are not logged.** `TheoremCompositionTests` counts logged lines, and the log is for
the constraints the caller wrote.

**No existing test changed its answer.** Sudoku, the shipping and oil problems, every
optimisation test - all pass unchanged, because every one of them bounds its symbols itself, as a
caller normally does. The bounds only matter at the edges, which is where they were missing.

## Tests

270 → 281. Three pins rewritten from "throws" to "unsatisfiable", and a new `SymbolBoundsTests`.

| Test | What it covers |
|---|---|
| `Optimize_ShortSymbolMaximised_ReturnsShortMaxValue` / `..Minimised..`, `..Int..`, `..Long..`, `..DateTime..` ×2 | one per type: the extreme of the type, which was an arbitrary value before. Each fails by itself if its type's row of the bounds is dropped |
| `Solve_IntSymbolConstrainedBeyondIntRange_IsUnsatisfiable` | the route #87 recorded as unreachable, which #76 opened |
| `Solve_ShortSymbolAtBothEndsOfItsRange_IsSatisfiable` | the bounds are inclusive - the extremes are still values |
| `Optimize_ShortSymbolInANestedObjectMaximised_ReturnsShortMaxValue` | the walk descends into nested objects |
| `TryOptimize_ShortSymbolConstrainedOutsideItsRange_ReturnsFalse` | the optimiser path reports unsatisfiable too |
| `Solve_ShortSymbolConstrainedOutsideShortRange_IsUnsatisfiable`, `Solve_DateTimeSymbolConstrainedBeyondMaxValue_IsUnsatisfiable`, `..BelowMinValue..` | the three former overflow pins, now the true answer |
| `Solve_DateTimeArrayElementConstrainedBeyondMaxValue_ThrowsOverflowExceptionNamingIt` (in `CollectionSymbolTests`) | the #83 guard, now reachable only through an element, kept load-bearing |

## Mutation results

| Mutation | Failures | Which |
|---|---|---|
| Bounds never asserted | **11** | eight of the new bounds tests and the three rewritten pins. Two survive by coincidence, not by passing: minimising a `DateTime` returns tick 0, which is `MinValue`, and the inclusive-ends test is satisfiable with or without the bounds |
| No row for `short` | **5** | the three short tests, the nested-object test, and the short TryOptimize |
| No row for `DateTime` | **3** | both DateTime optimisation extremes and the beyond-range unsatisfiability |
| No descent into nested objects | **1** | the nested-object test alone |
| Bounds exclusive rather than inclusive | **16** | every extreme test - the extreme is now excluded - plus the inclusive-ends and the #83 max-value round-trip |

## New issue

**#97** - an enum symbol is bounded as its underlying integer, not to the members of the
enum: maximising a `DayOfWeek` symbol now returns `(DayOfWeek)2147483647`. Before this change it
returned `Sunday` only because Z3 supplied zero for an unbounded objective; nothing was respecting
the enum either way. A different rule - membership, not range - with a `[Flags]` question attached,
so raised rather than folded in.

## Verification

- `dotnet build solutions/Z3.Linq.slnx -c Release` - clean, `TreatWarningsAsErrors` and
  documentation generation on
- 281/281 locally
- `./build.ps1 -Configuration Release` - 46 tasks, 0 errors, 0 warnings
- Coverage 88.7% -> 88.9% line (820 of 922); branch 78.8% -> 78.6% (557 of 708). The branch percentage slips because the two new switches carry defensive default arms the guard above them makes unreachable - GetBounds is only called when the symbol is an IntExpr, which is only short/int/long/DateTime, so its `_ => null` never runs, and SymbolType only ever sees a property or a field. Both are there for exhaustiveness, and both count as uncovered

## Release note

Releases remain on hold under #60 until Microsoft.Z3 5.x reaches nuget.org, so this reaches `main`
but not consumers. Nothing about the hold changes.
