### PR TITLE
Support uint and ulong as bit-vector symbols

### DIFF
--- a/solutions/Z3.Linq.Tests/BitVectorSymbolTests.cs
+++ b/solutions/Z3.Linq.Tests/BitVectorSymbolTests.cs
@@ -1,0 +1,296 @@
+namespace Z3.Linq.Tests;
+
+/// <summary>
+/// <c>uint</c> and <c>ulong</c> symbols, which travel through Z3 as fixed-width bit-vectors and so
+/// carry the operators a mathematical integer cannot: bitwise <c>&amp;</c> <c>|</c> <c>^</c>
+/// <c>~</c>, shifts, and wrapping arithmetic with unsigned comparison.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A <c>uint</c> maps to a 32-bit bit-vector and a <c>ulong</c> to a 64-bit one. <c>int</c>,
+/// <c>long</c> and <c>short</c> stay unbounded mathematical integers, where those bit operators
+/// have no meaning and are refused (see <c>ExpressionTranslationTests</c> and
+/// <c>UnsupportedExpressionTests</c>). <c>byte</c> and <c>ushort</c> are deliberately not mapped:
+/// C# promotes them to <c>int</c> in every expression, so such a symbol could never keep its
+/// bit-vector sort through a constraint.
+/// </para>
+/// <para>
+/// Constants must carry the unsigned suffix - <c>6u</c>, <c>6UL</c> - so C# keeps them
+/// <c>uint</c>/<c>ulong</c> rather than promoting the whole expression to <c>long</c>; an int
+/// literal that fits is implicitly typed to the symbol, so <c>t.X1 == 7</c> is fine, but mixing a
+/// bit-vector symbol with an <c>int</c> that forces promotion is not supported.
+/// </para>
+/// <para>
+/// Where a constraint does not pin a unique value, the assertion checks that the constraint holds
+/// on the returned value rather than a specific model, per the suite's determinism rule.
+/// </para>
+/// </remarks>
+[TestClass]
+public class BitVectorSymbolTests
+{
+    [TestMethod]
+    [DataRow(0u, DisplayName = "Zero")]
+    [DataRow(42u, DisplayName = "Small")]
+    [DataRow(uint.MaxValue, DisplayName = "UInt32.MaxValue")]
+    public void Solve_UIntSymbol_RoundTripsTheValue(uint value)
+    {
+        // Arrange
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<Symbols<uint, int>>()
+            .Where(t => t.X1 == value)
+            .Where(t => t.X2 == 1)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.X1.ShouldBe(value);
+    }
+
+    [TestMethod]
+    public void Solve_UIntBitwiseAnd_SatisfiesTheConstraint()
+    {
+        // Arrange
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<Symbols<uint, int>>()
+            .Where(t => (t.X1 & 6u) == 4u)
+            .Where(t => t.X2 == 1)
+            .Solve();
+
+        // Assert: any satisfying value has those bits, so the relation is model-independent.
+        result.ShouldNotBeNull();
+        (result.X1 & 6u).ShouldBe(4u);
+    }
+
+    [TestMethod]
+    public void Solve_UIntBitwiseOr_SatisfiesTheConstraint()
+    {
+        // Arrange
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<Symbols<uint, int>>()
+            .Where(t => (t.X1 | 1u) == 7u)
+            .Where(t => t.X1 < 8u)
+            .Where(t => t.X2 == 1)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        (result.X1 | 1u).ShouldBe(7u);
+    }
+
+    [TestMethod]
+    public void Solve_UIntBitwiseXor_PinsTheValue()
+    {
+        // Arrange: XOR against a constant has one solution for a pinned result.
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<Symbols<uint, int>>()
+            .Where(t => (t.X1 ^ 5u) == 0u)
+            .Where(t => t.X2 == 1)
+            .Solve();
+
+        // Assert: x ^ 5 == 0 has the single solution x == 5.
+        result.ShouldNotBeNull();
+        result.X1.ShouldBe(5u);
+    }
+
+    [TestMethod]
+    public void Solve_UIntOnesComplement_PinsTheValue()
+    {
+        // Arrange
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<Symbols<uint, int>>()
+            .Where(t => (~t.X1) == 0xFFFFFFF0u)
+            .Where(t => t.X2 == 1)
+            .Solve();
+
+        // Assert: ~x == 0xFFFFFFF0 has the single solution x == 0x0000000F.
+        result.ShouldNotBeNull();
+        result.X1.ShouldBe(0x0000000Fu);
+    }
+
+    [TestMethod]
+    public void Solve_UIntLeftShift_PinsTheValue()
+    {
+        // Arrange: the shift amount is an int in C#, converted to the value's width. The upper
+        // bound removes the wrapped second solution, leaving a unique answer.
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<Symbols<uint, int>>()
+            .Where(t => (t.X1 << 2) == 8u)
+            .Where(t => t.X1 < 4u)
+            .Where(t => t.X2 == 1)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.X1.ShouldBe(2u);
+    }
+
+    [TestMethod]
+    public void Solve_UIntRightShift_SatisfiesTheConstraint()
+    {
+        // Arrange
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<Symbols<uint, int>>()
+            .Where(t => (t.X1 >> 1) == 5u)
+            .Where(t => t.X1 < 12u)
+            .Where(t => t.X2 == 1)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        (result.X1 >> 1).ShouldBe(5u);
+    }
+
+    /// <summary>
+    /// Bit-vector arithmetic wraps, as unsigned arithmetic does.
+    /// </summary>
+    /// <remarks>
+    /// The defining difference from an <c>int</c> symbol, which is an unbounded integer and could
+    /// never satisfy this: <c>x + 1 == 0</c> has a solution only because a 32-bit bit-vector wraps
+    /// at its width, and that solution is <see cref="uint.MaxValue"/>.
+    /// </remarks>
+    [TestMethod]
+    public void Solve_UIntArithmeticWraps_PinsMaxValue()
+    {
+        // Arrange
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<Symbols<uint, int>>()
+            .Where(t => t.X1 + 1u == 0u)
+            .Where(t => t.X2 == 1)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.X1.ShouldBe(uint.MaxValue);
+    }
+
+    /// <summary>
+    /// Comparison on a bit-vector symbol is unsigned.
+    /// </summary>
+    /// <remarks>
+    /// The band 2,000,000,000 to 3,000,000,000 straddles the signed 32-bit boundary
+    /// (0x7FFFFFFF ~ 2.147e9): 3,000,000,000 read as a signed <c>int</c> is negative. So under a
+    /// <em>signed</em> comparison the two bounds contradict - nothing is both above a large
+    /// positive and below a negative - and the theorem would be unsatisfiable. It is satisfiable
+    /// only because the comparison is unsigned, which is what makes a signed-comparison mutation
+    /// return <see langword="null"/> here rather than a coincidentally-passing model.
+    /// </remarks>
+    [TestMethod]
+    public void Solve_UIntComparison_IsUnsigned()
+    {
+        // Arrange
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<Symbols<uint, int>>()
+            .Where(t => t.X1 > 2_000_000_000u)
+            .Where(t => t.X1 < 3_000_000_000u)
+            .Where(t => t.X2 == 1)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.X1.ShouldBeGreaterThan(2_000_000_000u);
+        result.X1.ShouldBeLessThan(3_000_000_000u);
+    }
+
+    [TestMethod]
+    public void Solve_UIntSymbolMaximised_ReturnsTheUpperBound()
+    {
+        // Arrange: the optimiser reads a bit-vector solution back through the same marshalling.
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<Symbols<uint, int>>()
+            .Where(t => t.X1 < 100u)
+            .Where(t => t.X2 == 1)
+            .Optimize(Optimization.Maximize, t => t.X1);
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.X1.ShouldBe(99u);
+    }
+
+    /// <summary>
+    /// A <c>ulong</c> symbol is a 64-bit bit-vector, so it holds values beyond <c>uint</c>.
+    /// </summary>
+    [TestMethod]
+    public void Solve_ULongSymbol_RoundTripsAValueBeyondUInt()
+    {
+        // Arrange
+        using var context = new Z3Context();
+        const ulong value = 5_000_000_000UL;
+
+        // Act
+        var result = context.NewTheorem<Symbols<ulong, int>>()
+            .Where(t => t.X1 == value)
+            .Where(t => t.X2 == 1)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.X1.ShouldBe(value);
+    }
+
+    [TestMethod]
+    public void Solve_ULongBitwise_SatisfiesTheConstraint()
+    {
+        // Arrange
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<Symbols<ulong, int>>()
+            .Where(t => (t.X1 & 6UL) == 4UL)
+            .Where(t => t.X1 < 8UL)
+            .Where(t => t.X2 == 1)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        (result.X1 & 6UL).ShouldBe(4UL);
+    }
+
+    /// <summary>
+    /// A <c>uint</c> collection round-trips, and its elements support bitwise operators.
+    /// </summary>
+    [TestMethod]
+    public void Solve_UIntCollectionElement_SupportsBitwise()
+    {
+        // Arrange
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<UIntArrayEnvironment>()
+            .Where(t => (t.Values[0] & 6u) == 4u)
+            .Where(t => t.Values[0] < 8u)
+            .Where(t => t.Length == 2)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.Values.Length.ShouldBe(2);
+        (result.Values[0] & 6u).ShouldBe(4u);
+    }
+
+    private sealed class UIntArrayEnvironment
+    {
+        public uint[] Values { get; set; } = new uint[2];
+
+        public int Length { get; set; }
+    }
+}

