### PR TITLE
Support byte, sbyte and ushort as bounded integer symbols

### DIFF
--- a/solutions/Z3.Linq.Tests/SmallIntegerSymbolTests.cs
+++ b/solutions/Z3.Linq.Tests/SmallIntegerSymbolTests.cs
@@ -1,0 +1,222 @@
+namespace Z3.Linq.Tests;
+
+/// <summary>
+/// <c>byte</c>, <c>sbyte</c> and <c>ushort</c> symbols, which - like <c>short</c> - travel through
+/// Z3 as mathematical integers bounded to the range of the type.
+/// </summary>
+/// <remarks>
+/// <para>
+/// These are the sub-<c>int</c> integer types. C# promotes them to <c>int</c> in every
+/// expression, so - unlike <c>uint</c> and <c>ulong</c> - they cannot be bit-vectors: a promoted
+/// operand would lose a bit-vector sort at the <c>Convert</c> the compiler inserts. Mapping them
+/// to the integer sort instead makes that promotion a no-op in Z3 terms (the symbol is already an
+/// integer), exactly as it is for <c>short</c>, so equality, ordering and arithmetic work. The
+/// range is enforced the way #87 does it, so a value the type cannot hold makes the theorem
+/// unsatisfiable rather than being read back wrong.
+/// </para>
+/// <para>
+/// They do not support bitwise operators or shifts - the integer sort has none; that needs
+/// <c>uint</c>/<c>ulong</c> and is covered by <c>BitVectorSymbolTests</c>.
+/// </para>
+/// </remarks>
+[TestClass]
+public class SmallIntegerSymbolTests
+{
+    [TestMethod]
+    [DataRow((byte)0, DisplayName = "Zero")]
+    [DataRow((byte)200, DisplayName = "Above sbyte range")]
+    [DataRow(byte.MaxValue, DisplayName = "Byte.MaxValue")]
+    public void Solve_ByteSymbol_RoundTripsTheValue(byte value)
+    {
+        // Arrange
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<Symbols<byte, int>>()
+            .Where(t => t.X1 == value)
+            .Where(t => t.X2 == 1)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.X1.ShouldBe(value);
+    }
+
+    [TestMethod]
+    [DataRow((sbyte)0, DisplayName = "Zero")]
+    [DataRow((sbyte)-100, DisplayName = "Negative")]
+    [DataRow(sbyte.MinValue, DisplayName = "SByte.MinValue")]
+    [DataRow(sbyte.MaxValue, DisplayName = "SByte.MaxValue")]
+    public void Solve_SByteSymbol_RoundTripsTheValue(sbyte value)
+    {
+        // Arrange
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<Symbols<sbyte, int>>()
+            .Where(t => t.X1 == value)
+            .Where(t => t.X2 == 1)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.X1.ShouldBe(value);
+    }
+
+    [TestMethod]
+    [DataRow((ushort)0, DisplayName = "Zero")]
+    [DataRow((ushort)40000, DisplayName = "Above short range")]
+    [DataRow(ushort.MaxValue, DisplayName = "UInt16.MaxValue")]
+    public void Solve_UShortSymbol_RoundTripsTheValue(ushort value)
+    {
+        // Arrange
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<Symbols<ushort, int>>()
+            .Where(t => t.X1 == value)
+            .Where(t => t.X2 == 1)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.X1.ShouldBe(value);
+    }
+
+    [TestMethod]
+    public void Solve_ByteSymbolsInArithmetic_RoundTripTheValues()
+    {
+        // Arrange: C# promotes both operands to int, which is a no-op against the int-sorted
+        // symbols, so the arithmetic just works.
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<Symbols<byte, byte>>()
+            .Where(t => t.X1 + t.X2 == 10)
+            .Where(t => t.X1 == 4)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.X1.ShouldBe((byte)4);
+        result.X2.ShouldBe((byte)6);
+    }
+
+    [TestMethod]
+    public void Optimize_ByteSymbolMaximised_ReturnsByteMaxValue()
+    {
+        // Arrange: the range bound is what makes the maximum the type's maximum rather than an
+        // arbitrary large integer.
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<Symbols<byte, int>>()
+            .Where(t => t.X2 == 1)
+            .Optimize(Optimization.Maximize, t => t.X1);
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.X1.ShouldBe(byte.MaxValue);
+    }
+
+    [TestMethod]
+    public void Optimize_SByteSymbolMinimised_ReturnsSByteMinValue()
+    {
+        // Arrange
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<Symbols<sbyte, int>>()
+            .Where(t => t.X2 == 1)
+            .Optimize(Optimization.Minimize, t => t.X1);
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.X1.ShouldBe(sbyte.MinValue);
+    }
+
+    [TestMethod]
+    public void Optimize_UShortSymbolMaximised_ReturnsUShortMaxValue()
+    {
+        // Arrange
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<Symbols<ushort, int>>()
+            .Where(t => t.X2 == 1)
+            .Optimize(Optimization.Maximize, t => t.X1);
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.X1.ShouldBe(ushort.MaxValue);
+    }
+
+    /// <summary>
+    /// A <c>byte</c> constrained outside its range has no solution.
+    /// </summary>
+    /// <remarks>
+    /// The bound is enforced, so a constraint written through an <c>int</c> variable that no
+    /// <c>byte</c> can satisfy is unsatisfiable - the true answer - rather than a value read back
+    /// wrong. C# blocks the direct <c>t.X1 == 300</c>, so it takes a variable to reach.
+    /// </remarks>
+    [TestMethod]
+    public void Solve_ByteSymbolConstrainedOutsideItsRange_IsUnsatisfiable()
+    {
+        // Arrange
+        using var context = new Z3Context();
+        int beyondByteRange = 300;
+        var theorem = context.NewTheorem<Symbols<byte, int>>()
+            .Where(t => t.X1 == beyondByteRange);
+
+        // Act
+        bool satisfiable = theorem.TrySolve(out _);
+
+        // Assert
+        satisfiable.ShouldBeFalse();
+    }
+
+    /// <summary>
+    /// Bitwise operators are refused on a <c>byte</c> symbol.
+    /// </summary>
+    /// <remarks>
+    /// A <c>byte</c> is an integer, not a bit-vector, and C# computes <c>byte &amp; byte</c> in
+    /// <c>int</c> space - so this is a bitwise operation on integer operands, which the integer
+    /// sort has no counterpart for. The refusal points at the bit-vector types.
+    /// </remarks>
+    [TestMethod]
+    public void Solve_ByteBitwise_ThrowsNotSupported()
+    {
+        // Arrange
+        using var context = new Z3Context();
+        var theorem = context.NewTheorem<Symbols<byte, int>>()
+            .Where(t => (t.X1 & 6) == 4);
+
+        // Act & Assert
+        Should.Throw<NotSupportedException>(() => theorem.Solve());
+    }
+
+    [TestMethod]
+    public void Solve_ByteArrayElement_RoundTripsTheValue()
+    {
+        // Arrange: the element read has its own arm, so byte has to work there too.
+        using var context = new Z3Context();
+
+        // Act
+        var result = context.NewTheorem<ByteArrayEnvironment>()
+            .Where(t => t.Values[0] == 42)
+            .Where(t => t.Length == 2)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.Values.Length.ShouldBe(2);
+        result.Values[0].ShouldBe((byte)42);
+    }
+
+    private sealed class ByteArrayEnvironment
+    {
+        public byte[] Values { get; set; } = new byte[2];
+
+        public int Length { get; set; }
+    }
+}

