### PR TITLE
Extract MemberClrType for the property/field type switch

### DIFF
--- a/solutions/Z3.Linq/Theorem.cs
+++ b/solutions/Z3.Linq/Theorem.cs
@@ -421,14 +421,24 @@ public class Theorem
     /// <returns>The type the symbol is declared and read as.</returns>
     private static Type SymbolType(MemberInfo member)
     {
-        Type type = member switch
+        Type type = MemberClrType(member);
+
+        return GetTypeMapping(type)?.RegularType ?? type;
+    }
+
+    /// <summary>
+    /// The declared CLR type of a property or field.
+    /// </summary>
+    /// <param name="member">The property or field.</param>
+    /// <returns>The member's <see cref="PropertyInfo.PropertyType"/> or <see cref="FieldInfo.FieldType"/>.</returns>
+    private static Type MemberClrType(MemberInfo member)
+    {
+        return member switch
         {
             PropertyInfo property => property.PropertyType,
             FieldInfo field => field.FieldType,
             _ => throw new NotSupportedException(),
         };
-
-        return GetTypeMapping(type)?.RegularType ?? type;
     }
 
     /// <summary>
@@ -629,12 +639,7 @@ public class Theorem
     {
         var toReturn = new Environment();
 
-        var parameterType = parameter switch
-        {
-            PropertyInfo parameterProperty => parameterProperty.PropertyType,
-            FieldInfo parameterField => parameterField.FieldType,
-            _ => throw new NotSupportedException(),
-        };
+        var parameterType = MemberClrType(parameter);
 
         parameterType = GetTypeMapping(parameterType)?.RegularType ?? parameterType;
 
@@ -680,12 +685,7 @@ public class Theorem
         // Normalize types when facing Z3. Theorem variable type mappings allow for strong
         // typing within the theorem, while underlying variable representations are Z3-
         // friendly types.
-        var parameterType = parameter switch
-        {
-            PropertyInfo parameterProperty => parameterProperty.PropertyType,
-            FieldInfo parameterField => parameterField.FieldType,
-            _ => throw new NotSupportedException(),
-        };
+        var parameterType = MemberClrType(parameter);
 
         TheoremVariableTypeMappingAttribute? parameterTypeMapping = GetTypeMapping(parameterType);
         parameterType = parameterTypeMapping?.RegularType ?? parameterType;


### PR DESCRIPTION
First of three small dedup refactors flagged during the modernisation review. The
`member switch { PropertyInfo => .PropertyType, FieldInfo => .FieldType, _ => throw }` shape - "a
symbol is a property or a field, and its declared type is one or the other" - appeared verbatim in
three places: `SymbolType`, the environment builder (`GetEnvironment(MemberInfo, ...)`) and the
marshaller (`ConvertZ3Expression`). A single private `MemberClrType(MemberInfo)` helper now owns it.

Pure extraction - no behaviour change, and no allocation change (the helper is a small static method
the JIT inlines back to the switch it replaced).

## Verified

- `dotnet build solutions/Z3.Linq.slnx -c Release` - clean, `TreatWarningsAsErrors` on.
- 322/322 tests green.
- `./build.ps1 -Configuration Release` - 46 tasks, 0 errors, 0 warnings.

No public-API or behaviour change. Releases remain on hold under #60 regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