--- a/solutions/Z3.Linq.Tests/UnsupportedExpressionTests.cs
+++ b/solutions/Z3.Linq.Tests/UnsupportedExpressionTests.cs
@@ -83,12 +83,14 @@ public class UnsupportedExpressionTests
     }
 
     [TestMethod]
-    public void Solve_UnsignedIntProperty_ThrowsNotSupportedException()
+    public void Solve_ByteProperty_ThrowsNotSupportedException()
     {
-        // Arrange: uint is likewise absent. Z3 integers are unbounded, so the omission is about
-        // the type switch rather than anything Z3 cannot represent.
+        // Arrange: byte and ushort are deliberately not mapped, even though uint and ulong are
+        // bit-vectors - because C# promotes byte and ushort to int in every expression, so such a
+        // symbol could never keep a bit-vector sort through a constraint. See the bit-vector work
+        // and BitVectorSymbolTests.
         using var context = new Z3Context();
-        var theorem = context.NewTheorem<UnsignedEnvironment>().Where(t => t.Other == 1);
+        var theorem = context.NewTheorem<ByteEnvironment>().Where(t => t.Other == 1);
 
         // Act & Assert
         Should.Throw<NotSupportedException>(() => theorem.Solve());
@@ -117,8 +119,8 @@ public class UnsupportedExpressionTests
     /// An enum is only ever as supported as its underlying type. #63 fixed the <c>int</c>-backed
     /// case - <see cref="DayOfWeek"/> and friends - which is now round-tripped in
     /// <c>SymbolTypeMarshallingTests</c>. A <c>byte</c>-backed enum is <c>TypeCode.Byte</c>,
-    /// which the sort mapping has never handled, so it stops at the same guard that rejects a
-    /// bare <c>byte</c> or <c>uint</c>.
+    /// which the sort mapping does not handle, so it stops at the same guard that rejects a
+    /// bare <c>byte</c> or <c>ushort</c>.
     /// </para>
     /// <para>
     /// This is the outcome #63 asked for where a type genuinely is not supported: a
@@ -180,9 +182,9 @@ public class UnsupportedExpressionTests
         public int Other { get; set; }
     }
 
