### PR TITLE
Modernise the solve path with C# 14 idioms

### DIFF
--- a/solutions/Z3.Linq/ExpressionVisitor.cs
+++ b/solutions/Z3.Linq/ExpressionVisitor.cs
@@ -524,7 +524,7 @@ internal sealed class ExpressionVisitor
         // E.g. Symbols l = ...;
         //      theorem.Where(s => l.X1)
         //                         ^^
-        var hierarchy = new List<MemberExpression>();
+        List<MemberExpression> hierarchy = [];
         var mExp = member;
         hierarchy.Add(mExp);
 

--- a/solutions/Z3.Linq/ExpressionVisitor.cs
+++ b/solutions/Z3.Linq/ExpressionVisitor.cs
@@ -472,40 +472,36 @@ internal sealed class ExpressionVisitor
     /// <returns>Z3 expression handle.</returns>
     private Expr VisitConstantValue(object val)
     {
-        switch (Type.GetTypeCode(val.GetType()))
+        TypeCode typeCode = Type.GetTypeCode(val.GetType());
+
+        return typeCode switch
         {
-            case TypeCode.SByte:
-            case TypeCode.Byte:
-            case TypeCode.Int16:
-            case TypeCode.UInt16:
-            case TypeCode.Int32:
-            case TypeCode.Int64:
-                return this.context.MkInt(Convert.ToInt64(val));
-            case TypeCode.UInt32:
-            case TypeCode.UInt64:
-                // uint and ulong are bit-vectors of their width. See #99's bit-vector follow-up.
-                return this.context.MkBV(Convert.ToUInt64(val), Theorem.BitVectorWidth(Type.GetTypeCode(val.GetType()))!.Value);
-            case TypeCode.Boolean:
-                return this.context.MkBool((bool)val);
-            case TypeCode.Single:
-            case TypeCode.Double:
-            case TypeCode.Decimal:
-                // Invariant, not current: Z3's parser accepts only '.' as the decimal separator,
-                // and about half of all cultures render 1.5 as something else. See #52.
-                return this.context.MkReal(((IFormattable)val).ToString(null, CultureInfo.InvariantCulture));
-            case TypeCode.DateTime:
-                // A DateTime is encoded as its ticks - 100ns intervals from 0001-01-01 - on the UTC
-                // timeline, which covers the whole DateTime range. A Windows file time counted from
-                // 1601 instead, so nothing earlier could be written or read. See #83.
-                //
-                // A Kind of Local is converted to UTC first; Unspecified is taken to be UTC already,
-                // which is the convention ToFileTimeUtc had and the read path inverts. See #56.
-                return this.context.MkInt(ToUtcTicks((DateTime)val));
-            case TypeCode.String:
-                return this.context.MkString((string)val);
-            default:
-                throw new NotSupportedException($"Unsupported constant {val}");
-        }
+            TypeCode.SByte or TypeCode.Byte or TypeCode.Int16 or TypeCode.UInt16 or TypeCode.Int32 or TypeCode.Int64
+                => this.context.MkInt(Convert.ToInt64(val)),
+
+            // uint and ulong are bit-vectors of their width. See #99's bit-vector follow-up.
+            TypeCode.UInt32 or TypeCode.UInt64
+                => this.context.MkBV(Convert.ToUInt64(val), Theorem.BitVectorWidth(typeCode)!.Value),
+
+            TypeCode.Boolean => this.context.MkBool((bool)val),
+
+            // Invariant, not current: Z3's parser accepts only '.' as the decimal separator,
+            // and about half of all cultures render 1.5 as something else. See #52.
+            TypeCode.Single or TypeCode.Double or TypeCode.Decimal
+                => this.context.MkReal(((IFormattable)val).ToString(null, CultureInfo.InvariantCulture)),
+
+            // A DateTime is encoded as its ticks - 100ns intervals from 0001-01-01 - on the UTC
+            // timeline, which covers the whole DateTime range. A Windows file time counted from
+            // 1601 instead, so nothing earlier could be written or read. See #83.
+            //
+            // A Kind of Local is converted to UTC first; Unspecified is taken to be UTC already,
+            // which is the convention ToFileTimeUtc had and the read path inverts. See #56.
+            TypeCode.DateTime => this.context.MkInt(ToUtcTicks((DateTime)val)),
+
+            TypeCode.String => this.context.MkString((string)val),
+
+            _ => throw new NotSupportedException($"Unsupported constant {val}"),
+        };
     }
 
     private Expr VisitIndex(IndexExpression expression, Func<Context, Expr, Expr[], Expr> ctor)
