### PR TITLE
Add a BenchmarkDotNet suite for solve hot paths

### DIFF
--- a/solutions/Directory.Packages.props
+++ b/solutions/Directory.Packages.props
@@ -19,4 +19,8 @@
     <PackageVersion Include="Shouldly" Version="4.3.0" />
   </ItemGroup>
 
+  <ItemGroup Label="Benchmarking">
+    <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
+  </ItemGroup>
+
 </Project>

--- a/solutions/Z3.Linq.Benchmarks/Program.cs
+++ b/solutions/Z3.Linq.Benchmarks/Program.cs
@@ -1,0 +1,20 @@
+namespace Z3.Linq.Benchmarks;
+
+using BenchmarkDotNet.Running;
+
+/// <summary>
+/// Entry point for the Z3.Linq benchmark suite.
+/// </summary>
+/// <remarks>
+/// Uses <see cref="BenchmarkSwitcher"/> rather than a single <c>BenchmarkRunner.Run</c> so the
+/// suite is driven from the command line - <c>dotnet run -c Release -- --filter '*'</c> runs
+/// everything, <c>--filter '*Solve*'</c> a subset, <c>--list flat</c> enumerates them. See the
+/// project README for the optimise/re-measure loop.
+/// </remarks>
+public static class Program
+{
+    public static void Main(string[] args)
+    {
+        BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+    }
+}