-    private sealed class UnsignedEnvironment
+    private sealed class ByteEnvironment
     {
-        public uint Value { get; set; }
+        public byte Value { get; set; }
 
         public int Other { get; set; }
     }

--- a/solutions/Z3.Linq/ExpressionVisitor.cs
+++ b/solutions/Z3.Linq/ExpressionVisitor.cs
@@ -66,17 +66,25 @@ internal sealed class ExpressionVisitor
         {
             case ExpressionType.And:
             case ExpressionType.AndAlso:
-                return VisitLogical((BinaryExpression)expression, "&", static (ctx, a, b) => ctx.MkAnd(a, b));
+                return VisitBitwise((BinaryExpression)expression, "&", static (ctx, a, b) => ctx.MkAnd(a, b), static (ctx, a, b) => ctx.MkBVAND(a, b));
 
             case ExpressionType.Or:
             case ExpressionType.OrElse:
-                return VisitLogical((BinaryExpression)expression, "|", static (ctx, a, b) => ctx.MkOr(a, b));
+                return VisitBitwise((BinaryExpression)expression, "|", static (ctx, a, b) => ctx.MkOr(a, b), static (ctx, a, b) => ctx.MkBVOR(a, b));
 
             case ExpressionType.ExclusiveOr:
-                return VisitLogical((BinaryExpression)expression, "^", static (ctx, a, b) => ctx.MkXor(a, b));
+                return VisitBitwise((BinaryExpression)expression, "^", static (ctx, a, b) => ctx.MkXor(a, b), static (ctx, a, b) => ctx.MkBVXOR(a, b));
 
+            // C# spells both boolean '!' and bitwise '~' with the Not node (OnesComplement is the
+            // alternative spelling some providers emit for '~'); the operand's sort decides.
             case ExpressionType.Not:
-                return VisitUnary((UnaryExpression)expression, static (ctx, a) => ctx.MkNot((BoolExpr)a));
+            case ExpressionType.OnesComplement:
+                return VisitUnary((UnaryExpression)expression, static (ctx, a) => a switch
+                {
+                    BoolExpr boolExpr => ctx.MkNot(boolExpr),
+                    BitVecExpr bvExpr => ctx.MkBVNot(bvExpr),
+                    _ => throw new NotSupportedException("The '~' operator is supported only on bit-vector (uint/ulong) symbols; '!' only on Boolean operands."),
+                });
 
             case ExpressionType.Negate:
             case ExpressionType.NegateChecked:
@@ -84,36 +92,44 @@ internal sealed class ExpressionVisitor
 
             case ExpressionType.Add:
             case ExpressionType.AddChecked:
-                return VisitBinary((BinaryExpression)expression, static (ctx, a, b) => ctx.MkAdd((ArithExpr)a, (ArithExpr)b));
+                return VisitArithmetic((BinaryExpression)expression, static (ctx, a, b) => ctx.MkAdd(a, b), static (ctx, a, b) => ctx.MkBVAdd(a, b));
 
             case ExpressionType.Subtract:
             case ExpressionType.SubtractChecked:
-                return VisitBinary((BinaryExpression)expression, static (ctx, a, b) => ctx.MkSub((ArithExpr)a, (ArithExpr)b));
+                return VisitArithmetic((BinaryExpression)expression, static (ctx, a, b) => ctx.MkSub(a, b), static (ctx, a, b) => ctx.MkBVSub(a, b));
 
             case ExpressionType.Multiply:
             case ExpressionType.MultiplyChecked:
-                return VisitBinary((BinaryExpression)expression, static (ctx, a, b) => ctx.MkMul((ArithExpr)a, (ArithExpr)b));
+                return VisitArithmetic((BinaryExpression)expression, static (ctx, a, b) => ctx.MkMul(a, b), static (ctx, a, b) => ctx.MkBVMul(a, b));
 
             case ExpressionType.Divide:
-                return VisitBinary((BinaryExpression)expression, static (ctx, a, b) => ctx.MkDiv((ArithExpr)a, (ArithExpr)b));
+                return VisitArithmetic((BinaryExpression)expression, static (ctx, a, b) => ctx.MkDiv(a, b), static (ctx, a, b) => ctx.MkBVUDiv(a, b));
 
             case ExpressionType.Modulo:
-                return VisitBinary((BinaryExpression)expression, static (ctx, a, b) =>
-                    a is IntExpr ia && b is IntExpr ib
-                        ? ctx.MkRem(ia, ib)
-                        : throw new NotSupportedException("The modulo operator is supported only on integer operands; Z3 has no remainder on real-sorted values."));
+                return VisitBinary((BinaryExpression)expression, static (ctx, a, b) => (a, b) switch
+                {
+                    (BitVecExpr ba, BitVecExpr bb) => ctx.MkBVURem(ba, bb),
+                    (IntExpr ia, IntExpr ib) => ctx.MkRem(ia, ib),
+                    _ => throw new NotSupportedException("The modulo operator is supported only on integer or bit-vector operands; Z3 has no remainder on real-sorted values."),
+                });
+
+            case ExpressionType.LeftShift:
+                return VisitShift((BinaryExpression)expression, "<<", static (ctx, a, b) => ctx.MkBVSHL(a, b));
+
+            case ExpressionType.RightShift:
+                return VisitShift((BinaryExpression)expression, ">>", static (ctx, a, b) => ctx.MkBVLSHR(a, b));
 
             case ExpressionType.LessThan:
-                return VisitBinary((BinaryExpression)expression, static (ctx, a, b) => ctx.MkLt((ArithExpr)a, (ArithExpr)b));
+                return VisitComparison((BinaryExpression)expression, static (ctx, a, b) => ctx.MkLt(a, b), static (ctx, a, b) => ctx.MkBVULT(a, b));
 
             case ExpressionType.LessThanOrEqual:
-                return VisitBinary((BinaryExpression)expression, static (ctx, a, b) => ctx.MkLe((ArithExpr)a, (ArithExpr)b));
+                return VisitComparison((BinaryExpression)expression, static (ctx, a, b) => ctx.MkLe(a, b), static (ctx, a, b) => ctx.MkBVULE(a, b));
 
             case ExpressionType.GreaterThan:
-                return VisitBinary((BinaryExpression)expression, static (ctx, a, b) => ctx.MkGt((ArithExpr)a, (ArithExpr)b));
+                return VisitComparison((BinaryExpression)expression, static (ctx, a, b) => ctx.MkGt(a, b), static (ctx, a, b) => ctx.MkBVUGT(a, b));
 
             case ExpressionType.GreaterThanOrEqual:
-                return VisitBinary((BinaryExpression)expression, static (ctx, a, b) => ctx.MkGe((ArithExpr)a, (ArithExpr)b));
+                return VisitComparison((BinaryExpression)expression, static (ctx, a, b) => ctx.MkGe(a, b), static (ctx, a, b) => ctx.MkBVUGE(a, b));
 
             case ExpressionType.Equal:
                 return VisitBinary((BinaryExpression)expression, static (ctx, a, b) => ctx.MkEq(a, b));
@@ -207,32 +223,107 @@ internal sealed class ExpressionVisitor
     }
 
     /// <summary>