--- a/solutions/Z3.Linq.Tests/UnsupportedExpressionTests.cs
+++ b/solutions/Z3.Linq.Tests/UnsupportedExpressionTests.cs
@@ -50,12 +50,12 @@ public class UnsupportedExpressionTests
     /// A cast to a type the sort mapping does not know falls through to the catch-all.
     /// </summary>
     /// <remarks>
-    /// This pinned <c>(long)t.X1</c> until #76, when the Convert case chose by target type and
-    /// had no arm for <c>long</c>. Conversions are now decided by the sorts involved, using the
-    /// same mapping the symbols are declared with, so what is unsupported is a target type that
-    /// mapping has no row for - <c>byte</c> here. Note this one is NotImplementedException
-    /// rather than NotSupportedException - the throw sites are not consistent about which they
-    /// use.
+    /// This pinned <c>(long)t.X1</c> until #76, then <c>(byte)</c> until byte became a supported
+    /// integer type. Conversions are decided by the sorts involved, using the same mapping the
+    /// symbols are declared with, so what is unsupported is a target type that mapping has no row
+    /// for - <c>nint</c> here, whose <c>TypeCode</c> is <c>Object</c>. Note this one is
+    /// NotImplementedException rather than NotSupportedException - the throw sites are not
+    /// consistent about which they use.
     /// </remarks>
     [TestMethod]
     public void Solve_CastToAnUnmappedType_ThrowsNotImplementedException()
