### PR TITLE
Fix two defects in the solve-limits code found by review

### DIFF
--- a/solutions/Z3.Linq.Tests/SolveLimitTests.cs
+++ b/solutions/Z3.Linq.Tests/SolveLimitTests.cs
@@ -46,6 +46,28 @@ public class SolveLimitTests
     }
 
     /// <summary>
+    /// A sub-millisecond timeout still bounds the solve, rather than silently becoming no timeout.
+    /// </summary>
+    /// <remarks>
+    /// Z3's timeout is whole milliseconds, and a <see cref="TimeSpan"/> below one millisecond used
+    /// to truncate to 0 - which Z3 reads as unlimited - so a caller who asked for a tiny timeout
+    /// would hang on an undecidable theorem. A positive timeout now rounds up to at least one
+    /// millisecond. The <see cref="TimeoutAttribute"/> fails this test rather than hanging if the
+    /// truncation returns.
+    /// </remarks>
+    [TestMethod]
+    [Timeout(HangGuardMilliseconds)]
+    public void Solve_UndecidableTheoremWithASubMillisecondTimeout_StillThrows()
+    {
+        // Arrange
+        using var context = new Z3Context { Timeout = TimeSpan.FromMilliseconds(0.5) };
+        var theorem = SumOfThreeCubes(context);
+
+        // Act & Assert
+        Should.Throw<TheoremUndecidedException>(() => theorem.Solve());
+    }
+
+    /// <summary>
     /// A solve that stopped without deciding throws rather than returning <see langword="false"/>.
     /// </summary>
     /// <remarks>

--- a/solutions/Z3.Linq/Theorem.cs
+++ b/solutions/Z3.Linq/Theorem.cs
@@ -238,7 +238,10 @@ public class Theorem
     {
         cancellationToken.ThrowIfCancellationRequested();
 
-        Params? limits = this.context.CreateLimits(ctx);
+        // Disposed when this method returns, after the check has run: Params is native-backed, and
+        // the solver has copied what it needs by the time Check completes. A null (no limits set)
+        // is a no-op to dispose.
+        using Params? limits = this.context.CreateLimits(ctx);
 
         switch (approach)
         {

--- a/solutions/Z3.Linq/Z3Context.cs
+++ b/solutions/Z3.Linq/Z3Context.cs
@@ -179,7 +179,12 @@ public sealed class Z3Context : IDisposable
 
         if (this.timeout is { } t)
         {
-            limits.Add("timeout", (uint)t.TotalMilliseconds);
+            // Round up, not truncate: Z3's timeout is in whole milliseconds, and a positive
+            // TimeSpan below one millisecond truncates to 0, which Z3 reads as "no timeout" - so
+            // a caller who asked for a tiny timeout would silently get none. Ceiling keeps any
+            // positive timeout at least one millisecond, and stays within uint (the setter bounds
+            // the value at uint.MaxValue milliseconds).
+            limits.Add("timeout", (uint)Math.Ceiling(t.TotalMilliseconds));
         }
 
         if (this.resourceLimit is { } r)


### PR DESCRIPTION
Fixes two defects a code review of the stack found in the solve-limits work (#96), each verified
by measurement before fixing.

## The two defects

**A native `Params` leak.** `Z3Context.CreateLimits` builds a `Microsoft.Z3.Params` - which is
`IDisposable`, backed by native memory - and `Theorem.Check` assigned it to the solver and dropped
it without disposing. Every `Solve`/`Optimize` that set a `Timeout` or `ResourceLimit` leaked one.
It is now a `using`, disposed when `Check` returns, by which point the solver has copied what it
needs.

**A sub-millisecond timeout silently became no timeout.** `(uint)TimeSpan.FromMilliseconds(0.5).TotalMilliseconds`
is `0`, and Z3 reads `timeout=0` as unlimited - so a caller who asked for a tiny timeout got none
and would hang on an undecidable theorem, exactly the failure the timeout was meant to prevent. The
value now rounds up (`Math.Ceiling`), so any positive timeout is at least one millisecond. Measured:
`Timeout = 0.5ms` on the sum-of-three-cubes theorem now throws `TheoremUndecidedException` in ~1ms
instead of running unbounded.

## Verified, not a defect

The same review raised, at low confidence, that maximising an unsigned bit-vector might use signed
ordering. Measured and it does not: `MkMaximize` on a bit-vector is unsigned, so a `uint` symbol
constrained to `[2e9, 3e9]` maximises to `2999999999` and minimises to `2000000001` - both the
unsigned-correct extremes. No change needed; noted here so the finding is closed with evidence.

## Not in scope (pre-existing / documented)

- The review noted the `double`/`float` read paths do not strip Z3's trailing `?` for a
  non-terminating rational, unlike the `decimal` arms. That is on `main` unchanged, is open issue
  **#6**, and is already pinned by
  `Solve_{Double,Float}SymbolWithANonTerminatingValue_ThrowsFormatException`. Not a regression from
  this stack.
- It also noted that a conversion involving a bit-vector operand (`(ulong)uintSymbol`,
  `(int)uintSymbol`) throws `NotImplementedException`. That is the documented limitation from #101 -
  mixing a bit-vector with a conversion is not supported - and it correctly refuses; the raw
  exception type is the pre-existing throw-site inconsistency, tracked separately.

## Tests

321 -> 322: `Solve_UndecidableTheoremWithASubMillisecondTimeout_StillThrows`, guarded by
`[Timeout]` so a return to truncation fails the test rather than hanging. The leak fix is not
behaviourally testable - a leak fails no test - so it is verified by inspection (the `using`) and
the green suite; reverting the timeout fix fails the new test, reverting the `using` fails nothing,
as expected.

## Verification

- `dotnet build solutions/Z3.Linq.slnx -c Release` - clean, `TreatWarningsAsErrors` and
  documentation generation on
- 322/322 locally
- `./build.ps1 -Configuration Release` - 46 tasks, 0 errors, 0 warnings
- Coverage 88.5% -> 88.6% line (918 of 1036), branch unchanged at 78.2%

## Release note

Releases remain on hold under #60 until Microsoft.Z3 5.x reaches nuget.org, so this reaches `main`
but not consumers. Nothing about the hold changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
