### PR TITLE
Translate ternaries, and stop crashing on bitwise and real modulo

### DIFF
--- a/solutions/Z3.Linq.Tests/ExpressionTranslationTests.cs
+++ b/solutions/Z3.Linq.Tests/ExpressionTranslationTests.cs
@@ -1,0 +1,218 @@
+namespace Z3.Linq.Tests;
+
+/// <summary>
+/// Translation of the operators the <c>ExpressionVisitor</c> turns into Z3 terms, focused on the
+/// cases that were added or corrected: the ternary conditional, and the operators C# spells the
+/// same way for two different meanings.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The visitor dispatches on the expression node, but two of C#'s operators are overloaded across
+/// sorts the node cannot distinguish: <c>&amp;</c>/<c>|</c>/<c>^</c> mean Boolean logic on
+/// <c>bool</c> and bitwise arithmetic on integers, and <c>%</c> means integer remainder on
+/// integers and has no counterpart on reals. Those used to be translated by an unconditional cast
+/// that succeeded for one meaning and threw <see cref="InvalidCastException"/> from inside Z3 for
+/// the other. They now choose - or refuse - by the operands' sort, so the Boolean and integer
+/// cases keep working and the unsupported ones say why.
+/// </para>
+/// <para>
+/// The ternary <c>?:</c> was simply unsupported before; it now maps onto Z3's if-then-else.
+/// </para>
+/// </remarks>
+[TestClass]
+public class ExpressionTranslationTests
+{
+    /// <summary>
+    /// A ternary chooses its true branch when the test holds.
+    /// </summary>
+    /// <remarks>
+    /// <c>ExpressionType.Conditional</c> had no case and threw; it now translates to
+    /// <c>MkITE</c>. Here <c>X1</c> is pinned positive, so the value read from the conditional is
+    /// the true branch, <c>X2</c>, which the equality then pins to 5.
+    /// </remarks>
+    [TestMethod]
+    public void Solve_TernaryWhoseTestHolds_TakesTheTrueBranch()
+    {
+        // Arrange
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<Symbols<int, int>>()
+            .Where(t => (t.X1 > 0 ? t.X2 : 0) == 5)
+            .Where(t => t.X1 == 3)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.X1.ShouldBe(3);
+        result.X2.ShouldBe(5);
+    }
+
+    /// <summary>
+    /// A ternary chooses its false branch when the test fails.
+    /// </summary>
+    /// <remarks>
+    /// The mirror of the test above: <c>X1</c> is pinned non-positive, so the conditional yields
+    /// its false branch, the constant 9, and the constraint <c>== 9</c> is satisfied without
+    /// pinning <c>X2</c> at all. Only <c>X1</c> is asserted; <c>X2</c> is free.
+    /// </remarks>
+    [TestMethod]
+    public void Solve_TernaryWhoseTestFails_TakesTheFalseBranch()
+    {
+        // Arrange
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<Symbols<int, int>>()
+            .Where(t => (t.X1 > 0 ? t.X2 : 9) == 9)
+            .Where(t => t.X1 == -1)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.X1.ShouldBe(-1);
+    }
+
+    [TestMethod]
+    public void Solve_TernaryOverRealBranches_Translates()
+    {
+        // Arrange: both branches are real-sorted, so the if-then-else is well-sorted.
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<Symbols<double, int>>()
+            .Where(t => (t.X1 > 1.0 ? 2.5 : 0.5) > 1.0)
+            .Where(t => t.X1 == 2.0)
+            .Where(t => t.X2 == 1)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.X1.ShouldBe(2.0);
+    }
+
+    /// <summary>
+    /// A ternary nested inside arithmetic translates too.
+    /// </summary>
+    /// <remarks>
+    /// The conditional is a sub-term of an addition rather than the whole constraint, so the
+    /// visitor meets it below a binary node - the case that would break if the conditional were
+    /// only handled at the top level.
+    /// </remarks>
+    [TestMethod]
+    public void Solve_TernaryNestedInArithmetic_Translates()
+    {
+        // Arrange
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<Symbols<int, int>>()
+            .Where(t => ((t.X1 > 0 ? 10 : 20) + t.X2) == 15)
+            .Where(t => t.X1 == 1)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.X2.ShouldBe(5);
+    }
+
+    /// <summary>
+    /// A bitwise operator on integer symbols is refused with a message that names the limitation.
+    /// </summary>
+    /// <remarks>
+    /// C# spells integer bitwise <c>&amp;</c> with the same node as Boolean <c>&amp;</c>, and the
+    /// old code cast both to a Boolean term - so this threw <see cref="InvalidCastException"/>
+    /// from inside Z3, naming neither the operator nor the reason. Z3's integer sort has no
+    /// bitwise operators (those need a bit-vector), so the honest answer is a clear refusal.
+    /// </remarks>
+    [TestMethod]
+    [DataRow("&", DisplayName = "Bitwise AND")]
+    [DataRow("|", DisplayName = "Bitwise OR")]
+    [DataRow("^", DisplayName = "Bitwise XOR")]
+    public void Solve_BitwiseOperatorOnIntegerSymbols_ThrowsNotSupportedNamingIt(string op)
+    {
+        // Arrange
+        using var context = new Z3Context();
+        var theorem = op switch
+        {
+            "&" => context.NewTheorem<Symbols<int, int>>().Where(t => (t.X1 & 6) == 4),
+            "|" => context.NewTheorem<Symbols<int, int>>().Where(t => (t.X1 | 1) == 7),
+            _ => context.NewTheorem<Symbols<int, int>>().Where(t => (t.X1 ^ 2) == 3),
+        };
+
+        // Act
+        NotSupportedException exception = Should.Throw<NotSupportedException>(() => theorem.Solve());
+
+        // Assert
+        exception.Message.ShouldContain(op);
+        exception.Message.ShouldContain("bit-vector");
+    }
+
+    /// <summary>
+    /// The modulo operator on real symbols is refused with a message that names the limitation.
+    /// </summary>
+    /// <remarks>
+    /// <c>%</c> translated to Z3's integer remainder unconditionally, so a real modulo threw
+    /// <see cref="InvalidCastException"/>. Z3 has no remainder on reals, so this is refused
+    /// clearly rather than crashing in the cast.
+    /// </remarks>
+    [TestMethod]
+    public void Solve_ModuloOnRealSymbols_ThrowsNotSupportedNamingIt()
+    {
+        // Arrange
+        using var context = new Z3Context();
+        var theorem = context.NewTheorem<Symbols<double, int>>()
+            .Where(t => t.X1 % 2.5 == 0.5);
+
+        // Act
+        NotSupportedException exception = Should.Throw<NotSupportedException>(() => theorem.Solve());
+
+        // Assert
+        exception.Message.ShouldContain("modulo");
+    }
+
+    /// <summary>
+    /// Boolean <c>&amp;</c>, <c>|</c> and <c>^</c> still translate, unchanged by the sort-aware
+    /// dispatch.
+    /// </summary>
+    /// <remarks>
+    /// The load-bearing regression guard: making the operators refuse the integer case must not
+    /// disturb the Boolean case, which is the one the operators were written for.
+    /// </remarks>
+    [TestMethod]
+    public void Solve_BooleanBitwiseOperators_StillTranslate()
+    {
+        // Arrange
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<Symbols<bool, bool>>()
+            .Where(t => (t.X1 & t.X2) ^ (t.X1 | t.X2))
+            .Where(t => t.X1)
+            .Solve();
+
+        // Assert: X1 & X2 differs from X1 | X2 exactly when the two differ, and X1 is true, so X2
+        // must be false.
+        result.ShouldNotBeNull();
+        result.X1.ShouldBeTrue();
+        result.X2.ShouldBeFalse();
+    }
+
+    [TestMethod]
+    public void Solve_ModuloOnIntegerSymbols_StillTranslates()
+    {
+        // Arrange: the integer remainder the operator was always able to do.
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<Symbols<int, int>>()
+            .Where(t => t.X1 % 3 == 1)
+            .Where(t => t.X1 > 3)
+            .Where(t => t.X1 < 7)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.X1.ShouldBe(4);
+    }
+}