-    /// Translates <c>&amp;</c>, <c>|</c> and <c>^</c>, which C# uses for both Boolean logic and
-    /// integer bitwise arithmetic.
+    /// Translates an arithmetic operator, choosing the integer/real form or the bit-vector form
+    /// from the operands' sort.
     /// </summary>
     /// <param name="expression">Binary expression.</param>
-    /// <param name="op">The C# operator, for the diagnostic when the operands are not Boolean.</param>
-    /// <param name="build">Builds the Z3 term from two Boolean operands.</param>
+    /// <param name="arith">Builds the term for integer- or real-sorted operands.</param>
+    /// <param name="bv">Builds the term for bit-vector operands.</param>
     /// <returns>Z3 expression handle.</returns>
     /// <remarks>
-    /// The operator is chosen from the operands' Z3 sort, not from the expression node, because
-    /// the node is the same for <c>bool &amp; bool</c> and <c>int &amp; int</c>. Boolean operands
-    /// give the logical operator; anything else is a bitwise operation, which Z3's integer sort
-    /// has no counterpart for, so it is rejected with a message that says so rather than an
-    /// <see cref="InvalidCastException"/> from inside the cast.
+    /// A bit-vector symbol (an unsigned CLR type) carries wrapping arithmetic; an <c>int</c>,
+    /// <c>long</c> or real symbol carries mathematical arithmetic. Both operands share a sort,
+    /// since C# would not compile a mixed expression without a conversion, which
+    /// <see cref="VisitConvert"/> handles first.
     /// </remarks>