@@ -63,7 +63,7 @@ public class UnsupportedExpressionTests
         // Arrange
         using var context = new Z3Context();
         var theorem = context.NewTheorem<Symbols<int, int>>()
-            .Where(t => (byte)t.X1 == 1);
+            .Where(t => (nint)t.X1 == 1);
 
         // Act & Assert
         Should.Throw<NotImplementedException>(() => theorem.Solve());
@@ -77,20 +77,6 @@ public class UnsupportedExpressionTests
         // which is worth knowing when diagnosing one of these.
         using var context = new Z3Context();
         var theorem = context.NewTheorem<CharEnvironment>().Where(t => t.Other == 1);
-
-        // Act & Assert
-        Should.Throw<NotSupportedException>(() => theorem.Solve());
-    }
-
-    [TestMethod]
-    public void Solve_ByteProperty_ThrowsNotSupportedException()
-    {
-        // Arrange: byte and ushort are deliberately not mapped, even though uint and ulong are
-        // bit-vectors - because C# promotes byte and ushort to int in every expression, so such a
-        // symbol could never keep a bit-vector sort through a constraint. See the bit-vector work
-        // and BitVectorSymbolTests.
-        using var context = new Z3Context();
-        var theorem = context.NewTheorem<ByteEnvironment>().Where(t => t.Other == 1);
 
         // Act & Assert
         Should.Throw<NotSupportedException>(() => theorem.Solve());
@@ -111,36 +97,31 @@ public class UnsupportedExpressionTests
     }
 
     /// <summary>
-    /// An enum whose underlying type is not one the environment builder maps is rejected by
-    /// name, before anything is translated.
+    /// A <c>byte</c>-backed enum round-trips, like an <c>int</c>-backed one.
     /// </summary>
     /// <remarks>
-    /// <para>
-    /// An enum is only ever as supported as its underlying type. #63 fixed the <c>int</c>-backed
-    /// case - <see cref="DayOfWeek"/> and friends - which is now round-tripped in
-    /// <c>SymbolTypeMarshallingTests</c>. A <c>byte</c>-backed enum is <c>TypeCode.Byte</c>,
-    /// which the sort mapping does not handle, so it stops at the same guard that rejects a
-    /// bare <c>byte</c> or <c>ushort</c>.
-    /// </para>
-    /// <para>
-    /// This is the outcome #63 asked for where a type genuinely is not supported: a
-    /// <see cref="NotSupportedException"/> naming the member, rather than an
-    /// <see cref="InvalidCastException"/> from inside the visitor. Pinned so the distinction
-    /// between the two enum cases does not quietly collapse.
-    /// </para>
+    /// An enum is only ever as supported as its underlying type. #63 made the <c>int</c>-backed
+    /// case work, and once <c>byte</c>, <c>sbyte</c> and <c>ushort</c> became supported integer
+    /// types every enum underlying type is one the sort mapping handles - so a <c>byte</c>-backed
+    /// enum is created as a bounded integer and read back through reflection like any other.
+    /// Whether the value is constrained to the defined members is a separate question, #97.
     /// </remarks>
     [TestMethod]