--- a/solutions/Z3.Linq.Benchmarks/README.md
+++ b/solutions/Z3.Linq.Benchmarks/README.md
@@ -1,0 +1,73 @@
+# Z3.Linq.Benchmarks
+
+A [BenchmarkDotNet](https://benchmarkdotnet.org/) suite for finding performance and memory hot paths
+in Z3.Linq, and for confirming an optimisation actually helped.
+
+## What it measures
+
+The benchmarks solve theorems that Z3 decides in microseconds, so the time and - more usefully - the
+`Allocated` column are dominated by the **library's** per-solve work, not the solver: building the
+environment by reflection, translating the constraint expression trees, and marshalling the model
+back onto the CLR members. Nothing is cached across solves today, so re-solving the same theorem
+re-does all of that every time - which is exactly what these numbers can be used to change.
+
+`SolveBenchmarks` covers the shapes that stress different parts of that path:
+
+| Benchmark | Exercises |
+|---|---|
+| `ScalarSymbols` (baseline) | a flat `Symbols<int,int>` |
+| `ValueTuple` | the value-tuple environment path |
+| `NestedObject` | recursive marshalling of a nested object |
+| `Collection` | the array element loop |
+| `WideSymbols` | more members to reflect and translate (`Symbols<int,int,int,int,int>`) |
+| `Optimize` | the optimiser's own solve path |
+
+## Running it
+
+BenchmarkDotNet refuses to run outside Release.
+
+```bash
+cd solutions/Z3.Linq.Benchmarks
+
+# everything
+dotnet run -c Release -- --filter '*'
+
+# one shape
+dotnet run -c Release -- --filter '*NestedObject*'
+
+# list what's available
+dotnet run -c Release -- --list flat
+
+# a fast sanity run (one shot each, NOT accurate - for wiring only)
+dotnet run -c Release -- --filter '*' --job dry
+```
+
+Results print to the console and are written under `BenchmarkDotNet.Artifacts/results/` as GitHub
+markdown; add `--exporters json` for machine-readable output.
+
+## The optimisation loop
+
+1. Run the suite and read the `Allocated` and `Mean` columns - the shape that allocates most, or the
+   one that scales worst as members/constraints grow, is where to look.
+2. Find the allocation in the library (reflection over the environment type, the `ArrayList` and
+   `ToArray` in the marshalling loop, boxing of value-type members, the per-solve attribute lookups)
+   and change it.
+3. Re-run the same filter and compare. Keep the `[Benchmark(Baseline = true)]` scalar case as the
+   reference; the `Ratio` column shows movement relative to it.
+
+For regression tracking across commits, export JSON and diff with the
+[`bdna`](https://github.com/NewdayTechnology/benchmarkdotnet.analyser) tool, as the endjin
+BenchmarkDotNet guidelines describe:
+
+```bash
+dotnet run -c Release -- --exporters json
+dotnet bdna aggregate --new ./BenchmarkDotNet.Artifacts/results --aggregates ./aggregates --output ./aggregates
+dotnet bdna analyse --aggregates ./aggregates --tolerance 10
+```
+
+## Extending it
+
+Add a `[Benchmark]` method for any shape or path you want to track - build the theorem once in
+`[GlobalSetup]` and measure only the `Solve`/`Optimize`, so the query construction is not counted.
+Return the result (do not discard it) so the JIT cannot eliminate the call. To measure how cost
+scales, add a `[Params]`-driven count (of constraints or symbols) rather than a fixed theorem.

--- a/solutions/Z3.Linq.Benchmarks/SolveBenchmarks.cs
+++ b/solutions/Z3.Linq.Benchmarks/SolveBenchmarks.cs
@@ -1,0 +1,141 @@
+namespace Z3.Linq.Benchmarks;
+
+using BenchmarkDotNet.Attributes;
+
+using Z3.Linq;
+
+/// <summary>
+/// End-to-end <c>Solve</c>/<c>Optimize</c> across the environment shapes the library supports,
+/// with <see cref="MemoryDiagnoserAttribute"/> so the allocation of each shape is visible.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Each benchmark solves a theorem that Z3 decides in microseconds, so the time and - more usefully
+/// - the allocation are dominated by the library's own per-solve work rather than by the solver:
+/// building the environment by reflection, translating the constraint expression trees, and
+/// marshalling the model back onto the CLR members. That is exactly the work an optimisation would
+/// target, and the <c>Allocated</c> column is where a hot path shows up.
+/// </para>
+/// <para>
+/// The theorem for each shape is built once in <see cref="Setup"/>; the benchmark measures only the
+/// solve, which rebuilds the environment and translation every time (nothing is cached across
+/// solves today - the point these numbers can be used to change). The shapes are chosen to exercise
+/// different parts of that path: a flat symbol set, a value tuple, a nested object (recursive
+/// marshalling), a collection (the element loop), a wider symbol set (more members to reflect and
+/// translate), and an optimisation (the optimiser's own solve path).
+/// </para>
+/// </remarks>
+[MemoryDiagnoser]
+public class SolveBenchmarks
+{
+    private Z3Context context = null!;
+    private Theorem<Symbols<int, int>> scalar = null!;
+    private Theorem<(int A, int B)> tuple = null!;
+    private Theorem<NestedEnvironment> nested = null!;
+    private Theorem<CollectionEnvironment> collection = null!;
+    private Theorem<Symbols<int, int, int, int, int>> wide = null!;
+    private Theorem<Symbols<int, int>> optimizeSource = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        this.context = new Z3Context();
+
+        this.scalar = this.context.NewTheorem<Symbols<int, int>>()
+            .Where(t => t.X1 == 42)
+            .Where(t => t.X2 == t.X1 + 1);
+
+        this.tuple = this.context.NewTheorem<(int A, int B)>()
+            .Where(t => t.A == 3)
+            .Where(t => t.B == t.A * 2);
+
+        this.nested = this.context.NewTheorem<NestedEnvironment>()
+            .Where(t => t.Inner.A == 4)
+            .Where(t => t.Inner.B == t.Top * 2)
+            .Where(t => t.Top == 5);
+
+        this.collection = this.context.NewTheorem<CollectionEnvironment>()
+            .Where(t => t.Values[0] == 10)
+            .Where(t => t.Values[1] == 20)
+            .Where(t => t.Values[2] == 30)
+            .Where(t => t.Length == 3);
+
+        this.wide = this.context.NewTheorem<Symbols<int, int, int, int, int>>()
+            .Where(t => t.X1 == 1)
+            .Where(t => t.X2 == 2)
+            .Where(t => t.X3 == 3)
+            .Where(t => t.X4 == 4)
+            .Where(t => t.X5 == 5);
+
+        this.optimizeSource = this.context.NewTheorem<Symbols<int, int>>()
+            .Where(t => t.X1 >= 0)
+            .Where(t => t.X1 <= 100)
+            .Where(t => t.X2 == 1);
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        this.context.Dispose();
+    }
+
+    [Benchmark(Baseline = true)]
+    public Symbols<int, int>? ScalarSymbols()
+    {
+        return this.scalar.Solve();
+    }
+
+    [Benchmark]
+    public (int A, int B) ValueTuple()
+    {
+        return this.tuple.Solve();
+    }
+
+    // Returns object? (not the private environment type) so the public benchmark method does not
+    // expose a nested type; the reference-type result is not boxed, so the allocation figures stay
+    // honest.
+    [Benchmark]
+    public object? NestedObject()
+    {
+        return this.nested.Solve();
+    }
+
+    [Benchmark]
+    public object? Collection()
+    {
+        return this.collection.Solve();
+    }
+
+    [Benchmark]
+    public Symbols<int, int, int, int, int>? WideSymbols()
+    {
+        return this.wide.Solve();
+    }
+
+    [Benchmark]
+    public Symbols<int, int>? Optimize()
+    {
+        return this.optimizeSource.Optimize(Optimization.Maximize, t => t.X1);
+    }
+
+    private sealed class NestedEnvironment
+    {
+        public InnerEnvironment Inner { get; set; } = new();
+
+        public int Top { get; set; }
+    }
+
+    private sealed class InnerEnvironment
+    {
+        public int A { get; set; }
+
+        public int B { get; set; }
+    }
+
+    private sealed class CollectionEnvironment
+    {
+        public int[] Values { get; set; } = new int[3];
+
+        public int Length { get; set; }
+    }
+}

--- a/solutions/Z3.Linq.Benchmarks/Z3.Linq.Benchmarks.csproj
+++ b/solutions/Z3.Linq.Benchmarks/Z3.Linq.Benchmarks.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
+    <RootNamespace>Z3.Linq.Benchmarks</RootNamespace>
+    <!-- Benchmark classes and methods are the surface of a runnable tool, driven by
+         BenchmarkDotNet's attributes, not a public API - a doc comment on each [Benchmark] would
+         add nothing. The comments they do carry are still validated (Directory.Build.props). -->
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <!-- BenchmarkDotNet refuses to run outside Release; building in any configuration is fine. -->
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Z3.Linq\Z3.Linq.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/solutions/Z3.Linq.slnx
+++ b/solutions/Z3.Linq.slnx
@@ -12,4 +12,5 @@
   <Project Path="Z3.Linq.Examples/Z3.Linq.Examples.csproj" />
   <Project Path="Z3.Linq.Demo/Z3.Linq.Demo.csproj" />
   <Project Path="Z3.Linq.Tests/Z3.Linq.Tests.csproj" />
+  <Project Path="Z3.Linq.Benchmarks/Z3.Linq.Benchmarks.csproj" />
 </Solution>


### PR DESCRIPTION
Adds a `Z3.Linq.Benchmarks` project - a [BenchmarkDotNet](https://benchmarkdotnet.org/) suite,
following the endjin BenchmarkDotNet guidelines, for finding performance and memory hot paths in
the library and confirming an optimisation actually helped. It measures; it changes no library
code.

## What it measures, and why it's the right thing

`SolveBenchmarks` runs end-to-end `Solve`/`Optimize` over six environment shapes, each against a
theorem Z3 decides in **microseconds**. That is deliberate: with the solver's own work negligible,
the time and - more usefully - the `MemoryDiagnoser` `Allocated` column are dominated by the
**library's** per-solve work: building the environment by reflection, translating the constraint
expression trees, and marshalling the model back onto the CLR members. Nothing is cached across
solves today, so re-solving the same theorem re-does all of it - which is exactly what these numbers
can be used to change.

| Benchmark | Exercises |
|---|---|
| `ScalarSymbols` (baseline) | a flat `Symbols<int,int>` |
| `ValueTuple` | the value-tuple environment path |
| `NestedObject` | recursive marshalling of a nested object |
| `Collection` | the array element loop |
| `WideSymbols` | more members to reflect and translate (`Symbols<int,int,int,int,int>`) |
| `Optimize` | the optimiser's own solve path |

Each theorem is built once in `[GlobalSetup]`; the benchmark measures only the solve, and returns
the result so the JIT cannot eliminate the call.

## It already points somewhere

A first `--job dry` run (allocation is meaningful even in Dry; the Dry `Mean` is not) - relative to
the flat-symbol baseline:

| Shape | Allocated | vs baseline |
|---|---|---|
| `ValueTuple` | 4.5 KB | 0.4x |
| `ScalarSymbols` | 11.6 KB | 1.0x |
| `NestedObject` | 20.1 KB | 1.7x |
| `Optimize` | 24.6 KB | 2.1x |
| `WideSymbols` | 24.7 KB | 2.1x |
| `Collection` | 26.3 KB | 2.3x |

The collection path allocates over twice the flat baseline, and the nested/wide/optimise shapes
around twice - the marshalling loop (`ArrayList` + `ToArray`, boxing), the recursive marshalling,
and the per-solve reflection. That is the map an optimisation would follow; this PR just draws it.

## The loop it enables

1. Run the suite; the `Allocated`/`Mean` columns say which shape to look at.
2. Change the allocation in the library (the marshalling loop, the per-solve `GetProperties` /
   `GetCustomAttributes` reflection, boxing of value-type members).
3. Re-run the same filter; `Ratio` and `Alloc Ratio` against the baseline show the movement.

JSON export plus the `bdna` tool tracks regressions across commits, as the README and the endjin
guidelines describe.

## Wiring

- New `solutions/Z3.Linq.Benchmarks/` (Exe, `IsPackable=false`), referencing `Z3.Linq`.
- `BenchmarkDotNet` 0.15.8 added to central package management; the project references it
  version-less like every other package here.
- Added to `Z3.Linq.slnx`, so it builds with the solution (validated) but - being a plain Exe, not
  a test project - is not run by `dotnet test`.
- `CS1591` suppressed as on the test/examples/demo projects; a `[Benchmark]` method is a tool
  surface, not an API.
- `BenchmarkDotNet.Artifacts/` was already in `.gitignore`; no artifacts are committed.

## Verification

- `dotnet build solutions/Z3.Linq.slnx -c Release` - clean, `TreatWarningsAsErrors` and
  documentation generation on
- The suite runs: `dotnet run -c Release --project solutions/Z3.Linq.Benchmarks -- --filter '*' --job dry`
  executed all six benchmarks and produced the memory table above
- 322/322 tests unchanged - this PR adds no library code
- `./build.ps1 -Configuration Release` - 46 tasks, 0 errors, 0 warnings, with the new project in
  the build

## Release note

No library or public-API change - a developer tool that ships with the source, not the package.
Releases remain on hold under #60 regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