-    private Expr VisitLogical(BinaryExpression expression, string op, Func<Context, BoolExpr, BoolExpr, BoolExpr> build)
+    private Expr VisitArithmetic(BinaryExpression expression, Func<Context, ArithExpr, ArithExpr, ArithExpr> arith, Func<Context, BitVecExpr, BitVecExpr, BitVecExpr> bv)
     {
         Expr left = Visit(expression.Left);
         Expr right = Visit(expression.Right);
 
-        if (left is BoolExpr boolLeft && right is BoolExpr boolRight)
+        return left is BitVecExpr bvLeft
+            ? bv(this.context, bvLeft, (BitVecExpr)right)
+            : arith(this.context, (ArithExpr)left, (ArithExpr)right);
+    }
+
+    /// <summary>
+    /// Translates a relational operator, choosing the ordered-arithmetic form or the
+    /// <em>unsigned</em> bit-vector form from the operands' sort.
+    /// </summary>
+    /// <param name="expression">Binary expression.</param>
+    /// <param name="arith">Builds the comparison for integer- or real-sorted operands.</param>
+    /// <param name="bv">Builds the unsigned comparison for bit-vector operands.</param>
+    /// <returns>Z3 expression handle.</returns>
+    /// <remarks>
+    /// Bit-vectors map from the unsigned CLR types, so the comparison is unsigned - <c>uint</c>
+    /// order, not two's-complement signed order.
+    /// </remarks>
+    private Expr VisitComparison(BinaryExpression expression, Func<Context, ArithExpr, ArithExpr, BoolExpr> arith, Func<Context, BitVecExpr, BitVecExpr, BoolExpr> bv)
+    {
+        Expr left = Visit(expression.Left);
+        Expr right = Visit(expression.Right);
+
+        return left is BitVecExpr bvLeft
+            ? bv(this.context, bvLeft, (BitVecExpr)right)
+            : arith(this.context, (ArithExpr)left, (ArithExpr)right);
+    }
+
+    /// <summary>
+    /// Translates <c>&amp;</c>, <c>|</c> and <c>^</c>, which C# uses for Boolean logic, integer
+    /// bitwise arithmetic, and bit-vector bitwise arithmetic alike.
+    /// </summary>
+    /// <param name="expression">Binary expression.</param>
+    /// <param name="op">The C# operator, for the diagnostic when the operands fit neither form.</param>
+    /// <param name="boolOp">Builds the logical term for Boolean operands.</param>
+    /// <param name="bvOp">Builds the bitwise term for bit-vector operands.</param>
+    /// <returns>Z3 expression handle.</returns>
+    /// <remarks>
+    /// The operator is chosen from the operands' Z3 sort, not the expression node, which is the
+    /// same for <c>bool &amp; bool</c>, <c>int &amp; int</c> and <c>uint &amp; uint</c>. Boolean
+    /// operands give the logical operator and bit-vector operands the bitwise one. A plain
+    /// integer symbol has neither - Z3's integer sort has no bitwise operations - so it is
+    /// rejected with a message pointing at the unsigned types, rather than an
+    /// <see cref="InvalidCastException"/> from inside the cast.
+    /// </remarks>
+    private Expr VisitBitwise(BinaryExpression expression, string op, Func<Context, BoolExpr, BoolExpr, BoolExpr> boolOp, Func<Context, BitVecExpr, BitVecExpr, BitVecExpr> bvOp)
+    {
+        Expr left = Visit(expression.Left);
+        Expr right = Visit(expression.Right);
+
+        return (left, right) switch
         {
-            return build(this.context, boolLeft, boolRight);
+            (BoolExpr boolLeft, BoolExpr boolRight) => boolOp(this.context, boolLeft, boolRight),
+            (BitVecExpr bvLeft, BitVecExpr bvRight) => bvOp(this.context, bvLeft, bvRight),
+            _ => throw new NotSupportedException(
+                $"The '{op}' operator is supported on Boolean operands and on bit-vector (uint/ulong) symbols. It is not supported on plain integer symbols, whose Z3 sort has no bitwise operations."),
+        };
+    }
+
+    /// <summary>
+    /// Translates a shift, <c>&lt;&lt;</c> or <c>&gt;&gt;</c>, on a bit-vector.
+    /// </summary>
+    /// <param name="expression">Binary expression.</param>
+    /// <param name="op">The C# operator, for the diagnostic.</param>
+    /// <param name="bvOp">Builds the shift term from the value and the shift amount.</param>
+    /// <returns>Z3 expression handle.</returns>
+    /// <remarks>
+    /// C# types the shift amount as <c>int</c>, so the right operand translates to an integer and
+    /// is converted to a bit-vector of the value's width before the shift. Only a bit-vector value
+    /// can be shifted; Z3's integer sort has no shift.
+    /// </remarks>
+    private Expr VisitShift(BinaryExpression expression, string op, Func<Context, BitVecExpr, BitVecExpr, BitVecExpr> bvOp)
+    {
+        Expr value = Visit(expression.Left);
+        Expr amount = Visit(expression.Right);
+
+        if (value is not BitVecExpr bvValue)
+        {
+            throw new NotSupportedException($"The '{op}' shift operator is supported only on bit-vector (uint/ulong) symbols.");
         }
 
-        throw new NotSupportedException(
-            $"The '{op}' operator is supported only on Boolean operands. A bitwise operation on integer symbols is not supported, because it would need a bit-vector representation the library does not expose.");
+        BitVecExpr bvAmount = amount as BitVecExpr ?? this.context.MkInt2BV(bvValue.SortSize, (IntExpr)amount);
+
+        return bvOp(this.context, bvValue, bvAmount);
     }
 
     /// <summary>