-    public void Solve_EnumPropertyWithAnUnsupportedUnderlyingType_ThrowsNotSupportedException()
+    public void Solve_ByteBackedEnumProperty_RoundTripsTheValue()
     {
         // Arrange
         using var context = new Z3Context();
-        var theorem = context.NewTheorem<ByteEnumEnvironment>()
-            .Where(t => t.Size == ByteBackedEnum.Large)
-            .Where(t => t.Other == 1);
 
-        // Act & Assert
-        Should.Throw<NotSupportedException>(() => theorem.Solve())
-            .Message.ShouldContain("Size");
+        // Act
+        var result = context.NewTheorem<ByteEnumEnvironment>()
+            .Where(t => t.Size == ByteBackedEnum.Large)
+            .Where(t => t.Other == 1)
+            .Solve();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.Size.ShouldBe(ByteBackedEnum.Large);
+        result.Other.ShouldBe(1);
     }
 
     [TestMethod]
@@ -178,13 +159,6 @@ public class UnsupportedExpressionTests
     private sealed class CharEnvironment
     {
         public char Value { get; set; }
-
-        public int Other { get; set; }
-    }
-
-    private sealed class ByteEnvironment
-    {
-        public byte Value { get; set; }
 
         public int Other { get; set; }
     }

--- a/solutions/Z3.Linq/ExpressionVisitor.cs
+++ b/solutions/Z3.Linq/ExpressionVisitor.cs
@@ -472,7 +472,10 @@ internal sealed class ExpressionVisitor
     {
         switch (Type.GetTypeCode(val.GetType()))
         {
+            case TypeCode.SByte:
+            case TypeCode.Byte:
             case TypeCode.Int16:
+            case TypeCode.UInt16:
             case TypeCode.Int32:
             case TypeCode.Int64:
                 return this.context.MkInt(Convert.ToInt64(val));

--- a/solutions/Z3.Linq/Theorem.cs
+++ b/solutions/Z3.Linq/Theorem.cs
@@ -397,7 +397,10 @@ public class Theorem
     {
         return typeCode switch
         {
+            TypeCode.SByte => (sbyte.MinValue, sbyte.MaxValue),
+            TypeCode.Byte => (byte.MinValue, byte.MaxValue),
             TypeCode.Int16 => (short.MinValue, short.MaxValue),
+            TypeCode.UInt16 => (ushort.MinValue, ushort.MaxValue),
             TypeCode.Int32 => (int.MinValue, int.MaxValue),
             TypeCode.Int64 => (long.MinValue, long.MaxValue),
             TypeCode.DateTime => (DateTime.MinValue.Ticks, DateTime.MaxValue.Ticks),
@@ -448,7 +451,7 @@ public class Theorem
         return typeCode switch
         {
             TypeCode.String => context.StringSort,
-            TypeCode.Int16 or TypeCode.Int32 or TypeCode.Int64 or TypeCode.DateTime => context.IntSort,
+            TypeCode.SByte or TypeCode.Byte or TypeCode.Int16 or TypeCode.UInt16 or TypeCode.Int32 or TypeCode.Int64 or TypeCode.DateTime => context.IntSort,
             TypeCode.Boolean => context.BoolSort,
             TypeCode.Single or TypeCode.Decimal or TypeCode.Double => context.RealSort,
             TypeCode.UInt32 or TypeCode.UInt64 => context.MkBitVecSort(BitVectorWidth(typeCode)!.Value),
@@ -463,13 +466,18 @@ public class Theorem
     /// <param name="typeCode">The type code of the CLR type.</param>
     /// <returns>The bit width, or <see langword="null"/>.</returns>
     /// <remarks>
+    /// <para>
     /// <c>uint</c> and <c>ulong</c> travel through Z3 as bit-vectors of their width - so they
     /// carry wrapping arithmetic, bitwise operators and shifts, which a mathematical integer has
-    /// no counterpart for. <c>short</c>, <c>int</c> and <c>long</c> stay unbounded integers.
-    /// <c>byte</c> and <c>ushort</c> are deliberately not mapped: C# promotes them to <c>int</c>
-    /// in every expression, so a <c>byte</c> symbol could never keep its bit-vector sort through
-    /// a constraint, and mapping it would only produce a confusing conversion error rather than a
-    /// usable symbol.
+    /// no counterpart for.
+    /// </para>
+    /// <para>
+    /// <c>byte</c>, <c>sbyte</c> and <c>ushort</c> are not bit-vectors: C# promotes them to
+    /// <c>int</c> in every expression, so such a symbol could never keep a bit-vector sort through
+    /// a constraint. They map to the integer sort instead, bounded to their range like
+    /// <c>short</c> - so they support equality, ordering and arithmetic but not bitwise operators,
+    /// which need one of the bit-vector types above.
+    /// </para>
     /// </remarks>
     internal static uint? BitVectorWidth(TypeCode typeCode)
     {
@@ -684,6 +692,15 @@ public class Theorem
                             // an unchecked cast would wrap it into a plausible wrong answer. See #63.
                             numVal = checked((short)((IntNum)numValExpr).Int);
                             break;
+                        case TypeCode.SByte:
+                            numVal = checked((sbyte)((IntNum)numValExpr).Int);
+                            break;
+                        case TypeCode.Byte:
+                            numVal = checked((byte)((IntNum)numValExpr).Int);
+                            break;
+                        case TypeCode.UInt16:
+                            numVal = checked((ushort)((IntNum)numValExpr).Int);
+                            break;
                         case TypeCode.Int32:
                             numVal = ((IntNum)numValExpr).Int;
                             break;
@@ -756,6 +773,15 @@ public class Theorem
                     // asserted, so the check cannot fire here, but it costs nothing and the element
                     // arm above still depends on it. See #63.
                     value = checked((short)((IntNum)val).Int);
+                    break;
+                case TypeCode.SByte:
+                    value = checked((sbyte)((IntNum)val).Int);
+                    break;
+                case TypeCode.Byte:
+                    value = checked((byte)((IntNum)val).Int);
+                    break;
+                case TypeCode.UInt16:
+                    value = checked((ushort)((IntNum)val).Int);
                     break;
                 case TypeCode.Int32:
                     value = ((IntNum)val).Int;


### PR DESCRIPTION
Makes `byte`, `sbyte` and `ushort` usable as symbols - the case the bit-vector work (#101) left
with no user-side workaround: a `byte` or `ushort` member on an environment type a caller cannot
rewrite to `uint`.

## Why they are integers, not bit-vectors

#101 explained that `byte`/`ushort` cannot be bit-vectors: C# promotes them to `int` in every
expression, so `byte & byte` is computed in `int` space, and a bit-vector `byte` symbol would lose
its sort at the `Convert(byte -> int)` the compiler inserts. This PR maps them to the **integer
sort** instead, which turns that same promotion into a no-op - the symbol is already an integer, so
`Convert(byte -> int)` passes straight through. That is exactly the mechanism that already makes
`short` work; `byte`, `sbyte` and `ushort` are its remaining siblings.

So they support equality, ordering and arithmetic; they do **not** support bitwise operators or
shifts, which have no integer counterpart and need `uint`/`ulong`.

## The change

Additive, ~20 lines of library code:

- `TryGetSymbolSort` gains `sbyte`/`byte`/`ushort` in its integer row.
- `GetBounds` gains their ranges - `[0,255]`, `[-128,127]`, `[0,65535]` - so #87 bounds a value
  the type cannot hold to unsatisfiable rather than reading it back wrong.
- Both read paths gain checked reads, like `short`.
- `VisitConstantValue` folds them into the integer-constant arm.

Measured across every shape: round-trip (incl. each boundary), `Optimize` returning the type's
extreme (`byte` -> 255, `sbyte` -> -128, `ushort` -> 65535), out-of-range -> unsatisfiable,
arithmetic, and array elements.

## Enum and cast consequences, handled

Two existing pins changed subject because the supported-type set grew, and both are updated to
match the new truth rather than worked around:

- **Every enum underlying type is now supported** (`byte`/`sbyte`/`short`/`ushort`/`int`/`long`
  -> integer, `uint`/`ulong` -> bit-vector). So a `byte`-backed enum now round-trips like an
  `int`-backed one - measured. `Solve_EnumPropertyWithAnUnsupportedUnderlyingType_ThrowsNotSupportedException`
  becomes `Solve_ByteBackedEnumProperty_RoundTripsTheValue`. (Member-constraining is still #97.)
- **The unmapped-cast pin moves from `(byte)` to `(nint)`.** `byte` is now a mapped type, so a
  cast to it resolves; `nint`'s `TypeCode` is `Object`, which the mapping genuinely has no row
  for, so it still hits the conversion catch-all.

## Tests

305 -> 321. A new `SmallIntegerSymbolTests` for the three types, plus the two repointed pins above
and the removal of the byte-not-supported pin from #101.

| Test | Covers |
|---|---|
| `Solve_{Byte,SByte,UShort}Symbol_RoundTripsTheValue` | round-trip, each with boundary rows |
| `Solve_ByteSymbolsInArithmetic_RoundTripTheValues` | promotion is a no-op against the int-sorted symbols |
| `Optimize_{Byte,SByte,UShort}Symbol{Max,Min}imised_*` | the range bound makes the extreme the type's extreme |
| `Solve_ByteSymbolConstrainedOutsideItsRange_IsUnsatisfiable` | #87 bound enforced |
| `Solve_ByteBitwise_ThrowsNotSupported` | bitwise still refused - byte is an integer, not a bit-vector |
| `Solve_ByteArrayElement_RoundTripsTheValue` | the element read arm |
| `Solve_ByteBackedEnumProperty_RoundTripsTheValue` (repointed) | enum underlying types all supported |

## Mutation results

| Mutation | Failures | Which |
|---|---|---|
| `byte`/`sbyte`/`ushort` not mapped to a sort | **17** | every small-integer test, the arithmetic and element ones, and the byte-backed enum |
| No `byte` bounds row | **2** | the byte maximise and out-of-range tests |
| No `ushort` bounds row | **1** | the ushort maximise test |
| No `sbyte` bounds row | **1** | the sbyte minimise test |

The doc guard from #82 also earned its place mid-change: an unbalanced `<para>` in the reworded
`BitVectorWidth` remark was a `CS1570` build error, caught and fixed before it could ship.

## Verification

- `dotnet build solutions/Z3.Linq.slnx -c Release` - clean, `TreatWarningsAsErrors` and
  documentation generation on
- 321/321 locally
- `./build.ps1 -Configuration Release` - 46 tasks, 0 errors, 0 warnings
- Coverage 89.0% -> 88.5% line (916 of 1034), 77.2% -> 78.2% branch (607 of 776); the line
  percentage dips only because the two read switches gained three arms each that the scalar tests
  exercise but the element tests reach for one type

## Release note

Releases remain on hold under #60 until Microsoft.Z3 5.x reaches nuget.org, so this reaches `main`
but not consumers. The public surface gains `byte`/`sbyte`/`ushort` symbol support; nothing is
removed.
