### PR TITLE
Extract Assert for the Solver/Optimize dispatch

### DIFF
--- a/solutions/Z3.Linq/Theorem.cs
+++ b/solutions/Z3.Linq/Theorem.cs
@@ -320,20 +320,32 @@ public class Theorem
         {
             BoolExpr expression = (BoolExpr)ExpressionVisitor.Translate(context, environment, constraint.Body, constraint.Parameters[0]);
 
-            switch (approach)
-            {
-                case Solver solver:
-                    solver.Assert(expression);
-                    break;
-                case Optimize optimize:
-                    optimize.Assert(expression);
-                    break;
-            }
+            Assert(approach, expression);
 
             this.context.LogWriteLine(expression.ToString());
         }
 
         AssertBounds(context, approach, environment);
+    }
+
+    /// <summary>
+    /// Asserts a Boolean term into the <see cref="Solver"/> or <see cref="Optimize"/> the theorem
+    /// is being checked with - the one dispatch on the two forms a <see cref="Z3Object"/> approach
+    /// can take.
+    /// </summary>
+    /// <param name="approach">The <see cref="Solver"/> or <see cref="Optimize"/> to assert into.</param>
+    /// <param name="expression">The Boolean term to assert.</param>
+    private static void Assert(Z3Object approach, BoolExpr expression)
+    {
+        switch (approach)
+        {
+            case Solver solver:
+                solver.Assert(expression);
+                break;
+            case Optimize optimize:
+                optimize.Assert(expression);
+                break;
+        }
     }
 
     /// <summary>
@@ -373,15 +385,7 @@ public class Theorem
                     context.MkGe(symbol, context.MkInt(low)),
                     context.MkLe(symbol, context.MkInt(high)));
 
-                switch (approach)
-                {
-                    case Solver solver:
-                        solver.Assert(bounds);
-                        break;
-                    case Optimize optimize:
-                        optimize.Assert(bounds);
-                        break;
-                }
+                Assert(approach, bounds);
             }
 
             AssertBounds(context, approach, child);


### PR DESCRIPTION
Second of the three flagged dedup refactors. A theorem is checked with either a `Solver` or an
`Optimize`, carried as a `Z3Object`, and both `AssertConstraints` and `AssertBounds` held the same
`switch (approach) { case Solver: solver.Assert(x); case Optimize: optimize.Assert(x); }` block to
add a term. That block now lives in one private `Assert(Z3Object, BoolExpr)` helper, so asserting a
term reads as `Assert(approach, term)` and the Solver-or-Optimize dispatch for asserting has a single
home.

The other per-approach operations are distinct and stay where they are: `Check()` and `ReasonUnknown`
are already concise `switch` expressions, and applying the limits is a different operation (it sets a
property, under a guard).

Pure extraction - no behaviour change, no allocation change.

## Verified

- `dotnet build solutions/Z3.Linq.slnx -c Release` - clean.
- 322/322 tests green.
- `./build.ps1 -Configuration Release` - 46 tasks, 0 errors, 0 warnings.

No public-API or behaviour change. Releases remain on hold under #60 regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