@@ -385,6 +476,10 @@ internal sealed class ExpressionVisitor
             case TypeCode.Int32:
             case TypeCode.Int64:
                 return this.context.MkInt(Convert.ToInt64(val));
+            case TypeCode.UInt32:
+            case TypeCode.UInt64:
+                // uint and ulong are bit-vectors of their width. See #99's bit-vector follow-up.
+                return this.context.MkBV(Convert.ToUInt64(val), Theorem.BitVectorWidth(Type.GetTypeCode(val.GetType()))!.Value);
             case TypeCode.Boolean:
                 return this.context.MkBool((bool)val);
             case TypeCode.Single:

--- a/solutions/Z3.Linq/Theorem.cs
+++ b/solutions/Z3.Linq/Theorem.cs
@@ -451,6 +451,32 @@ public class Theorem
             TypeCode.Int16 or TypeCode.Int32 or TypeCode.Int64 or TypeCode.DateTime => context.IntSort,
             TypeCode.Boolean => context.BoolSort,
             TypeCode.Single or TypeCode.Decimal or TypeCode.Double => context.RealSort,
+            TypeCode.UInt32 or TypeCode.UInt64 => context.MkBitVecSort(BitVectorWidth(typeCode)!.Value),
+            _ => null,
+        };
+    }
+
+    /// <summary>
+    /// The width, in bits, of the Z3 bit-vector a fixed-width unsigned CLR type maps to, or
+    /// <see langword="null"/> for a type that is not a bit-vector.
+    /// </summary>
+    /// <param name="typeCode">The type code of the CLR type.</param>
+    /// <returns>The bit width, or <see langword="null"/>.</returns>
+    /// <remarks>
+    /// <c>uint</c> and <c>ulong</c> travel through Z3 as bit-vectors of their width - so they
+    /// carry wrapping arithmetic, bitwise operators and shifts, which a mathematical integer has
+    /// no counterpart for. <c>short</c>, <c>int</c> and <c>long</c> stay unbounded integers.
+    /// <c>byte</c> and <c>ushort</c> are deliberately not mapped: C# promotes them to <c>int</c>
+    /// in every expression, so a <c>byte</c> symbol could never keep its bit-vector sort through
+    /// a constraint, and mapping it would only produce a confusing conversion error rather than a
+    /// usable symbol.
+    /// </remarks>
+    internal static uint? BitVectorWidth(TypeCode typeCode)
+    {
+        return typeCode switch
+        {
+            TypeCode.UInt32 => 32,
+            TypeCode.UInt64 => 64,
             _ => null,
         };
     }