--- a/solutions/Z3.Linq.Tests/UnsupportedExpressionTests.cs
+++ b/solutions/Z3.Linq.Tests/UnsupportedExpressionTests.cs
@@ -32,19 +32,6 @@ public class UnsupportedExpressionTests
     }
 
     [TestMethod]
-    public void Solve_ConditionalExpression_ThrowsNotSupportedException()
-    {
-        // Arrange: a ternary is a Conditional node, which the visitor has no case for. Z3 can
-        // express if-then-else, so this is a gap rather than a fundamental limit.
-        using var context = new Z3Context();
-        var theorem = context.NewTheorem<Symbols<int, int>>()
-            .Where(t => (t.X1 > 0 ? t.X1 : 0) == 1);
-
-        // Act & Assert
-        Should.Throw<NotSupportedException>(() => theorem.Solve());
-    }
-
-    [TestMethod]
     public void Solve_CallToAnUnrecognisedMethod_ThrowsNotSupportedException()
     {
         // Arrange: only Z3Methods.Distinct, indexed property getters and methods carrying a
@@ -173,11 +160,12 @@ public class UnsupportedExpressionTests
     {
         // Arrange: an unsupported constraint is not skipped in favour of the ones that do
         // translate. Worth pinning, because silently dropping a constraint would produce a
-        // satisfying-looking answer to a different question.
+        // satisfying-looking answer to a different question. The rejected constraint is an
+        // integer bitwise operation, which Z3's integer sort has no counterpart for.
         using var context = new Z3Context();
         var theorem = context.NewTheorem<Symbols<int, int>>()
             .Where(t => t.X1 > 0)
-            .Where(t => (t.X1 > 5 ? t.X1 : 0) == 6);
+            .Where(t => (t.X1 & 2) == 0);
 
         // Act & Assert
         Should.Throw<NotSupportedException>(() => theorem.Solve());

--- a/solutions/Z3.Linq/ExpressionVisitor.cs
+++ b/solutions/Z3.Linq/ExpressionVisitor.cs
@@ -20,6 +20,17 @@ using Microsoft.Z3;
 /// </remarks>
 public static class ExpressionVisitor
 {
+    /// <summary>The generic definition of <see cref="Z3Methods.Distinct{T}"/>, cached for the call-site match.</summary>
+    private static readonly MethodInfo DistinctMethod = typeof(Z3Methods).GetMethod(nameof(Z3Methods.Distinct))!;
+
+    /// <summary>The generic definition of <see cref="Enumerable.ToArray{TSource}"/>, cached for the call-site match.</summary>
+    private static readonly MethodInfo EnumerableToArrayMethod =
+        typeof(Enumerable).GetMethods().First(m => m.Name == nameof(Enumerable.ToArray));
+
+    /// <summary>The generic definition of the two-argument <see cref="Enumerable.Select{TSource, TResult}(IEnumerable{TSource}, Func{TSource, TResult})"/>, cached for the call-site match.</summary>
+    private static readonly MethodInfo EnumerableSelectMethod =
+        typeof(Enumerable).GetMethods().First(m => m.Name == nameof(Enumerable.Select) && m.GetParameters().Length == 2);
+
     /// <summary>
     /// Main visitor method to translate the LINQ expression tree into a Z3 expression handle.
     /// </summary>
@@ -35,14 +46,14 @@ public static class ExpressionVisitor
         {
             case ExpressionType.And:
             case ExpressionType.AndAlso:
-                return VisitBinary(context, environment, (BinaryExpression)expression, param, (ctx, a, b) => ctx.MkAnd((BoolExpr)a, (BoolExpr)b));
+                return VisitLogical(context, environment, (BinaryExpression)expression, param, "&", static (ctx, a, b) => ctx.MkAnd(a, b));
 
             case ExpressionType.Or:
             case ExpressionType.OrElse:
-                return VisitBinary(context, environment, (BinaryExpression)expression, param, (ctx, a, b) => ctx.MkOr((BoolExpr)a, (BoolExpr)b));
+                return VisitLogical(context, environment, (BinaryExpression)expression, param, "|", static (ctx, a, b) => ctx.MkOr(a, b));
 
             case ExpressionType.ExclusiveOr:
-                return VisitBinary(context, environment, (BinaryExpression)expression, param, (ctx, a, b) => ctx.MkXor((BoolExpr)a, (BoolExpr)b));
+                return VisitLogical(context, environment, (BinaryExpression)expression, param, "^", static (ctx, a, b) => ctx.MkXor(a, b));
 
             case ExpressionType.Not:
                 return VisitUnary(context, environment, (UnaryExpression)expression, param, (ctx, a) => ctx.MkNot((BoolExpr)a));
@@ -67,7 +78,10 @@ public static class ExpressionVisitor
                 return VisitBinary(context, environment, (BinaryExpression)expression, param, (ctx, a, b) => ctx.MkDiv((ArithExpr)a, (ArithExpr)b));
 
             case ExpressionType.Modulo:
-                return VisitBinary(context, environment, (BinaryExpression)expression, param, (ctx, a, b) => ctx.MkRem((IntExpr)a, (IntExpr)b));
+                return VisitBinary(context, environment, (BinaryExpression)expression, param, static (ctx, a, b) =>
+                    a is IntExpr ia && b is IntExpr ib
+                        ? ctx.MkRem(ia, ib)
+                        : throw new NotSupportedException("The modulo operator is supported only on integer operands; Z3 has no remainder on real-sorted values."));
 
             case ExpressionType.LessThan:
                 return VisitBinary(context, environment, (BinaryExpression)expression, param, (ctx, a, b) => ctx.MkLt((ArithExpr)a, (ArithExpr)b));
@@ -96,9 +110,9 @@ public static class ExpressionVisitor
             case ExpressionType.Call:
                 return VisitCall(context, environment, (MethodCallExpression)expression, param);
 
-/*               case ExpressionType.Parameter:
-                return VisitParameter(context, environment, (ParameterExpression)expression, param);
-            */
+            case ExpressionType.Conditional:
+                return VisitConditional(context, environment, (ConditionalExpression)expression, param);
+
             case ExpressionType.ArrayIndex:
                 return VisitBinary(context, environment, (BinaryExpression)expression, param, (ctx, a, b) => ctx.MkSelect((ArrayExpr)a, b));
                 
@@ -176,6 +190,59 @@ public static class ExpressionVisitor
     }
 
     /// <summary>
+    /// Visitor method to translate <c>&amp;</c>, <c>|</c> and <c>^</c>, which C# uses for both
+    /// Boolean logic and integer bitwise arithmetic.
+    /// </summary>
+    /// <param name="context">Z3 context.</param>
+    /// <param name="environment">Environment with bindings of theorem variables to Z3 handles.</param>
+    /// <param name="expression">Binary expression.</param>
+    /// <param name="param">Parameter used to express the constraint on.</param>
+    /// <param name="op">The C# operator, for the diagnostic when the operands are not Boolean.</param>
+    /// <param name="build">Builds the Z3 term from two Boolean operands.</param>
+    /// <returns>Z3 expression handle.</returns>
+    /// <remarks>
+    /// The operator is chosen from the operands' Z3 sort, not from the expression node, because
+    /// the node is the same for <c>bool &amp; bool</c> and <c>int &amp; int</c>. Boolean operands
+    /// give the logical operator; anything else is a bitwise operation, which Z3's integer sort
+    /// has no counterpart for, so it is rejected with a message that says so rather than an
+    /// <see cref="InvalidCastException"/> from inside the cast.
+    /// </remarks>
+    private static Expr VisitLogical(Context context, Environment environment, BinaryExpression expression, ParameterExpression param, string op, Func<Context, BoolExpr, BoolExpr, BoolExpr> build)
+    {
+        Expr left = Visit(context, environment, expression.Left, param);
+        Expr right = Visit(context, environment, expression.Right, param);
+
+        if (left is BoolExpr boolLeft && right is BoolExpr boolRight)
+        {
+            return build(context, boolLeft, boolRight);
+        }
+
+        throw new NotSupportedException(
+            $"The '{op}' operator is supported only on Boolean operands. A bitwise operation on integer symbols is not supported, because it would need a bit-vector representation the library does not expose.");
+    }
+
+    /// <summary>
+    /// Visitor method to translate a conditional (ternary <c>?:</c>) expression.
+    /// </summary>
+    /// <param name="context">Z3 context.</param>
+    /// <param name="environment">Environment with bindings of theorem variables to Z3 handles.</param>
+    /// <param name="expression">Conditional expression.</param>
+    /// <param name="param">Parameter used to express the constraint on.</param>
+    /// <returns>Z3 expression handle.</returns>
+    /// <remarks>
+    /// Maps onto Z3's if-then-else term. The two branches must share a sort, which they do for
+    /// any ternary the C# compiler accepts, since both arms are converted to a common type.
+    /// </remarks>
+    private static Expr VisitConditional(Context context, Environment environment, ConditionalExpression expression, ParameterExpression param)
+    {
+        Expr test = Visit(context, environment, expression.Test, param);
+        Expr ifTrue = Visit(context, environment, expression.IfTrue, param);
+        Expr ifFalse = Visit(context, environment, expression.IfFalse, param);
+
+        return context.MkITE((BoolExpr)test, ifTrue, ifFalse);
+    }
+
+    /// <summary>
     /// Visitor method to translate a method call expression.
     /// </summary>
     /// <param name="context">Z3 context.</param>
@@ -217,7 +284,7 @@ public static class ExpressionVisitor
         }
 
         // Filter for known Z3 operators.
-        if (method.IsGenericMethod && method.GetGenericMethodDefinition() == typeof(Z3Methods).GetMethod("Distinct"))
+        if (method.IsGenericMethod && method.GetGenericMethodDefinition() == DistinctMethod)
         {
             // We know the signature of the Distinct method call. Its argument is a params
             // array, hence we expect a NewArrayExpression.
@@ -226,13 +293,12 @@ public static class ExpressionVisitor
             var itemsExpression = call.Arguments[0];
             if (itemsExpression is MethodCallExpression mExp)
             {
-                if (mExp.Method.IsGenericMethod && mExp.Method.GetGenericMethodDefinition() == typeof(Enumerable)
-                    .GetMethods().First(m => m.Name == nameof(Enumerable.ToArray)))
+                if (mExp.Method.IsGenericMethod && mExp.Method.GetGenericMethodDefinition() == EnumerableToArrayMethod)
                 {
                     var callerToArrayExp = mExp.Arguments[0];
                     if (callerToArrayExp is MethodCallExpression callerToArrayMethodExp)
                     {
-                        if (callerToArrayMethodExp.Method.IsGenericMethod && callerToArrayMethodExp.Method.GetGenericMethodDefinition() == typeof(Enumerable).GetMethods().First(m => m.Name == nameof(Enumerable.Select) && m.GetParameters().Length == 2))
+                        if (callerToArrayMethodExp.Method.IsGenericMethod && callerToArrayMethodExp.Method.GetGenericMethodDefinition() == EnumerableSelectMethod)
                         {
                             var caller = (ICollection)ExpressionInterpreter.Instance.Interpret(callerToArrayMethodExp.Arguments[0]);
                             var arg = callerToArrayMethodExp.Arguments[1] as LambdaExpression;
@@ -270,7 +336,7 @@ public static class ExpressionVisitor
 
             if (distinctExps == null)
             {
-                throw new NotSupportedException("unsuported method call:" + method.ToString() + "with sub expression " + call.Arguments[0].ToString());
+                throw new NotSupportedException("Unsupported method call: " + method.ToString() + " with sub expression " + call.Arguments[0].ToString());
             }
 
             IEnumerable<Expr> args = from Expression arg in distinctExps 
@@ -334,7 +400,7 @@ public static class ExpressionVisitor
                 // which is the convention ToFileTimeUtc had and the read path inverts. See #56.
                 return context.MkInt(ToUtcTicks((DateTime)val));
             case TypeCode.String:
-                return context.MkString(val.ToString());
+                return context.MkString((string)val);
             default:
                 throw new NotSupportedException($"Unsupported constant {val}");
         }
@@ -410,10 +476,6 @@ public static class ExpressionVisitor
 
                 throw new NotSupportedException($"Could not reduce expression {topMember.Expression}");
             }
-            else
-            {
-                //Debugger.Break(); 
-            }
         }
 
         // Only members we allow currently are direct accesses to the theorem's variables
@@ -438,20 +500,6 @@ public static class ExpressionVisitor
 
         return subEnv.Expr!;
     }
-
-/*      
-    private static Expr VisitParameter(Context context, Environment environment, ParameterExpression expression, ParameterExpression param)
-    {
-        Expr value;
-
-        if (!environment.Properties.TryGetValue(expression., out value))
-        {
-            throw new NotSupportedException("Unknown parameter encountered: " + expression.Name + ".");
-        }
-
-        return value;
-    }
-*/
 
     /// <summary>
     /// Visitor method to translate a unary expression.


### PR DESCRIPTION
Improves the expression-tree translation layer (`ExpressionVisitor`) — the part of the library
that turns a constraint lambda into Z3 terms. Behavioural, perf, and cleanup; no public-API
change (the instance-visitor refactor and `internal` narrowing are a separate PR).

## What was wrong, measured

Three rough edges, all confirmed by probe before the change:

| Constraint | Before |
|---|---|
| `(t.X1 > 0 ? t.X2 : 0) == 5` — a ternary | `NotSupportedException: Conditional` — no case at all |
| `(t.X1 & 6) == 4` — integer bitwise `&` (also `\|`, `^`) | `InvalidCastException: IntExpr → BoolExpr`, from inside Z3 |
| `t.X1 % 2.5 == 0.5` — real modulo | `InvalidCastException: RealExpr → IntExpr` |

The bitwise and modulo crashes share one cause: the operator dispatch keyed on the expression
*node* and cast the operands to an assumed sort. But C# spells two different operations the same
way — `&`/`|`/`^` are Boolean logic on `bool` and bitwise arithmetic on integers, and `%` is
integer remainder with no real counterpart. The node can't tell them apart, so the wrong operand
got a cast that succeeded for one meaning and threw an opaque Z3 cast error for the other. This is
the same lesson the `Convert` case learned in #63/#76 — decide from the operand's translated
sort, not the node — that the rest of the dispatch never got.

## The change

**Ternary → if-then-else.** `ExpressionType.Conditional` now translates to `MkITE`, so
`t.X1 > 0 ? a : b` works, including nested inside arithmetic and over real-sorted branches.

**Sort-aware `&` `|` `^`.** The operator is chosen from the operands: Boolean operands give the
logical operator exactly as before; anything else is a bitwise operation, which Z3's integer sort
has no counterpart for, so it is refused with

```
The '&' operator is supported only on Boolean operands. A bitwise operation on integer symbols
is not supported, because it would need a bit-vector representation the library does not expose.
```

**Sort-aware `%`.** Integer operands give the remainder as before; a real modulo is refused with a
message saying Z3 has no remainder on reals, rather than crashing in the cast.

Genuine integer bitwise and shift support needs bit-vector symbols — a separate feature. This PR
turns two opaque crashes into clear, honest diagnostics; it does not pretend to add the feature.

**Perf.** The `Distinct` translation looked up three `MethodInfo`s by reflection on *every* visit
— `typeof(Z3Methods).GetMethod("Distinct")` and, worse, `typeof(Enumerable).GetMethods().First(…)`
twice, materialising all of `Enumerable`. They are now cached in `static readonly` fields.

**Cleanup.** Removed the commented-out `VisitParameter` and a dead `else { //Debugger.Break(); }`;
fixed `MkString(val.ToString())` to `(string)val` where the value is already a string; corrected
an "unsuported" message.

## Tests

280 → 290. A new `ExpressionTranslationTests` for the operators this touches, and two pins in
`UnsupportedExpressionTests` updated because their subject changed.

| Test | What it covers |
|---|---|
| `Solve_TernaryWhoseTestHolds_TakesTheTrueBranch` / `..TestFails_TakesTheFalseBranch` | both arms of the conditional |
| `Solve_TernaryOverRealBranches_Translates` | real-sorted branches |
| `Solve_TernaryNestedInArithmetic_Translates` | the conditional as a sub-term, not just the whole constraint |
| `Solve_BitwiseOperatorOnIntegerSymbols_ThrowsNotSupportedNamingIt` (`&`, `\|`, `^`) | the refusal names the operator and `bit-vector` |
| `Solve_ModuloOnRealSymbols_ThrowsNotSupportedNamingIt` | the refusal names modulo |
| `Solve_BooleanBitwiseOperators_StillTranslate` | the load-bearing regression guard — Boolean `&`/`\|`/`^` unchanged |
| `Solve_ModuloOnIntegerSymbols_StillTranslates` | integer remainder unchanged |
| `Solve_ConditionalExpression_ThrowsNotSupportedException` (removed) | ternary is now supported and covered positively above |
| `Solve_SupportedExpressionsAlongsideRejectedOnes_StillRejects` (updated) | its rejected example was a ternary; now an integer bitwise op |

The `Distinct` MethodInfo caching is behaviour-preserving and stays covered by the existing
`DistinctSelectorTheoremTests` / `DistinctInlineArrayTheoremTests`.

## Mutation results

| Mutation | Failures | Which |
|---|---|---|
| Remove the `Conditional` case | **4** | every ternary test |
| `&`/`\|`/`^` cast to `BoolExpr` blindly (the old code) | **4** | the three bitwise rows and the alongside-rejected pin — back to `InvalidCastException` |
| `%` casts to `IntExpr` blindly (the old code) | **1** | the real-modulo test |

## Verification

- `dotnet build solutions/Z3.Linq.slnx -c Release` — clean, `TreatWarningsAsErrors` and
  documentation generation on
- 290/290 locally
- `./build.ps1 -Configuration Release` — 46 tasks, 0 errors, 0 warnings
- Coverage 88.9% -> 89.2% line (839 of 940); branch 78.6% -> 76.0% (543 of 714), the dip being the
  new refusal branches that fire only in the negative tests plus the ternary `MkITE` paths — the
  operators' own branches are covered in both directions

## Follow-ups (not in this PR)

- **Instance visitor + `internal` narrowing** — `ExpressionVisitor` threads
  `(Context, Environment, ParameterExpression)` through every method and is `public` only "for
  historical reasons." Turning it into an `internal` instance class with those as fields is the
  mechanical modernisation the .NET 10 / major-version work unblocks; kept separate so a large
  no-behaviour diff doesn't bury these fixes. Next PR on the stack.
- **Bit-vector symbols** — what would make integer bitwise and shifts actually work, rather than
  be diagnosed. A feature in its own right.

## Release note

Releases remain on hold under #60 until Microsoft.Z3 5.x reaches nuget.org, so this reaches `main`
but not consumers. Nothing about the hold changes.