@@ -551,19 +547,12 @@ internal sealed class ExpressionVisitor
                 {
                     var currentMember = hierarchy[hierarchyIdx].Member;
 
-                    switch (currentMember.MemberType)
+                    val = currentMember switch
                     {
-                        case MemberTypes.Property:
-                            var property = (PropertyInfo)currentMember;
-                            val = property.GetValue(target);
-                            break;
-                        case MemberTypes.Field:
-                            var field = (FieldInfo)currentMember;
-                            val = field.GetValue(target);
-                            break;
-                        default:
-                            throw new NotSupportedException($"Unsupported constant {target} .");
-                    }
+                        PropertyInfo property => property.GetValue(target),
+                        FieldInfo field => field.GetValue(target),
+                        _ => throw new NotSupportedException($"Unsupported constant {target} ."),
+                    };
 
                     hierarchyIdx++;
                 }

--- a/solutions/Z3.Linq/ExpressionVisitor.cs
+++ b/solutions/Z3.Linq/ExpressionVisitor.cs
@@ -557,12 +557,7 @@ internal sealed class ExpressionVisitor
                     hierarchyIdx++;
                 }
 
-                if (val != null)
-                {
-                    return VisitConstantValue(val);
-                }
-
-                throw new NotSupportedException($"Could not reduce expression {topMember.Expression}");
+                return VisitConstantValue(val ?? throw new NotSupportedException($"Could not reduce expression {topMember.Expression}"));
             }
         }
 

--- a/solutions/Z3.Linq/Theorem.cs
+++ b/solutions/Z3.Linq/Theorem.cs
@@ -636,12 +636,7 @@ public class Theorem
             _ => throw new NotSupportedException(),
         };
 
-        TheoremVariableTypeMappingAttribute? parameterTypeMapping = GetTypeMapping(parameterType);
-
-        if (parameterTypeMapping != null)
-        {
-            parameterType = parameterTypeMapping.RegularType;
-        }
+        parameterType = GetTypeMapping(parameterType)?.RegularType ?? parameterType;
 
         // Map the environment onto Z3-compatible types.
         Expr constrExp;
@@ -693,11 +688,7 @@ public class Theorem
         };
 
         TheoremVariableTypeMappingAttribute? parameterTypeMapping = GetTypeMapping(parameterType);
-
-        if (parameterTypeMapping != null)
-        {
-            parameterType = parameterTypeMapping.RegularType;
-        }
+        parameterType = parameterTypeMapping?.RegularType ?? parameterType;
 
         object value;
         TypeCode typeCode = Type.GetTypeCode(parameterType);