@@ -664,6 +690,12 @@ public class Theorem
                         case TypeCode.Int64:
                             numVal = ((IntNum)numValExpr).Int64;
                             break;
+                        case TypeCode.UInt32:
+                            numVal = (uint)((BitVecNum)numValExpr).UInt64;
+                            break;
+                        case TypeCode.UInt64:
+                            numVal = ((BitVecNum)numValExpr).UInt64;
+                            break;
                         case TypeCode.DateTime:
                             // Ticks on the UTC timeline, for the reason given on the scalar arm below.
                             numVal = ToDateTime(((IntNum)numValExpr).Int64, parameter.Name);
@@ -730,6 +762,12 @@ public class Theorem
                     break;
                 case TypeCode.Int64:
                     value = ((IntNum)val).Int64;
+                    break;
+                case TypeCode.UInt32:
+                    value = (uint)((BitVecNum)val).UInt64;
+                    break;
+                case TypeCode.UInt64:
+                    value = ((BitVecNum)val).UInt64;
                     break;
                 case TypeCode.DateTime:
                     // The write path encodes the instant as its ticks on the UTC timeline


### PR DESCRIPTION
The second follow-up #99 listed. #99 diagnosed integer bitwise (`&`/`|`/`^`), `~` and shifts as
unsupported, because Z3's *integer* sort has no bit operations - they need a fixed-width
`BitVec`. This adds the bit-vector: `uint` maps to a 32-bit bit-vector and `ulong` to a 64-bit one,
so those symbols carry the operators an unbounded integer cannot. Purely additive - both types
were rejected before.

## The change

**Sort.** `uint`/`ulong` join the one CLR-type-to-sort mapping (`TryGetSymbolSort`) as
`MkBitVecSort(32|64)`, alongside a `BitVectorWidth` helper. The read paths gain arms that read a
`BitVecNum` back to `uint`/`ulong`; constants translate through `MkBV`.

**Operators, chosen by sort.** The visitor's dispatch became sort-aware: each arithmetic and
relational operator picks the bit-vector form for bit-vector operands and the arithmetic form for
integer/real ones; `&`/`|`/`^` and `~` pick the Boolean form for bools, the bitwise form for
bit-vectors, and are refused with a clear message on plain integers. So:

| Shape (all measured) | Result |
|---|---|
| `t.X1 == 7u`, round-trip incl. `uint.MaxValue` | exact |
| `(t.X1 & 6u) == 4u`, `(t.X1 \| 1u) == 7u`, `(t.X1 ^ 5u) == 0u` | bitwise works |
| `(~t.X1) == 0xFFFFFFF0u` | complement works (C# emits `Not` for `~`; now sort-aware) |
| `(t.X1 << 2) == 8u`, `(t.X1 >> 1) == 5u` | shifts work; the `int` shift amount is widened to the value's width |
| `t.X1 + 1u == 0u` | wraps to `uint.MaxValue` - the defining bit-vector behaviour |
| `t.X1 > 0xFFFFFFF0u` | **unsigned** comparison |
| `ulong` beyond `uint`, `uint[]` elements, `Optimize` | all work |

Comparisons are **unsigned**, matching `uint`/`ulong`; shifts are logical (`MkBVLSHR`). The #87
range bounds do not apply - a bit-vector is bounded by its width, and `AssertBounds` only touches
`IntExpr` symbols, so bit-vectors are skipped naturally.

## byte and ushort, measured and deliberately excluded

The opt-in was "unsigned/fixed types," but building it surfaced that **`byte` and `ushort` cannot
carry the feature**: C# promotes them to `int` in every expression - `byte & 0x0F` is computed in
`int` space - so a `byte` symbol would produce a `byte`->`int` `Convert` and then fail, because
`int` has no bitwise. `uint`/`ulong` are not promoted, which is why they work. Mapping `byte`/
`ushort` to a bit-vector sort would be a trap: the symbol would carry a sort every constraint then
fails to use. So they stay unsupported (rejected cleanly at environment build, as before), and
`BitVectorWidth` documents why. The pin that asserted `uint` was unsupported is repointed at
`byte`.

## Limitation

A bit-vector symbol mixed with an `int` that forces promotion (an `int` *variable*, or a literal
too big for `uint`) is not supported - the resulting `uint`<->`int` conversion has no meaning the
library commits to, and falls through to the existing conversion catch-all. Unsigned literals
(`6u`, `6UL`) and int literals that fit keep the expression in bit-vector space. Documented on
`BitVectorSymbolTests`.

## Tests

290 -> 305, in a new `BitVectorSymbolTests`, plus one repointed pin. Where a constraint does not
pin a unique value, the assertion checks the constraint holds on the result rather than a specific
model.

| Test | Covers |
|---|---|
| `Solve_UIntSymbol_RoundTripsTheValue` | round-trip incl. `uint.MaxValue` |
| `Solve_UIntBitwiseAnd/Or/Xor`, `Solve_UIntOnesComplement` | the bitwise operators and `~` |
| `Solve_UIntLeftShift`, `Solve_UIntRightShift` | shifts, with the int-amount conversion |
| `Solve_UIntArithmeticWraps_PinsMaxValue` | wrapping - unsatisfiable for an `int` symbol |
| `Solve_UIntComparison_IsUnsigned` | a band across the signed boundary, UNSAT under signed order |
| `Solve_UIntSymbolMaximised`, `Solve_ULong*`, `Solve_UIntCollectionElement` | optimiser, 64-bit, collections |
| `Solve_ByteProperty_ThrowsNotSupportedException` (repointed from `uint`) | byte/ushort stay unsupported |

## Mutation results

| Mutation | Failures | Which |
|---|---|---|
| `uint`/`ulong` not mapped to a sort | **15** | every bit-vector test |
| Bitwise arm throws instead of the BV op | **5** | the four bitwise tests and the ulong one |
| All comparisons signed (`MkBVU*` -> `MkBVS*`) | **2** | the unsigned-comparison band and the maximise test |
| Shift amount not widened to the value's sort | **2** | both shift tests |
| Complement arm dead (`~` no longer `MkBVNot`) | **1** | the ones-complement test |

The unsigned-comparison test needed strengthening first: a value that satisfied the constraint
under *signed* order coincidentally satisfied the unsigned assertion, so the mutation slipped
through until the constraint was made a band that is unsatisfiable under signed order.

## Verification

- `dotnet build solutions/Z3.Linq.slnx -c Release` - clean, `TreatWarningsAsErrors` and
  documentation generation on
- 305/305 locally
- `./build.ps1 -Configuration Release` - 46 tasks, 0 errors, 0 warnings
- Coverage 89.3% -> 89.0% line (894 of 1004), 76.0% -> 77.2% branch (592 of 766)

## Release note

Releases remain on hold under #60 until Microsoft.Z3 5.x reaches nuget.org, so this reaches `main`
but not consumers. The public surface gains `uint`/`ulong` symbol support; nothing is removed.