@@ -705,12 +696,8 @@ public class Theorem
         {
             if (IsCollection(parameterType))
             {
-                Type eltType = parameterType.IsArray ? parameterType.GetElementType()! : parameterType.GetGenericArguments()[0];
-
-                if (eltType == null)
-                {
-                    throw new NotSupportedException("Unsupported untyped array parameter type for " + parameter.Name + ".");
-                }
+                Type eltType = (parameterType.IsArray ? parameterType.GetElementType() : parameterType.GetGenericArguments()[0])
+                    ?? throw new NotSupportedException("Unsupported untyped array parameter type for " + parameter.Name + ".");
 
                 var arrVal = (ArrayExpr)(subEnv.Expr ?? throw new ArgumentException(
                     $"nameof(ConvertZ3Expression) requires {nameof(subEnv)}.{nameof(subEnv.Expr)} to be non-null",
@@ -895,23 +882,15 @@ public class Theorem
         {
             if (parameter is PropertyInfo propertyInfo)
             {
-                var ctor = propertyInfo.PropertyType.GetConstructor([parameterType]);
-
-                if (ctor == null)
-                {
-                    throw new InvalidOperationException("Could not construct an instance of the mapped type " + propertyInfo.PropertyType.Name + ". No public constructor with parameter type " + parameterType + " found.");
-                }
+                var ctor = propertyInfo.PropertyType.GetConstructor([parameterType])
+                    ?? throw new InvalidOperationException("Could not construct an instance of the mapped type " + propertyInfo.PropertyType.Name + ". No public constructor with parameter type " + parameterType + " found.");
 
                 value = ctor.Invoke([value!]);
             }
             if (parameter is FieldInfo fieldInfo)
             {
-                var ctor = fieldInfo.FieldType.GetConstructor([parameterType]);
-
-                if (ctor == null)
-                {
-                    throw new InvalidOperationException("Could not construct an instance of the mapped type " + fieldInfo.FieldType.Name + ". No public constructor with parameter type " + parameterType + " found.");
-                }
+                var ctor = fieldInfo.FieldType.GetConstructor([parameterType])
+                    ?? throw new InvalidOperationException("Could not construct an instance of the mapped type " + fieldInfo.FieldType.Name + ". No public constructor with parameter type " + parameterType + " found.");
 
                 value = ctor.Invoke([value!]);
             }

--- a/solutions/Z3.Linq/Theorem.cs
+++ b/solutions/Z3.Linq/Theorem.cs
@@ -38,7 +38,7 @@ public class Theorem
     /// </summary>
     /// <param name="context">Z3 context.</param>
     protected Theorem(Z3Context context)
-        : this(context, new List<LambdaExpression>(), null)
+        : this(context, [], null)
     {
     }
 
@@ -895,25 +895,25 @@ public class Theorem
         {
             if (parameter is PropertyInfo propertyInfo)
             {
-                var ctor = propertyInfo.PropertyType.GetConstructor(new Type[] { parameterType });
+                var ctor = propertyInfo.PropertyType.GetConstructor([parameterType]);
 
                 if (ctor == null)
                 {
                     throw new InvalidOperationException("Could not construct an instance of the mapped type " + propertyInfo.PropertyType.Name + ". No public constructor with parameter type " + parameterType + " found.");
                 }
 
-                value = ctor.Invoke(new object[] { value! });
+                value = ctor.Invoke([value!]);
             }
             if (parameter is FieldInfo fieldInfo)
             {
-                var ctor = fieldInfo.FieldType.GetConstructor(new Type[] { parameterType });
+                var ctor = fieldInfo.FieldType.GetConstructor([parameterType]);
 
                 if (ctor == null)
                 {
                     throw new InvalidOperationException("Could not construct an instance of the mapped type " + fieldInfo.FieldType.Name + ". No public constructor with parameter type " + parameterType + " found.");
                 }
 
-                value = ctor.Invoke(new object[] { value! });
+                value = ctor.Invoke([value!]);
             }
         }
 
@@ -1041,42 +1041,19 @@ public class Theorem
 
             foreach (var parameter in environment.Properties.Keys)
             {
-                if (parameter is PropertyInfo)
+                var subEnv = environment.Properties[parameter];
+
+                // Evaluation of the values through the handle in the environment bindings.
+                object value = ConvertZ3Expression(result, context, model, subEnv, parameter, GetMemberValue(parameter, template));
+
+                switch (parameter)
                 {
-                    var prop = parameter as PropertyInfo;
-
-                    if (prop == null) 
-                    {
-                        continue;
-                    }
-
-                    // Evaluation of the values though the handle in the environment bindings.
-                    object value;
-
-                    var subEnv = environment.Properties[prop];
-
-                    value = ConvertZ3Expression(result, context, model, subEnv, prop, GetMemberValue(prop, template));
-
-                    prop.SetValue(result, value, null);
-                }
-
-                if (parameter is FieldInfo)
-                {
-                    var prop = parameter as FieldInfo;
-
-                    if (prop == null)
-                    {
-                        continue;
-                    }
-
-                    // Evaluation of the values though the handle in the environment bindings.
-                    object value;
-
-                    var subEnv = environment.Properties[prop];
-
-                    value = ConvertZ3Expression(result, context, model, subEnv, prop, GetMemberValue(prop, template));
-
-                    prop.SetValue(result, value);
+                    case PropertyInfo prop:
+                        prop.SetValue(result, value, null);
+                        break;
+                    case FieldInfo field:
+                        field.SetValue(result, value);
+                        break;
                 }
             }
 

--- a/solutions/Z3.Linq/Theorem{T}.cs
+++ b/solutions/Z3.Linq/Theorem{T}.cs
@@ -30,7 +30,7 @@ public class Theorem<T> : Theorem, ISolveable<T>
     /// solution's. See #78.
     /// </param>
     internal Theorem(Z3Context context, T template)
-        : base(context, new List<LambdaExpression>(), template)
+        : base(context, [], template)
     {
     }
 
@@ -177,7 +177,7 @@ public class Theorem<T> : Theorem, ISolveable<T>
     /// <returns>Theorem with the new constraint applied.</returns>
     public Theorem<T> Where(Expression<Func<T, bool>> constraint)
     {
-        return new Theorem<T>(base.Context, base.Constraints.Concat(new List<LambdaExpression> { constraint }), base.Template);
+        return new Theorem<T>(base.Context, base.Constraints.Concat([constraint]), base.Template);
     }
 
     /// <summary>

--- a/solutions/Z3.Linq/Z3Context.cs
+++ b/solutions/Z3.Linq/Z3Context.cs
@@ -55,7 +55,7 @@ public sealed class Z3Context : IDisposable
     /// </exception>
     public TimeSpan? Timeout
     {
-        get => this.timeout;
+        get => field;
         set
         {
             if (value is { } t && (t <= TimeSpan.Zero || t.TotalMilliseconds > uint.MaxValue))
@@ -63,7 +63,7 @@ public sealed class Z3Context : IDisposable
                 throw new ArgumentOutOfRangeException(nameof(value), value, "The timeout must be positive and no more than uint.MaxValue milliseconds.");
             }
 
-            this.timeout = value;
+            field = value;
         }
     }
 
@@ -80,7 +80,7 @@ public sealed class Z3Context : IDisposable
     /// <exception cref="ArgumentOutOfRangeException">The value is zero.</exception>
     public uint? ResourceLimit
     {
-        get => this.resourceLimit;
+        get => field;
         set
         {
             if (value is 0)
@@ -88,13 +88,9 @@ public sealed class Z3Context : IDisposable
                 throw new ArgumentOutOfRangeException(nameof(value), value, "The resource limit must be positive.");
             }
 
-            this.resourceLimit = value;
+            field = value;
         }
     }
-
-    private TimeSpan? timeout;
-
-    private uint? resourceLimit;
 
     /// <summary>
     /// Closes the native resources held by the Z3 theorem prover.
@@ -170,14 +166,14 @@ public sealed class Z3Context : IDisposable
     /// </remarks>
     internal Params? CreateLimits(Context context)
     {
-        if (this.timeout is null && this.resourceLimit is null)
+        if (this.Timeout is null && this.ResourceLimit is null)
         {
             return null;
         }
 
         Params limits = context.MkParams();
 
-        if (this.timeout is { } t)
+        if (this.Timeout is { } t)
         {
             // Round up, not truncate: Z3's timeout is in whole milliseconds, and a positive
             // TimeSpan below one millisecond truncates to 0, which Z3 reads as "no timeout" - so
@@ -187,7 +183,7 @@ public sealed class Z3Context : IDisposable
             limits.Add("timeout", (uint)Math.Ceiling(t.TotalMilliseconds));
         }
 
-        if (this.resourceLimit is { } r)
+        if (this.ResourceLimit is { } r)
         {
             limits.Add("rlimit", r);
         }

--- a/solutions/Z3.Linq/Z3Context.cs
+++ b/solutions/Z3.Linq/Z3Context.cs
@@ -197,9 +197,6 @@ public sealed class Z3Context : IDisposable
     /// <param name="s">Log output string.</param>
     internal void LogWriteLine(string s)
     {
-        if (Log != null)
-        {
-            Log.WriteLine(s);
-        }
+        Log?.WriteLine(s);
     }
 }


### PR DESCRIPTION
A small, behaviour-preserving modernisation pass that leans on language features now available on
`net10.0` - C# 14 is the default language version, so no `LangVersion` bump is needed. Net **-27
lines**, no public-API, behaviour or allocation change.

## Changes

- **C# 14 `field` keyword** in `Z3Context`. `Timeout` and `ResourceLimit` have validating setters,
  which previously needed a pair of hand-rolled backing fields sitting apart from the properties
  they served. The `field` keyword lets the accessors refer to their own backing field directly, so
  the two `private` fields are gone and `CreateLimits` reads the properties instead.
- **Pattern `switch`** for the property/field marshalling loop in `GetSolution`, replacing the
  `if (x is PropertyInfo) { var p = x as PropertyInfo; if (p == null) continue; ... }` shape - an
  `is`-test immediately followed by an `as`-cast and a null-guard that can never fire - with a
  single `case PropertyInfo prop:` / `case FieldInfo field:`. The member is bound once, and the
  duplicated evaluation is written once.
- **Collection expressions** (`[]`, `[x]`) where the intent is an empty or throwaway collection: the
  no-constraint constructors, the single-constraint append in `Where`, the reflection argument
  arrays in the mapped-type marshaller, and the member-hierarchy list. The one list built with a
  capacity hint (`new List<Expression>(caller.Count)`) deliberately keeps its constructor - a
  collection expression cannot express a capacity.
- **Pattern matching for the two remaining type-test-plus-cast dispatches** (second commit).
  `VisitConstantValue` becomes a switch expression on the constant's `TypeCode`, with `or` patterns
  grouping the integer and real cases and the type code read once rather than again inside the
  bit-vector arm. `VisitMember`'s captured-constant walk uses type patterns (`PropertyInfo` /
  `FieldInfo`) in place of a `switch` on `MemberType` followed by a cast.
- **Null-coalescing / null-conditional** for the remaining `if (x == null)` shapes (third commit):
  the two mapped-type constructor lookups and the collection element type become `... ?? throw`
  (the latter also dropping a null-forgiving `!` that was masking the null the next line tested
  for); `VisitMember`'s tail becomes `VisitConstantValue(val ?? throw ...)`; the type-mapping
  assignment becomes `mapping?.RegularType ?? parameterType` in both marshaller and environment
  builder, matching `SymbolType`; and `Z3Context.LogWriteLine` becomes `Log?.WriteLine(s)`.

## Deliberately left alone

- No dictionary expression for `Z3Context`'s config map - C# 14 has none.
- No `System.Threading.Lock` or other synchronisation - the library takes no locks by design (a
  share-nothing native context per solve, plus concurrent caches), so there is nothing to modernise
  there.
- `FrozenDictionary` for the reflection caches would be wrong - they grow at runtime, so
  `ConcurrentDictionary` stays.

## Verified

- `dotnet build solutions/Z3.Linq.slnx -c Release` - clean, `TreatWarningsAsErrors` and
  documentation generation on (the `field` keyword and collection expressions compile with no
  warnings).
- **322/322 tests green** in Release, unchanged.
- `./build.ps1 -Configuration Release` - 46 tasks, 0 errors, 0 warnings.
- **Allocation-neutral**, confirmed against the perf PR below it with `Z3.Linq.Benchmarks` (short
  job, `MemoryDiagnoser`): every shape within run-to-run rounding of its previous figure
  (ScalarSymbols 3.32 -> 3.30 KB, WideSymbols 6.23 -> 6.19 KB, ...). These are IL-equivalent
  transforms, so no movement is expected and none is seen.

## Release note

No public-API or behaviour change - an internal readability pass. Releases remain on hold under #60
regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
